### PR TITLE
Optimizations sprint: Phase 0 → Phase 5

### DIFF
--- a/crates/frontend/scene-editor/src/actions/insert.rs
+++ b/crates/frontend/scene-editor/src/actions/insert.rs
@@ -845,10 +845,24 @@ pub(crate) fn extract_gltf_materials_into(
         }
     }
 
+    // Densify image_to_texture_asset into a Vec indexed by gltf image
+    // index. The renderer-gltf side will reuse this to seed the editor's
+    // texture cache with the renderer-side `TextureKey`s — saves a
+    // second decode + upload per glb texture for the editor's material
+    // override path (Phase 4.1 dedup).
+    let image_count = document.images().len();
+    let mut image_asset_ids: Vec<AssetId> = vec![AssetId::default(); image_count];
+    for (img_idx, asset_id) in image_to_texture_asset.iter() {
+        if *img_idx < image_asset_ids.len() {
+            image_asset_ids[*img_idx] = *asset_id;
+        }
+    }
+
     // ── Stamp the per-primitive lookup onto the gltf's AssetEntry ──────
     {
         if let Some(entry) = assets.entries.get_mut(&gltf_asset_id) {
             entry.gltf_material_asset_ids = material_asset_ids;
+            entry.gltf_image_asset_ids = image_asset_ids;
         }
     }
 

--- a/crates/frontend/scene-editor/src/actions/insert.rs
+++ b/crates/frontend/scene-editor/src/actions/insert.rs
@@ -164,6 +164,39 @@ async fn prepare_model(file: File) -> anyhow::Result<ModelPrep> {
         }
     }
 
+    // Phase 4.2 — fire the editor's raster bitmap prefetch *as soon
+    // as the texture bytes are in `pending_assets`* (i.e. right after
+    // `extract_gltf_materials_into` stamps them). Decoding via
+    // `createImageBitmap` is off-main-thread and doesn't touch the
+    // renderer; running it as a background spawn here means it
+    // overlaps with the rest of `prepare_model` (the
+    // "Uploading to GPU…" modal copy below, the renderer-lock
+    // acquisition inside `load_and_populate`, and the populate_gltf
+    // wall-clock itself) instead of running serially during populate.
+    // For a multi-MB textured glb this recovers ~the entire
+    // `createImageBitmap` window out of the user-visible insert path.
+    //
+    // The cache is idempotent — `load_and_populate` still calls the
+    // same prefetch helper as a safety net for paths that didn't
+    // route through `prepare_model` (project Load, programmatic
+    // `load_scene_by_path`), so a no-bytes case here is harmless.
+    let prefetch_material_ids: Vec<AssetId> = state
+        .scene
+        .assets
+        .lock()
+        .unwrap()
+        .get(asset_id)
+        .map(|e| e.gltf_material_asset_ids.clone())
+        .unwrap_or_default();
+    if !prefetch_material_ids.is_empty() {
+        spawn_local(async move {
+            crate::renderer_bridge::texture_cache::prefetch_raster_bitmaps_for_materials(
+                &prefetch_material_ids,
+            )
+            .await;
+        });
+    }
+
     // Kick off the asset load + wait for the populated template so we
     // know how many top-level nodes it has. A concurrent insert of the
     // same path will share this load.

--- a/crates/frontend/scene-editor/src/actions/measurement.rs
+++ b/crates/frontend/scene-editor/src/actions/measurement.rs
@@ -252,9 +252,11 @@ pub async fn read_mesh_coverage_stats() -> String {
 /// without any client-side bucketing logic. Clears the entries
 /// after sampling so the next call starts fresh.
 ///
-/// Skips spans whose count is below `min_count` (default 30) so
-/// rare one-shot init spans (GLTF parse, texture upload) don't
-/// dominate the output. Pass `min_count = 0` to include everything.
+/// Skips spans whose count is below `min_count` so rare one-shot
+/// init spans (GLTF parse, texture upload) don't dominate the output
+/// — pass e.g. 30 to focus on steady-state passes. The arg is
+/// required (no Rust default on a `#[wasm_bindgen]` export); pass
+/// `min_count = 0` to include everything.
 #[wasm_bindgen]
 pub fn read_render_pass_timings(min_count: u32) -> String {
     use js_sys::{Array, JsString, Reflect};
@@ -279,14 +281,15 @@ pub fn read_render_pass_timings(min_count: u32) -> String {
             .ok()
             .and_then(|v| v.as_f64())
             .unwrap_or(0.0);
-        // `tracing-web` formats every span as `"<base> [<id>]: span-measure"`.
-        // Strip the suffix so different span ids for the same call site
-        // collapse into one bucket. Entries without the suffix (e.g.
-        // manually-emitted measures) pass through untouched.
-        let base = match name.rfind(" [") {
-            Some(idx) => name[..idx].to_string(),
-            None => name,
-        };
+        // `tracing-web` formats every span measure as
+        // `"<base> [<id>]: span-measure"`. Strip the suffix so different
+        // span ids for the same call site collapse into one bucket.
+        // Match the full pattern (not just a bare `" ["`) so a
+        // non-tracing measure whose name happens to contain `" ["` passes
+        // through untouched.
+        let base = strip_tracing_span_suffix(&name)
+            .map(str::to_string)
+            .unwrap_or(name);
         buckets.entry(base).or_default().push(dur);
     }
     let min_count = min_count as usize;
@@ -319,6 +322,22 @@ pub fn read_render_pass_timings(min_count: u32) -> String {
     // emit, which is fine.
     perf.clear_measures();
     out
+}
+
+/// Strip the `tracing-web` span suffix from a `performance.measure`
+/// name, returning the span's base name. `tracing-web` formats every
+/// span measure as `"<base> [<id>]: span-measure"` (see its
+/// `performance_layer`), so the suffix is matched in full: the name
+/// must end with `"]: span-measure"` and contain the opening `" ["` of
+/// the id group. Returns `None` for anything that doesn't match — a
+/// manually-emitted measure whose name merely contains `" ["` is left
+/// alone rather than truncated.
+fn strip_tracing_span_suffix(name: &str) -> Option<&str> {
+    // `<base> [<id>` — the numeric span id holds no `]` or `" ["`, so the
+    // last `" ["` opens the id group.
+    let head = name.strip_suffix("]: span-measure")?;
+    let idx = head.rfind(" [")?;
+    Some(&head[..idx])
 }
 
 /// Read the renderer's light-bucket telemetry.

--- a/crates/frontend/scene-editor/src/actions/measurement.rs
+++ b/crates/frontend/scene-editor/src/actions/measurement.rs
@@ -242,6 +242,85 @@ pub async fn read_mesh_coverage_stats() -> String {
     )
 }
 
+/// Group every `performance.measure` entry by tracing-span base
+/// name (the `[id]: span-measure` suffix that `tracing-web` appends
+/// is stripped), then summarise per-pass timing as
+/// `{ "count": N, "mean_ms": f, "p50_ms": f, "p95_ms": f,
+///   "max_ms": f, "total_ms": f }`. Useful for the Chrome-vs-Safari
+/// comparison the optimization sprint calls out: a single
+/// `preview_eval` call returns a JSON map of per-pass distributions
+/// without any client-side bucketing logic. Clears the entries
+/// after sampling so the next call starts fresh.
+///
+/// Skips spans whose count is below `min_count` (default 30) so
+/// rare one-shot init spans (GLTF parse, texture upload) don't
+/// dominate the output. Pass `min_count = 0` to include everything.
+#[wasm_bindgen]
+pub fn read_render_pass_timings(min_count: u32) -> String {
+    use js_sys::{Array, JsString, Reflect};
+    use std::collections::BTreeMap;
+    let window = match web_sys::window() {
+        Some(w) => w,
+        None => return "{\"error\":\"no window\"}".to_string(),
+    };
+    let perf = match window.performance() {
+        Some(p) => p,
+        None => return "{\"error\":\"no performance\"}".to_string(),
+    };
+    let entries: Array = perf.get_entries_by_type("measure");
+    let mut buckets: BTreeMap<String, Vec<f64>> = BTreeMap::new();
+    for entry in entries.iter() {
+        let name = Reflect::get(&entry, &JsValue::from_str("name"))
+            .ok()
+            .and_then(|v| v.dyn_into::<JsString>().ok())
+            .map(String::from)
+            .unwrap_or_default();
+        let dur = Reflect::get(&entry, &JsValue::from_str("duration"))
+            .ok()
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.0);
+        // `tracing-web` formats every span as `"<base> [<id>]: span-measure"`.
+        // Strip the suffix so different span ids for the same call site
+        // collapse into one bucket. Entries without the suffix (e.g.
+        // manually-emitted measures) pass through untouched.
+        let base = match name.rfind(" [") {
+            Some(idx) => name[..idx].to_string(),
+            None => name,
+        };
+        buckets.entry(base).or_default().push(dur);
+    }
+    let min_count = min_count as usize;
+    let mut out = String::from("{");
+    let mut first = true;
+    for (name, mut samples) in buckets {
+        if samples.len() < min_count.max(1) {
+            continue;
+        }
+        samples.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        let n = samples.len();
+        let sum: f64 = samples.iter().sum();
+        let mean = sum / n as f64;
+        let p50 = samples[n / 2];
+        let p95 = samples[((n as f64 * 0.95) as usize).min(n - 1)];
+        let max = *samples.last().unwrap_or(&0.0);
+        if !first {
+            out.push(',');
+        }
+        first = false;
+        out.push_str(&format!(
+            "{}:{{\"count\":{},\"mean_ms\":{:.4},\"p50_ms\":{:.4},\"p95_ms\":{:.4},\"max_ms\":{:.4},\"total_ms\":{:.4}}}",
+            serde_json::to_string(&name).unwrap_or_else(|_| "\"\"".to_string()),
+            n, mean, p50, p95, max, sum
+        ));
+    }
+    out.push('}');
+    // Clear so the next call observes a fresh window. `clear_measures`
+    // also drops any `performance.mark` entries we never explicitly
+    // emit, which is fine.
+    let _ = perf.clear_measures();
+    out
+}
+
 /// Read the renderer's light-bucket telemetry.
 /// Returns a JSON string `{ "last_max_bucket": N, "oversized_count": M }`
 /// for the most-recently-rebuilt `LightMeshBuckets`. Drive from

--- a/crates/frontend/scene-editor/src/actions/measurement.rs
+++ b/crates/frontend/scene-editor/src/actions/measurement.rs
@@ -317,7 +317,7 @@ pub fn read_render_pass_timings(min_count: u32) -> String {
     // Clear so the next call observes a fresh window. `clear_measures`
     // also drops any `performance.mark` entries we never explicitly
     // emit, which is fine.
-    let _ = perf.clear_measures();
+    perf.clear_measures();
     out
 }
 

--- a/crates/frontend/scene-editor/src/actions/view.rs
+++ b/crates/frontend/scene-editor/src/actions/view.rs
@@ -5,6 +5,7 @@
 //! GPU. This way Load also fires the same path (hydrating env → observer
 //! applies it to the renderer).
 
+use crate::context::renderer_handle;
 use crate::scene::{AssetId, IblConfig, SkyboxConfig};
 use crate::state::app_state;
 use awsm_web_shared::atoms::modal::Modal;
@@ -23,6 +24,33 @@ pub fn set_gizmo_enabled(enabled: bool) {
     let state = app_state();
     state.gizmo_enabled.set_neq(enabled);
     tracing::info!("action: view::set_gizmo_enabled({enabled})");
+}
+
+/// Toggle MSAA (`msaa_sample_count: Some(4)` ↔ `None`) on the
+/// AppState mirror and push the result into the renderer. Mirrors
+/// model-tests' `SidebarProcessing::render_msaa_selector` flow.
+pub fn toggle_msaa() {
+    let state = app_state();
+    let aa = {
+        let mut lock = state.anti_aliasing.lock_mut();
+        lock.msaa_sample_count = if lock.msaa_sample_count.is_some() {
+            None
+        } else {
+            Some(4)
+        };
+        lock.clone()
+    };
+    tracing::info!(
+        "action: view::toggle_msaa → msaa_sample_count={:?}",
+        aa.msaa_sample_count
+    );
+    spawn_local(async move {
+        let handle = renderer_handle();
+        let mut renderer = handle.lock().await;
+        if let Err(err) = renderer.set_anti_aliasing(aa).await {
+            tracing::error!("set_anti_aliasing failed: {err}");
+        }
+    });
 }
 
 // ---------------- Skybox ----------------

--- a/crates/frontend/scene-editor/src/header/editor.rs
+++ b/crates/frontend/scene-editor/src/header/editor.rs
@@ -1,12 +1,13 @@
-//! Editor action-row — viewport toggles (Show Grid / Show Gizmo).
-//! Each routes through `actions::view::set_*` so the renderer and the
-//! `AppState` mirror stay in sync.
+//! Editor action-row — viewport toggles (Show Grid / Show Gizmo /
+//! MSAA Anti-Aliasing). Each routes through `actions::view::*` so the
+//! renderer and the `AppState` mirror stay in sync.
 
 use crate::{actions, prelude::*, state};
 
 pub(super) fn render_editor_row() -> Dom {
     let grid_enabled = state::app_state().grid_enabled.clone();
     let gizmo_enabled = state::app_state().gizmo_enabled.clone();
+    let anti_aliasing = state::app_state().anti_aliasing.clone();
     html!("div", {
         .style("display", "flex")
         .style("gap", "1rem")
@@ -28,6 +29,15 @@ pub(super) fn render_editor_row() -> Dom {
             .with_on_click(clone!(gizmo_enabled => move || {
                 actions::view::set_gizmo_enabled(!gizmo_enabled.get());
             }))
+            .render())
+        .child(Checkbox::new(CheckboxStyle::Dark)
+            .with_selected_signal(anti_aliasing.signal_ref(|aa| aa.msaa_sample_count.is_some()))
+            .with_content_after(html!("span", {
+                .text("MSAA Anti-Aliasing")
+            }))
+            .with_on_click(|| {
+                actions::view::toggle_msaa();
+            })
             .render())
     })
 }

--- a/crates/frontend/scene-editor/src/renderer_bridge/asset_cache.rs
+++ b/crates/frontend/scene-editor/src/renderer_bridge/asset_cache.rs
@@ -219,6 +219,21 @@ async fn load_and_populate(asset_id: AssetId) -> Result<AssetTemplate, String> {
     let (ctx, ()) = futures::future::join(populate_fut, prefetch_fut).await;
     let ctx = ctx?;
 
+    // Phase 4.1 — seed the editor's texture_cache with the
+    // `TextureKey`s renderer-gltf just uploaded so the override-path
+    // `texture_cache::get_or_upload(asset_id, ...)` returns the
+    // existing slot instead of re-decoding + re-uploading the same
+    // image. The renderer-gltf side keys by `(gltf_texture_index,
+    // color)`; the editor's cache keys by editor `AssetId`. We
+    // resolve the join via the gltf doc's `texture → image` map and
+    // the editor's per-image `gltf_image_asset_ids` (stashed at
+    // insert time by `extract_gltf_materials_into`). Multiple
+    // (texture_index, color) pairs can map to the same image — the
+    // first one to land wins; the editor cache is keyed by AssetId
+    // only (it doesn't track srgb/linear role per entry), so this
+    // matches the existing semantics.
+    seed_texture_cache_from_populate(&state, asset_id, &ctx);
+
     let root = renderer.transforms.root_node;
     let (all_keys, key_to_node_index, key_to_label): (
         Vec<TransformKey>,
@@ -270,6 +285,41 @@ async fn load_and_populate(asset_id: AssetId) -> Result<AssetTemplate, String> {
     hide_template_meshes(&mut renderer, &roots);
 
     Ok(AssetTemplate { roots })
+}
+
+fn seed_texture_cache_from_populate(
+    state: &crate::state::AppState,
+    gltf_asset_id: AssetId,
+    ctx: &awsm_renderer_gltf::populate::GltfPopulateContext,
+) {
+    let image_asset_ids = {
+        let table = state.scene.assets.lock().unwrap();
+        match table.get(gltf_asset_id) {
+            Some(e) if !e.gltf_image_asset_ids.is_empty() => e.gltf_image_asset_ids.clone(),
+            _ => return,
+        }
+    };
+    let textures = ctx.textures.lock().unwrap();
+    for (gltf_texture_key, texture_key) in textures.iter() {
+        // gltf::Document::textures() is ordered by texture index; we
+        // pull the image's index off the matching texture entry. If
+        // the gltf doc was malformed or trimmed between insert and
+        // populate (shouldn't happen — same bytes), skip silently.
+        let Some(gltf_texture) = ctx.data.doc.textures().nth(gltf_texture_key.index) else {
+            continue;
+        };
+        let image_index = gltf_texture.source().index();
+        let Some(asset_id) = image_asset_ids.get(image_index).copied() else {
+            continue;
+        };
+        // `AssetId::default()` is the "no extracted asset for this
+        // image" sentinel from extract_gltf_materials_into (e.g.
+        // URI-sourced images get skipped). Don't seed those.
+        if asset_id == AssetId::default() {
+            continue;
+        }
+        super::texture_cache::seed(asset_id, *texture_key);
+    }
 }
 
 fn hide_template_meshes(renderer: &mut awsm_renderer::AwsmRenderer, roots: &[AssetTemplateNode]) {

--- a/crates/frontend/scene-editor/src/renderer_bridge/asset_cache.rs
+++ b/crates/frontend/scene-editor/src/renderer_bridge/asset_cache.rs
@@ -15,6 +15,7 @@ use crate::scene::{AssetId, AssetSource, AssetStatus};
 use crate::state::app_state;
 use awsm_renderer::{
     meshes::MeshKey,
+    textures::TextureKey,
     transforms::{Transform, TransformKey},
 };
 use awsm_renderer_gltf::{
@@ -300,6 +301,23 @@ fn seed_texture_cache_from_populate(
         }
     };
     let textures = ctx.textures.lock().unwrap();
+    // One source image can back several `GltfTextureKey`s: the key
+    // carries the gltf *texture* index plus `color`, so the same image
+    // referenced srgb as a base-color in one material AND linear as a
+    // normal map in another (or via two distinct texture entries) lands
+    // under multiple keys, each with its own renderer `TextureKey`. The
+    // editor's texture cache keys purely on `AssetId` — one slot per
+    // image — so a multi-variant image has no single "correct" key to
+    // seed, and HashMap iteration order would otherwise pick the variant
+    // arbitrarily, silently overriding the role-specific upload that
+    // `texture_cache::get_or_upload` would have done.
+    //
+    // Resolve every renderer texture to its backing image first, then
+    // seed only images that map to exactly one renderer `TextureKey`.
+    // Ambiguous images fall back to the (correct, role-aware) on-demand
+    // upload — losing the dedup only for the rare multi-variant case,
+    // never binding the wrong color. `Some(None)` marks "ambiguous".
+    let mut per_image: HashMap<AssetId, Option<TextureKey>> = HashMap::new();
     for (gltf_texture_key, texture_key) in textures.iter() {
         // gltf::Document::textures() is ordered by texture index; we
         // pull the image's index off the matching texture entry. If
@@ -318,7 +336,21 @@ fn seed_texture_cache_from_populate(
         if asset_id == AssetId::default() {
             continue;
         }
-        super::texture_cache::seed(asset_id, *texture_key);
+        per_image
+            .entry(asset_id)
+            .and_modify(|slot| {
+                // A second *distinct* renderer key for this image ⇒
+                // ambiguous variant; clear the slot so we skip seeding.
+                if *slot != Some(*texture_key) {
+                    *slot = None;
+                }
+            })
+            .or_insert(Some(*texture_key));
+    }
+    for (asset_id, key) in per_image {
+        if let Some(texture_key) = key {
+            super::texture_cache::seed(asset_id, texture_key);
+        }
     }
 }
 

--- a/crates/frontend/scene-editor/src/renderer_bridge/material_cache.rs
+++ b/crates/frontend/scene-editor/src/renderer_bridge/material_cache.rs
@@ -93,29 +93,25 @@ pub fn drain() -> Vec<MaterialKey> {
     with_cache(|m| m.drain().map(|(_, k)| k).collect())
 }
 
-/// Cascade a `MaterialAsset` deletion through the renderer:
+/// Cascade-delete a batch of `MaterialAsset`s through the renderer
+/// in a single scene walk. For each asset id in the batch:
 ///
-/// 1. Drop the cached `MaterialKey` (so future `get_or_create` calls
-///    for the deleted id fall back to inline material via `resolve`).
-/// 2. For every editor node whose `material_ref` points at this
-///    asset, invalidate the apply-kind identity cache + re-emit the
-///    node's kind so the bridge re-resolves through `resolve`
-///    (which now falls back to inline because the table no longer
-///    has the entry).
-/// 3. Free the old `MaterialKey` from the renderer pool. Done last,
-///    after every referencing node has re-bound, so no live draw
-///    still points at the freed slot.
+/// 1. Drop the cached `MaterialKey` (so future `get_or_create`
+///    calls fall back to inline material via `resolve`).
+/// 2. For every editor node whose `material_ref` points at one of
+///    the deleted assets, invalidate the apply-kind identity
+///    cache + re-emit the node's kind so the bridge re-resolves
+///    through `resolve` (which now falls back to inline because
+///    the asset table no longer has the entry).
+/// 3. Free the old `MaterialKey`s from the renderer pool. Done
+///    last, after every referencing node has re-bound, so no
+///    live draw still points at a freed slot.
 ///
-/// Mirrors the structure of `texture_cache::update_existing` for the
-/// delete case. Implemented as the single-asset shape of
-/// [`cascade_after_delete_batch`].
-///
-/// Cascade-delete a batch of `MaterialAsset`s in a single scene walk.
-///
-/// Replaces an N-asset cleanup's N × scene walk with one. Each asset
-/// id still gets its own `MaterialKey` freed via `remove_material`;
-/// the saving is purely in the per-node identity check and the
+/// Replaces what would otherwise be N × scene-walk for an N-asset
+/// cleanup. The per-asset saving is in the node identity check +
 /// `kind.set` reemit, which scale with `scene_nodes × assets`.
+/// Mirrors the structure of `texture_cache::update_existing` for
+/// the delete case.
 pub async fn cascade_after_delete_batch(asset_ids: &[AssetId]) {
     use crate::context::with_renderer_mut;
     use crate::scene::{Node, NodeKind};

--- a/crates/frontend/scene-editor/src/renderer_bridge/node_sync.rs
+++ b/crates/frontend/scene-editor/src/renderer_bridge/node_sync.rs
@@ -183,11 +183,16 @@ impl Bridge {
     /// they're all `signal()` subscribers — so a one-frame delay
     /// is invisible.
     pub fn bump_nodes_revision(&self) {
-        {
-            let slot = self.pending_bump_raf.lock().unwrap();
-            if slot.is_some() {
-                return;
-            }
+        // Hold the slot lock across the whole check → schedule → store
+        // sequence. `request_animation_frame` only *registers* the
+        // callback (it never runs it inline), so the rAF closure — which
+        // locks `pending_bump_raf` itself — can't fire until this guard
+        // drops, well after this function returns. Taking the lock once
+        // and keeping it also closes the check-then-act window: two
+        // callers can't both observe `None` and each queue a frame.
+        let mut slot = self.pending_bump_raf.lock().unwrap();
+        if slot.is_some() {
+            return;
         }
         let frame = gloo_render::request_animation_frame(|_| {
             let b = bridge();
@@ -198,7 +203,7 @@ impl Bridge {
             let prev = b.nodes_revision.get();
             b.nodes_revision.set(prev.wrapping_add(1));
         });
-        *self.pending_bump_raf.lock().unwrap() = Some(frame);
+        *slot = Some(frame);
     }
 }
 

--- a/crates/frontend/scene-editor/src/renderer_bridge/node_sync.rs
+++ b/crates/frontend/scene-editor/src/renderer_bridge/node_sync.rs
@@ -144,6 +144,16 @@ pub struct Bridge {
     /// `collider_wireframe::render::collect_cameras` each frame to
     /// draw the editor's camera-frustum wireframes.
     pub camera_node_ids: Mutex<std::collections::HashSet<NodeId>>,
+    /// Pending coalesced `nodes_revision` bump, owned so its
+    /// `AnimationFrame` callback stays alive until it fires.
+    /// `bump_nodes_revision` consults this — if it's already
+    /// `Some`, a bump is already scheduled and the call is a
+    /// no-op. When the rAF fires it `take()`s itself out of the
+    /// slot, drops the frame handle (already-fired so cancel is
+    /// a no-op), and bumps the revision once. Result: N
+    /// per-frame `bump_nodes_revision` calls collapse into a
+    /// single signal-graph cascade per animation frame.
+    pub pending_bump_raf: Mutex<Option<gloo_render::AnimationFrame>>,
 }
 
 impl Bridge {
@@ -157,12 +167,38 @@ impl Bridge {
             decal_node_ids: Mutex::new(std::collections::HashSet::new()),
             collider_node_ids: Mutex::new(std::collections::HashSet::new()),
             camera_node_ids: Mutex::new(std::collections::HashSet::new()),
+            pending_bump_raf: Mutex::new(None),
         })
     }
 
+    /// Schedules a `nodes_revision` bump for the next animation
+    /// frame, coalescing every call that lands inside the same
+    /// frame into a single signal-graph cascade. Consumers
+    /// (selection observer, gizmo, point-handle, inspector) all
+    /// re-derive on every revision bump, so for a multi-mesh
+    /// model insert (which used to fire `bump_nodes_revision`
+    /// per node during `insert_node` and again per node during
+    /// `remove_node`) this collapses dozens of cascades into one.
+    /// Reactive observers don't expect synchronous response —
+    /// they're all `signal()` subscribers — so a one-frame delay
+    /// is invisible.
     pub fn bump_nodes_revision(&self) {
-        let prev = self.nodes_revision.get();
-        self.nodes_revision.set(prev.wrapping_add(1));
+        {
+            let slot = self.pending_bump_raf.lock().unwrap();
+            if slot.is_some() {
+                return;
+            }
+        }
+        let frame = gloo_render::request_animation_frame(|_| {
+            let b = bridge();
+            // Drop the held frame handle first — already-fired,
+            // so this is just slot cleanup; lets the next bump
+            // schedule another rAF.
+            b.pending_bump_raf.lock().unwrap().take();
+            let prev = b.nodes_revision.get();
+            b.nodes_revision.set(prev.wrapping_add(1));
+        });
+        *self.pending_bump_raf.lock().unwrap() = Some(frame);
     }
 }
 

--- a/crates/frontend/scene-editor/src/renderer_bridge/texture_cache.rs
+++ b/crates/frontend/scene-editor/src/renderer_bridge/texture_cache.rs
@@ -218,6 +218,22 @@ pub fn lookup(asset_id: AssetId) -> Option<TextureKey> {
     with_cache(|m| m.get(&asset_id).copied())
 }
 
+/// Insert a pre-existing `TextureKey` into the cache for `asset_id` —
+/// idempotent if the asset is already mapped (keeps the first-seen
+/// key, which avoids ping-ponging if a glb is re-loaded while the
+/// editor's override has already picked the prior key).
+///
+/// Used by `asset_cache::load_and_populate` to seed the cache from
+/// the `TextureKey`s renderer-gltf already uploaded — without that
+/// seeding, the editor's override path would re-decode +
+/// re-upload the same image, doubling GPU storage and decode wall-
+/// clock per glb texture. (Phase 4.1.)
+pub fn seed(asset_id: AssetId, texture_key: TextureKey) {
+    with_cache(|m| {
+        m.entry(asset_id).or_insert(texture_key);
+    });
+}
+
 /// How the renderer should interpret the pixel data of a raster
 /// texture. Mirrors the glTF convention: `Srgb` for visible-color
 /// channels (base color, emissive) — the bytes are gamma-encoded and

--- a/crates/frontend/scene-editor/src/state.rs
+++ b/crates/frontend/scene-editor/src/state.rs
@@ -15,6 +15,7 @@ use crate::renderer_bridge::gizmo::MoveAction;
 use crate::renderer_bridge::Bridge;
 use crate::scene::{AssetId, NodeId, Scene, SceneSnapshot};
 use crate::tree::drag::DropZone;
+use awsm_renderer::anti_alias::AntiAliasing;
 use awsm_renderer_editor::{
     point_handle::PointHandleSet, transform_controller::TransformController,
 };
@@ -79,6 +80,13 @@ pub struct AppState {
     /// hidden even with a selected node, and its handles aren't
     /// pickable (the GPU pick uses mesh visibility).
     pub gizmo_enabled: Mutable<bool>,
+    /// Anti-aliasing settings mirror (MSAA + SMAA + mipmap). The
+    /// Editor header's `MSAA Anti-Aliasing` checkbox writes here; an
+    /// `actions::view::reset_anti_aliasing()` call pushes the current
+    /// value into the renderer via `set_anti_aliasing`. Initialized
+    /// to `AntiAliasing::default()` so the editor's boot matches the
+    /// renderer's defaults.
+    pub anti_aliasing: Mutable<AntiAliasing>,
     pub rotation_display: Mutable<RotationDisplay>,
     /// Active viewport projection. The header `Camera` tab's dropdown is
     /// the single source of truth; `actions::camera::set_projection_mode`
@@ -166,6 +174,7 @@ impl AppState {
             project_name: Mutable::new(None),
             grid_enabled: Mutable::new(true),
             gizmo_enabled: Mutable::new(true),
+            anti_aliasing: Mutable::new(AntiAliasing::default()),
             rotation_display: Mutable::new(RotationDisplay::EulerDegrees),
             projection_mode: Mutable::new(ProjectionMode::Perspective),
             editor_camera_target: Mutable::new(None),

--- a/crates/renderer/askama.toml
+++ b/crates/renderer/askama.toml
@@ -6,6 +6,7 @@ dirs = [
     "src/render_passes/geometry/shader",
     "src/render_passes/hzb/shader",
     "src/render_passes/light_culling/shader",
+    "src/render_passes/lines/shader",
     "src/render_passes/material_classify/shader",
     "src/render_passes/material_decal/shader",
     "src/render_passes/material_decal/classify/shader",

--- a/crates/renderer/src/lib.rs
+++ b/crates/renderer/src/lib.rs
@@ -491,7 +491,7 @@ impl AwsmRendererBuilder {
             optimization_policy,
         } = self;
 
-        let mut gpu = match gpu {
+        let gpu = match gpu {
             AwsmRendererGpuBuilderKind::WebGpuBuilder(builder) => builder.build().await?,
             AwsmRendererGpuBuilderKind::WebGpuBuilt(gpu) => gpu,
         };
@@ -603,10 +603,19 @@ impl AwsmRendererBuilder {
         let environment =
             Environment::new(Skybox::register(&gpu, &mut textures, skybox_resources)?);
 
-        // temporarily push into an init struct for creating render passes
-        // we'll then destructure it to get our values back
+        // Parallelise `RenderPasses::new` with `RenderTextures::new`.
+        // Both subsystems compile pipelines + shaders against the same
+        // shared `&gpu` handle (no contention; WebGPU's device queue
+        // serialises internally) but touch disjoint owned state —
+        // RenderPasses mutates the shader / pipeline / bind-group-layout
+        // caches; RenderTextures::new is self-contained. The
+        // `RenderPassInitContext.gpu: &AwsmRendererWebGpu` shape (was
+        // `&mut`) is what unblocks the join — see the doc on
+        // `RenderPassInitContext`.
+        let formats_for_textures = render_texture_formats.clone();
+        let bind_groups = BindGroups::new(&features);
         let mut render_pass_init = RenderPassInitContext {
-            gpu: &mut gpu,
+            gpu: &gpu,
             bind_group_layouts: &mut bind_group_layouts,
             pipeline_layouts: &mut pipeline_layouts,
             pipelines: &mut pipelines,
@@ -615,15 +624,15 @@ impl AwsmRendererBuilder {
             textures: &mut textures,
             features: &features,
         };
-        let render_passes = RenderPasses::new(&mut render_pass_init, &features).await?;
-
-        let bind_groups = BindGroups::new(&features);
-        // RenderTextures itself uses `try_join3` internally to compile
-        // its 3 blit pipelines concurrently — see `render_textures.rs`.
-        // Parallelising at *this* level (between RenderPasses::new and
-        // RenderTextures::new) would require an `&gpu` shape across the
-        // RenderPassInitContext that the init currently keeps mutable.
-        let render_textures = RenderTextures::new(&gpu, render_texture_formats, &features).await?;
+        let (render_passes, render_textures) = futures::future::try_join(
+            RenderPasses::new(&mut render_pass_init, &features),
+            async {
+                RenderTextures::new(&gpu, formats_for_textures, &features)
+                    .await
+                    .map_err(crate::error::AwsmError::from)
+            },
+        )
+        .await?;
 
         let picker = Picker::new(
             &gpu,

--- a/crates/renderer/src/lib.rs
+++ b/crates/renderer/src/lib.rs
@@ -624,15 +624,13 @@ impl AwsmRendererBuilder {
             textures: &mut textures,
             features: &features,
         };
-        let (render_passes, render_textures) = futures::future::try_join(
-            RenderPasses::new(&mut render_pass_init, &features),
-            async {
+        let (render_passes, render_textures) =
+            futures::future::try_join(RenderPasses::new(&mut render_pass_init, &features), async {
                 RenderTextures::new(&gpu, formats_for_textures, &features)
                     .await
                     .map_err(crate::error::AwsmError::from)
-            },
-        )
-        .await?;
+            })
+            .await?;
 
         // Pre-warm the shader cache with everything Picker + LineRenderer
         // need before constructing either. Picker has two compute shader

--- a/crates/renderer/src/lib.rs
+++ b/crates/renderer/src/lib.rs
@@ -64,7 +64,7 @@ use materials::Materials;
 use meshes::Meshes;
 use pipelines::Pipelines;
 use scene_spatial::SceneSpatial;
-use shaders::Shaders;
+use shaders::{ShaderCacheKey, Shaders};
 use textures::Textures;
 use transforms::Transforms;
 
@@ -633,6 +633,30 @@ impl AwsmRendererBuilder {
             },
         )
         .await?;
+
+        // Pre-warm the shader cache with everything Picker + LineRenderer
+        // need before constructing either. Picker has two compute shader
+        // variants (multisampled true/false); LineRenderer has one
+        // (parameter-free). Issuing all three through `ensure_keys` lets
+        // the browser kick off all `compile_shader` calls together and
+        // await every `validate_shader` in parallel — see the doc on
+        // `Shaders::ensure_keys`. The per-pass constructors then proceed
+        // sequentially through `&mut pipelines / &mut shaders`, but the
+        // slow part (shader compile) is already done.
+        shaders
+            .ensure_keys(
+                &gpu,
+                [
+                    ShaderCacheKey::Picker(picker::ShaderCacheKeyPicker {
+                        multisampled_geometry: false,
+                    }),
+                    ShaderCacheKey::Picker(picker::ShaderCacheKeyPicker {
+                        multisampled_geometry: true,
+                    }),
+                    ShaderCacheKey::Line(render_passes::lines::ShaderCacheKeyLine),
+                ],
+            )
+            .await?;
 
         let picker = Picker::new(
             &gpu,

--- a/crates/renderer/src/render_passes.rs
+++ b/crates/renderer/src/render_passes.rs
@@ -115,8 +115,16 @@ impl RenderPasses {
 }
 
 /// Shared context used to initialize render passes.
+///
+/// `gpu` is `&` (not `&mut`) on purpose — no init path mutates the
+/// `AwsmRendererWebGpu` handle; everything goes through the shared
+/// `device` / `queue` JS handles which are `Clone`-cheap on
+/// `wasm-bindgen` types. Keeping it shared lets `RenderPasses::new`
+/// and `RenderTextures::new` run inside the same `futures::try_join`
+/// in `lib.rs` — both want `&gpu`, neither contends on the other's
+/// `&mut` fields.
 pub struct RenderPassInitContext<'a> {
-    pub gpu: &'a mut AwsmRendererWebGpu,
+    pub gpu: &'a AwsmRendererWebGpu,
     pub bind_group_layouts: &'a mut BindGroupLayouts,
     pub textures: &'a mut Textures,
     pub pipeline_layouts: &'a mut PipelineLayouts,

--- a/crates/renderer/src/render_passes/lines/api.rs
+++ b/crates/renderer/src/render_passes/lines/api.rs
@@ -3,8 +3,8 @@ use glam::{Vec3, Vec4};
 use crate::{error::Result, AwsmRenderer};
 
 use super::gpu::{
-    create_bind_group, create_segment_buffer, create_uniform_buffer, pack, segments_byte_size,
-    write_segments,
+    create_bind_group, create_segment_buffer, create_uniform_buffer, pack_into,
+    segments_byte_size, write_segments,
 };
 use super::types::{LineEntry, LineKey, LineTopology};
 
@@ -58,14 +58,16 @@ impl AwsmRenderer {
         depth_test_always: bool,
         topology: LineTopology,
     ) -> Result<Option<LineKey>> {
-        let segments = pack(positions, colors, topology);
+        pack_into(&mut self.lines.pack_buf, positions, colors, topology);
+        let segments = &self.lines.pack_buf;
         if segments.is_empty() {
             return Ok(None);
         }
-        let segment_bytes = segments_byte_size(segments.len());
+        let segment_count = segments.len();
+        let segment_bytes = segments_byte_size(segment_count);
 
         let segment_buffer = create_segment_buffer(&self.gpu, segment_bytes)?;
-        write_segments(&self.gpu, &segment_buffer, &segments)?;
+        write_segments(&self.gpu, &segment_buffer, segments)?;
 
         let uniform_buffer = create_uniform_buffer(&self.gpu)?;
 
@@ -80,7 +82,7 @@ impl AwsmRenderer {
         )?;
 
         let key = self.lines.entries.insert(LineEntry {
-            segment_count: segments.len() as u32,
+            segment_count: segment_count as u32,
             width_px: width.max(0.5),
             depth_test_always,
             segment_buffer,
@@ -124,13 +126,14 @@ impl AwsmRenderer {
             return Ok(());
         }
         let bind_group_layout_key = self.lines.pipelines.bind_group_layout_key;
-        let segments = pack(positions, colors, topology);
+        pack_into(&mut self.lines.pack_buf, positions, colors, topology);
+        let segment_count = self.lines.pack_buf.len();
         let entry = self.lines.entries.get_mut(key).expect("checked above");
-        if segments.is_empty() {
+        if segment_count == 0 {
             entry.segment_count = 0;
             return Ok(());
         }
-        let new_bytes = segments_byte_size(segments.len());
+        let new_bytes = segments_byte_size(segment_count);
         if new_bytes > entry.segment_capacity_bytes {
             entry.segment_buffer = create_segment_buffer(&self.gpu, new_bytes)?;
             entry.segment_capacity_bytes = new_bytes;
@@ -143,8 +146,8 @@ impl AwsmRenderer {
                 &entry.uniform_buffer,
             )?;
         }
-        write_segments(&self.gpu, &entry.segment_buffer, &segments)?;
-        entry.segment_count = segments.len() as u32;
+        write_segments(&self.gpu, &entry.segment_buffer, &self.lines.pack_buf)?;
+        entry.segment_count = segment_count as u32;
         Ok(())
     }
 

--- a/crates/renderer/src/render_passes/lines/api.rs
+++ b/crates/renderer/src/render_passes/lines/api.rs
@@ -3,8 +3,8 @@ use glam::{Vec3, Vec4};
 use crate::{error::Result, AwsmRenderer};
 
 use super::gpu::{
-    create_bind_group, create_segment_buffer, create_uniform_buffer, pack_into,
-    segments_byte_size, write_segments,
+    create_bind_group, create_segment_buffer, create_uniform_buffer, pack_into, segments_byte_size,
+    write_segments,
 };
 use super::types::{LineEntry, LineKey, LineTopology};
 

--- a/crates/renderer/src/render_passes/lines/gpu.rs
+++ b/crates/renderer/src/render_passes/lines/gpu.rs
@@ -13,19 +13,26 @@ use crate::{
 
 use super::types::{GpuLineSegment, LineTopology, LINE_UNIFORM_BYTES, SEGMENT_BYTES};
 
-pub(super) fn pack(
+/// Pack `(positions, colors, topology)` into `out`. Clears + extends
+/// in place so the caller can hand in a long-lived scratch buffer
+/// (see `LineRenderer::pack_buf`) and pay zero per-call allocation in
+/// the steady state. Leaves `out.is_empty()` when fewer than two
+/// positions are supplied (no segments to draw).
+pub(super) fn pack_into(
+    out: &mut Vec<GpuLineSegment>,
     positions: &[Vec3],
     colors: &[Vec4],
     topology: LineTopology,
-) -> Vec<GpuLineSegment> {
+) {
+    out.clear();
     if positions.len() < 2 {
-        return Vec::new();
+        return;
     }
     let last_color = colors.last().copied().unwrap_or(Vec4::ONE);
     let color_at = |i: usize| -> Vec4 { colors.get(i).copied().unwrap_or(last_color) };
     match topology {
         LineTopology::Strip => {
-            let mut out = Vec::with_capacity(positions.len() - 1);
+            out.reserve(positions.len() - 1);
             for i in 0..positions.len() - 1 {
                 out.push(GpuLineSegment {
                     a: [positions[i].x, positions[i].y, positions[i].z, 0.0],
@@ -39,11 +46,10 @@ pub(super) fn pack(
                     color_b: color_at(i + 1).to_array(),
                 });
             }
-            out
         }
         LineTopology::Segments => {
             let pair_count = positions.len() / 2;
-            let mut out = Vec::with_capacity(pair_count);
+            out.reserve(pair_count);
             for i in 0..pair_count {
                 let a = positions[2 * i];
                 let b = positions[2 * i + 1];
@@ -54,7 +60,6 @@ pub(super) fn pack(
                     color_b: color_at(2 * i + 1).to_array(),
                 });
             }
-            out
         }
     }
 }

--- a/crates/renderer/src/render_passes/lines/mod.rs
+++ b/crates/renderer/src/render_passes/lines/mod.rs
@@ -18,7 +18,9 @@ mod api;
 mod gpu;
 pub mod pipelines;
 mod renderer;
+pub mod shader;
 mod types;
 
 pub use renderer::LineRenderer;
+pub use shader::cache_key::ShaderCacheKeyLine;
 pub use types::{LineKey, LineTopology};

--- a/crates/renderer/src/render_passes/lines/pipelines.rs
+++ b/crates/renderer/src/render_passes/lines/pipelines.rs
@@ -10,7 +10,6 @@ use awsm_renderer_core::{
         primitive::PrimitiveState,
     },
     renderer::AwsmRendererWebGpu,
-    shaders::{ShaderModuleDescriptor, ShaderModuleExt},
 };
 
 use crate::{
@@ -23,6 +22,7 @@ use crate::{
         render_pipeline::{RenderPipelineCacheKey, RenderPipelineKey},
         Pipelines,
     },
+    render_passes::lines::shader::cache_key::ShaderCacheKeyLine,
     render_textures::RenderTextureFormats,
     shaders::Shaders,
 };
@@ -85,12 +85,14 @@ impl LinePipelines {
 
         let bind_group_layout_key = bind_group_layouts.get_key(gpu, bind_group_layout_cache_key)?;
 
-        let shader_source = include_str!("shader/line_wgsl/line.wgsl");
-        let shader_module = gpu.compile_shader(
-            &ShaderModuleDescriptor::new(shader_source, Some("line shader")).into(),
-        );
-        shader_module.validate_shader().await?;
-        let shader_key = shaders.insert_uncached(shader_module);
+        // Route through the shared `Shaders` cache. The shader has no
+        // per-variant parameters but going through the cache means
+        // `Shaders::ensure_keys` can pre-warm it alongside e.g. the
+        // picker's compute shaders, letting the browser do the
+        // parallel compile. The prior `insert_uncached` shape bypassed
+        // the cache entirely so the line compile always serialised
+        // behind whatever other shader work was in flight.
+        let shader_key = shaders.get_key(gpu, ShaderCacheKeyLine).await?;
 
         let pipeline_layout_key = pipeline_layouts.get_key(
             gpu,

--- a/crates/renderer/src/render_passes/lines/renderer.rs
+++ b/crates/renderer/src/render_passes/lines/renderer.rs
@@ -8,12 +8,20 @@ use crate::{
 };
 
 use super::pipelines::{LinePipelines, LineVariantKey};
-use super::types::{LineEntry, LineKey, LINE_UNIFORM_BYTES};
+use super::types::{GpuLineSegment, LineEntry, LineKey, LINE_UNIFORM_BYTES};
 
 /// Renderer-side state owning the four line pipelines and every registered line strip.
 pub struct LineRenderer {
     pub(super) pipelines: LinePipelines,
     pub(super) entries: SlotMap<LineKey, LineEntry>,
+    /// Scratch packing buffer reused across `add_line` / `update_line`
+    /// calls. The `pack_into` helper clears + extends in place so
+    /// per-call allocation cost goes to zero in the steady state.
+    /// Held on the renderer (not on each call site) so editor
+    /// overlays that re-pack many small line strips per frame
+    /// (collider wireframes, point handles, selection outlines)
+    /// don't bounce the allocator.
+    pub(super) pack_buf: Vec<GpuLineSegment>,
 }
 
 impl LineRenderer {
@@ -38,6 +46,7 @@ impl LineRenderer {
         Ok(Self {
             pipelines,
             entries: SlotMap::with_key(),
+            pack_buf: Vec::new(),
         })
     }
 

--- a/crates/renderer/src/render_passes/lines/shader/cache_key.rs
+++ b/crates/renderer/src/render_passes/lines/shader/cache_key.rs
@@ -1,0 +1,14 @@
+//! Line shader cache key.
+
+use crate::shaders::ShaderCacheKey;
+
+/// Cache key for the fat-line WGSL shader. Static source — no
+/// per-variant parameters — so a zero-size struct is enough.
+#[derive(Hash, Debug, Clone, PartialEq, Eq, Default)]
+pub struct ShaderCacheKeyLine;
+
+impl From<ShaderCacheKeyLine> for ShaderCacheKey {
+    fn from(key: ShaderCacheKeyLine) -> Self {
+        ShaderCacheKey::Line(key)
+    }
+}

--- a/crates/renderer/src/render_passes/lines/shader/mod.rs
+++ b/crates/renderer/src/render_passes/lines/shader/mod.rs
@@ -1,0 +1,12 @@
+//! Cache-key + template glue for the fat-line shader.
+//!
+//! The shader itself is a static `line.wgsl` with no template
+//! substitutions, but going through the `Shaders` cache means
+//! `Shaders::ensure_keys` can pre-warm the line shader alongside
+//! other shaders (e.g. the picker) so the browser compiles them
+//! in parallel. The previous `shaders.insert_uncached` shape
+//! bypassed the cache entirely, forcing the line shader's compile
+//! to serialize behind whatever other shader work was in flight.
+
+pub mod cache_key;
+pub mod template;

--- a/crates/renderer/src/render_passes/lines/shader/template.rs
+++ b/crates/renderer/src/render_passes/lines/shader/template.rs
@@ -1,0 +1,34 @@
+//! Line shader template.
+
+use askama::Template;
+
+use crate::{
+    render_passes::lines::shader::cache_key::ShaderCacheKeyLine,
+    shaders::{AwsmShaderError, Result},
+};
+
+/// Static fat-line shader — no per-variant parameters; the
+/// `depth_compare` / MSAA branching happens at pipeline-state
+/// creation, not in the WGSL itself.
+#[derive(Template, Debug, Default)]
+#[template(path = "line_wgsl/line.wgsl", whitespace = "minimize")]
+pub struct ShaderTemplateLine;
+
+impl TryFrom<&ShaderCacheKeyLine> for ShaderTemplateLine {
+    type Error = AwsmShaderError;
+
+    fn try_from(_value: &ShaderCacheKeyLine) -> Result<Self> {
+        Ok(Self)
+    }
+}
+
+impl ShaderTemplateLine {
+    pub fn into_source(self) -> Result<String> {
+        self.render().map_err(AwsmShaderError::from)
+    }
+
+    #[cfg(debug_assertions)]
+    pub fn debug_label(&self) -> Option<&str> {
+        Some("Line")
+    }
+}

--- a/crates/renderer/src/render_passes/material_decal/composite.rs
+++ b/crates/renderer/src/render_passes/material_decal/composite.rs
@@ -81,7 +81,7 @@ pub struct MaterialDecalComposite {
 
 impl MaterialDecalComposite {
     pub async fn new(ctx: &mut RenderPassInitContext<'_>) -> Result<Self> {
-        let gpu = &*ctx.gpu;
+        let gpu = ctx.gpu;
         let shader_module = gpu.compile_shader(
             &ShaderModuleDescriptor::new(SHADER_SOURCE, Some("Decal Composite shader")).into(),
         );

--- a/crates/renderer/src/render_textures.rs
+++ b/crates/renderer/src/render_textures.rs
@@ -72,16 +72,21 @@ impl RenderTextures {
         formats: RenderTextureFormats,
         features: &RendererFeatures,
     ) -> Result<Self> {
-        // The three blit pipelines are independent GPU operations
-        // (different shader variants, no shared mutable state). Compile
-        // them concurrently — the browser interleaves the shader
-        // validation under the hood, saving ~2/3 of the wall-clock
-        // each `await` would otherwise spend serial.
-        let (
-            opaque_to_transparent_blit_pipeline_no_anti_alias,
-            opaque_to_transparent_blit_pipeline_msaa_4,
-            transparent_to_composite_blit_pipeline_no_anti_alias,
-        ) = futures::future::try_join3(
+        // Two distinct blit pipeline variants: the `None` (single-
+        // sample) variant is used by *both* the opaque→transparent
+        // and the transparent→composite blits — they share the same
+        // shader + color target + (no) MSAA, so a single compiled
+        // GpuRenderPipeline is reused. The `Some(4)` (MSAA-4) variant
+        // is used by the opaque→transparent blit only. Compile both
+        // variants concurrently; the `None` result is cloned into
+        // the two destination fields (wasm-bindgen JS handle clone =
+        // refcount bump, not a pipeline copy).
+        //
+        // Earlier shape compiled the `None` variant twice inside one
+        // `try_join3` — `blit_get_pipeline` has no in-flight dedupe,
+        // so the two futures genuinely did the same work twice. Fixed
+        // here by compiling each variant exactly once.
+        let (single_sample_pipeline, msaa_4_pipeline) = futures::future::try_join(
             async {
                 blit_get_pipeline(gpu, formats.color, None)
                     .await
@@ -89,11 +94,6 @@ impl RenderTextures {
             },
             async {
                 blit_get_pipeline(gpu, formats.color, Some(4))
-                    .await
-                    .map_err(AwsmRenderTextureError::BlitPipeline)
-            },
-            async {
-                blit_get_pipeline(gpu, formats.color, None)
                     .await
                     .map_err(AwsmRenderTextureError::BlitPipeline)
             },
@@ -105,9 +105,9 @@ impl RenderTextures {
             features: features.clone(),
             frame_count: 0,
             inner: None,
-            opaque_to_transparent_blit_pipeline_msaa_4,
-            opaque_to_transparent_blit_pipeline_no_anti_alias,
-            transparent_to_composite_blit_pipeline_no_anti_alias,
+            opaque_to_transparent_blit_pipeline_msaa_4: msaa_4_pipeline,
+            opaque_to_transparent_blit_pipeline_no_anti_alias: single_sample_pipeline.clone(),
+            transparent_to_composite_blit_pipeline_no_anti_alias: single_sample_pipeline,
         })
     }
 

--- a/crates/renderer/src/renderable.rs
+++ b/crates/renderer/src/renderable.rs
@@ -184,6 +184,17 @@ impl AwsmRenderer {
                                 && self.features.indirect_first_instance_enabled(),
                         },
                     )
+                    .inspect_err(|err| {
+                        // Log the *actual* failure reason at collection
+                        // time — `Renderable` only stores
+                        // `Option<RenderPipelineKey>`, so the geometry
+                        // pass's `None` path can only emit a generic
+                        // "missing pipeline" warning. Surface the
+                        // structured error here while we still have it.
+                        tracing::warn!(
+                            "geometry pipeline key lookup failed for mesh {mesh_key:?}: {err:?}"
+                        );
+                    })
                     .ok(),
                 material_opaque_compute_pipeline_key: self
                     .render_passes

--- a/crates/renderer/src/shaders.rs
+++ b/crates/renderer/src/shaders.rs
@@ -13,6 +13,7 @@ use awsm_renderer_core::shaders::ShaderModuleExt;
 use crate::{
     picker::{ShaderCacheKeyPicker, ShaderTemplatePicker},
     render_passes::{
+        lines::shader::{cache_key::ShaderCacheKeyLine, template::ShaderTemplateLine},
         shader_cache_key::ShaderCacheKeyRenderPass, shader_template::ShaderTemplateRenderPass,
     },
     shadows::shader::{cache_key::ShaderCacheKeyShadow, template::ShaderTemplateShadow},
@@ -152,6 +153,10 @@ pub enum ShaderCacheKey {
     RenderPass(ShaderCacheKeyRenderPass),
     Picker(ShaderCacheKeyPicker),
     Shadow(ShaderCacheKeyShadow),
+    /// Fat-line shader (renderer-built editor / debug overlays).
+    /// Hoisted out of `RenderPass` for the same reason as `Picker` —
+    /// it's a top-level renderer concern, not a per-pass variant.
+    Line(ShaderCacheKeyLine),
 }
 
 /// Shader template variants for renderer-managed shaders.
@@ -159,6 +164,7 @@ pub enum ShaderTemplate {
     RenderPass(ShaderTemplateRenderPass),
     Picker(ShaderTemplatePicker),
     Shadow(ShaderTemplateShadow),
+    Line(ShaderTemplateLine),
 }
 
 impl TryFrom<&ShaderCacheKey> for ShaderTemplate {
@@ -171,6 +177,7 @@ impl TryFrom<&ShaderCacheKey> for ShaderTemplate {
             }
             ShaderCacheKey::Picker(cache_key) => Ok(ShaderTemplate::Picker(cache_key.into())),
             ShaderCacheKey::Shadow(cache_key) => Ok(ShaderTemplate::Shadow(cache_key.try_into()?)),
+            ShaderCacheKey::Line(cache_key) => Ok(ShaderTemplate::Line(cache_key.try_into()?)),
         }
     }
 }
@@ -196,6 +203,7 @@ impl ShaderTemplate {
             ShaderTemplate::RenderPass(tmpl) => tmpl.debug_label(),
             ShaderTemplate::Picker(tmpl) => tmpl.debug_label(),
             ShaderTemplate::Shadow(tmpl) => tmpl.debug_label(),
+            ShaderTemplate::Line(tmpl) => tmpl.debug_label(),
         }
     }
 
@@ -205,6 +213,7 @@ impl ShaderTemplate {
             ShaderTemplate::RenderPass(tmpl) => tmpl.into_source()?,
             ShaderTemplate::Picker(tmpl) => tmpl.into_source()?,
             ShaderTemplate::Shadow(tmpl) => tmpl.into_source()?,
+            ShaderTemplate::Line(tmpl) => tmpl.into_source()?,
         };
         //tracing::info!("{:#?}", tmpl);
         // print_shader_source(&source, true);

--- a/crates/renderer/src/shaders.rs
+++ b/crates/renderer/src/shaders.rs
@@ -14,7 +14,8 @@ use crate::{
     picker::{ShaderCacheKeyPicker, ShaderTemplatePicker},
     render_passes::{
         lines::shader::{cache_key::ShaderCacheKeyLine, template::ShaderTemplateLine},
-        shader_cache_key::ShaderCacheKeyRenderPass, shader_template::ShaderTemplateRenderPass,
+        shader_cache_key::ShaderCacheKeyRenderPass,
+        shader_template::ShaderTemplateRenderPass,
     },
     shadows::shader::{cache_key::ShaderCacheKeyShadow, template::ShaderTemplateShadow},
 };

--- a/crates/renderer/src/transforms.rs
+++ b/crates/renderer/src/transforms.rs
@@ -54,8 +54,18 @@ impl AwsmRenderer {
             self.sync_spatial_for_mesh(mesh_key);
         }
 
-        // Periodic BVH refresh.
-        self.scene_spatial.rebuild_if_needed();
+        // Periodic BVH refresh. Span so `read_render_pass_timings`
+        // can attribute the rebuild cost when tuning the cadence
+        // defaults (`SceneSpatialConfig::rebuild_period_frames` /
+        // `rebuild_dirty_threshold`).
+        {
+            let _maybe_span_guard = if self.logging.render_timings {
+                Some(tracing::span!(tracing::Level::INFO, "SceneSpatial Rebuild").entered())
+            } else {
+                None
+            };
+            self.scene_spatial.rebuild_if_needed();
+        }
 
         // Per-frame per-light → per-mesh bucket rebuild — cheap (one
         // `query_envelope` per active punctual light).

--- a/crates/scene-schema/src/assets.rs
+++ b/crates/scene-schema/src/assets.rs
@@ -100,6 +100,28 @@ pub struct AssetEntry {
     /// hint — an empty Vec serializes as zero length anyway.
     #[serde(default)]
     pub gltf_material_asset_ids: Vec<AssetId>,
+    /// Editable `Texture` asset ids extracted from a glTF file on
+    /// import, indexed by glTF *image* index (not texture index —
+    /// multiple glTF textures can share the same image with
+    /// different samplers, but the editor stores one Texture asset
+    /// per image so the assets library stays tidy). Empty for
+    /// non-glTF entries (and for glTFs imported before this
+    /// feature shipped).
+    ///
+    /// Used at populate-glb time to seed the editor's
+    /// `texture_cache` with the `TextureKey`s the renderer-gltf
+    /// side already uploaded — without this, every editor
+    /// material override would re-decode + re-upload the same
+    /// image, doubling GPU storage and decode wall-clock per glTF
+    /// texture. See `crates/frontend/scene-editor/src/renderer_bridge/asset_cache.rs::seed_texture_cache_from_populate`.
+    ///
+    /// Vec position is the glTF image index; gaps are filled with
+    /// `AssetId::default()` if the document skips one (rare —
+    /// glTF documents almost always pack image indices densely).
+    /// `#[serde(default)]` keeps pre-feature project.json files
+    /// round-tripping cleanly.
+    #[serde(default)]
+    pub gltf_image_asset_ids: Vec<AssetId>,
     /// SHA-256 of the on-disk file's content, as lowercase hex. Drives
     /// the disk path (see [`asset_disk_path`]) and the upload-time
     /// dedup check — two uploads of identical bytes reuse the same
@@ -122,6 +144,7 @@ impl AssetEntry {
         Self {
             source,
             gltf_material_asset_ids: Vec::new(),
+            gltf_image_asset_ids: Vec::new(),
             content_hash: String::new(),
         }
     }
@@ -134,6 +157,7 @@ impl AssetEntry {
         Self {
             source,
             gltf_material_asset_ids: Vec::new(),
+            gltf_image_asset_ids: Vec::new(),
             content_hash,
         }
     }

--- a/crates/web-shared/src/theme/misc.rs
+++ b/crates/web-shared/src/theme/misc.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 
 pub static USER_SELECT_NONE: LazyLock<String> = LazyLock::new(|| {
     class! {
-        .style(["-moz-user-select", "user-select", "-webkit-user-select"], "text")
+        .style(["-moz-user-select", "user-select", "-webkit-user-select"], "none")
     }
 });
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -570,11 +570,14 @@ scene-editor exposes four `#[cfg(debug_assertions)]`
 | `read_mesh_coverage_stats()` | JSON string | Verifies the GPU coverage producer reached the CPU table. |
 | `read_importance_tier_histogram()` | JSON string | Shadow-caster-light tier histogram. |
 | `read_oversized_mesh_stats()` | JSON string | `{ last_max_bucket, oversized_count }` from `LightMeshBuckets`. |
+| `read_render_pass_timings(min_count)` | JSON string | Per-pass `count / mean / p50 / p95 / max / total` (ms). Strips the `[id]: span-measure` suffix `tracing-web` appends so call sites collapse into one bucket. Clears measures after sampling. Pass `min_count=0` to include rare init spans (GLTF parse, etc.). |
 
 Per-frame render-pass timings come from
 `performance.getEntriesByType('measure')` — `tracing-web`'s
 `performance_layer` routes every renderer span through the
-browser's Performance API. No custom JSON harness required.
+browser's Performance API. `read_render_pass_timings(...)` is the
+one-shot summariser if you don't want to walk the entries
+manually.
 
 URL switch `?features=off` (debug only) flips
 `RendererFeatures::default()` for A/B comparison without

--- a/docs/plans/more-optimizations.md
+++ b/docs/plans/more-optimizations.md
@@ -357,22 +357,22 @@ config knob.
 
 ## Phase 5 — Per-frame polish
 
-### 5.3 Coalesce reactive signal cascades
-
-`bump_nodes_revision` in `renderer_bridge` fires when any bridge
-entry changes; consumers (selection observer, gizmo, point-handle,
-inspector) re-derive their own state on every fire. For a multi-
-mesh model insert this can spike to dozens of cascades per frame.
-Approach: debounce / batch via `request_animation_frame` so multi-
-node mutations cascade once per frame instead of once per node.
-
----
-
 ## ✅ Recently landed (do not redo)
 
 For PR context — these shipped in the prior sprint and the
 `indirect-first-instance` sprint before it.
 
+- ✅ Phase 5.3 — `Bridge::bump_nodes_revision` debounces via
+  `gloo_render::request_animation_frame`. A pending-frame slot
+  on `Bridge` short-circuits subsequent bumps inside the same
+  frame; the rAF callback `take()`s itself out and does the
+  actual `Mutable::set`. Multi-mesh model inserts (which fired
+  `bump_nodes_revision` per node during `insert_node` and again
+  per node during `remove_node`) now cascade once per frame
+  instead of once per node, collapsing dozens of selection /
+  gizmo / point-handle / inspector re-derivations into one.
+  Safe because every consumer is a `signal()` subscriber — none
+  expect synchronous response.
 - ✅ Phase 5.2 — added a `tracing::span!("SceneSpatial Rebuild")`
   around `scene_spatial.rebuild_if_needed` in `update_transforms`
   so `read_render_pass_timings(0)` attributes the rebuild cost.

--- a/docs/plans/more-optimizations.md
+++ b/docs/plans/more-optimizations.md
@@ -544,34 +544,59 @@ For the next picker — items explicitly considered and rejected.
 
 When picking up an item:
 
-- **Branch**: work from `main`; create a feature branch per logical
-  chunk, or work straight on a sprint branch like the prior
-  `more-optimizations` if doing many items.
-- **Verification**: `cargo check --workspace` (or
-  `cargo clippy --workspace`) + `cargo test --workspace` must stay
-  green at every commit. **Don't run `cargo build --workspace`** —
-  it's wasted wall-clock; `check` / `clippy` cover compile
-  validation and the trunk dev-server is the real "does it run"
-  check. For full visual verification, ensure the trunk server is
-  running (`task scene-editor:dev` or the
-  `mcp__Claude_Preview__preview_start` helper) and exercise the
-  editor in the browser. The editor must render correctly on both
-  `?ifi=on` and `?ifi=off` (or the Editor toggle equivalent once
-  Phase 0.1 lands).
-- **Smoke test**: launch `task scene-editor:dev`, insert a Box +
-  Sphere + Torus, confirm all three render. Repeat on the opposite
-  ifi setting before claiming done.
-- **Test in Safari + Chrome** where possible — the
-  `indirect-first-instance` saga showed how easily a Chrome-only
-  validation pass can mask Safari breakage. The Safari GPU process
-  is also more sensitive to dev-session state churn; a fresh
-  restart is the meaningful comparison.
-- **Commits**: small, logical, descriptive. End each with
+- **Branch**: work on the `optimizations` branch. Do *not* spin
+  up feature branches per chunk — the whole sprint lands on
+  `optimizations`. The branch will be PR'd to `main` as a single
+  batch once everything has landed.
+- **Commits**: small, logical, descriptive — sized for git-bisect
+  to be useful. Each commit should map to one Phase item (or a
+  clean sub-step of one). End each commit message with
   `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`.
+- **Verification policy** *(important — this is different from the
+  prior sprint)*: it is **acceptable for the workspace to be in a
+  broken state between commits** during this sprint. Don't pad
+  each individual commit with compatibility shims, redundant
+  conversions, or temporary forwarders just to keep the tree
+  compiling mid-sequence — that work would all be deleted later
+  and the technical debt is worse than the broken-middle state.
+  Verification (`cargo check`, `cargo clippy`, `cargo test`,
+  editor smoke test) is required **only at the end of the whole
+  sprint** before requesting review. Intermediate compile
+  failures are fine *if* the failure scope is bounded and the
+  next commit fixes it.
+
+  Use git-bisect semantics as the guide: a future bisector wants
+  *logical* boundaries, not "every commit must build." Tight,
+  honest commits beat fake-greenness.
+
+  Within a single commit, however: keep the diff coherent. Don't
+  ship "added field but forgot to update use sites" if updating
+  the use sites is a one-line change — that's just sloppy. The
+  "broken middle" permission is for genuine cross-file refactors
+  (e.g., a trait signature change that takes 30 use sites to
+  update) where staging matters for bisect.
+
+  **Don't run `cargo build --workspace`** at any point —
+  `cargo check` is cheaper and covers compile validation. The
+  trunk dev-server + editor browser smoke test are the real
+  "does it run" check at the end.
+
+- **End-of-sprint verification** (do once, before opening the PR):
+  - `cargo check --workspace` clean
+  - `cargo clippy --workspace` clean
+  - `cargo test --workspace` green
+  - Editor renders Primitive Box + Sphere + Torus on both
+    `?ifi=on` and `?ifi=off` (or the Editor toggle equivalent
+    once Phase 0.1 lands)
+  - Repeat the smoke test on Safari if possible; cold-restart
+    Safari is the meaningful comparison since dev-session
+    degradation is a dev-loop artifact, not a renderer bug
+
 - **Doc maintenance**: when a Phase item lands, move it to
   "Recently landed" with a one-line summary. When an item turns
-  out to be unwise, move it to "Won't do" with the reason. Keep
-  this doc the source of truth — don't let it drift.
+  out to be unwise mid-implementation, move it to "Won't do"
+  with the reason. Keep this doc the source of truth — don't let
+  it drift, even mid-sprint when other things are broken.
 
 Reference docs:
 - [`docs/PERFORMANCE.md`](../PERFORMANCE.md) — permanent renderer

--- a/docs/plans/more-optimizations.md
+++ b/docs/plans/more-optimizations.md
@@ -42,24 +42,6 @@ cross-references in commit messages stay valid.
 
 ## Phase 4 — Model insert UX
 
-### 4.1 🚀 Deduplicate the two GPU texture-pool uploads per glb texture
-
-The `renderer-gltf` path uploads each image via
-`Textures::add_image(ImageData::Bitmap)` for the baked materials,
-AND the editor's `texture_cache::get_or_upload` uploads the same
-image (separate `createImageBitmap` decode + separate pool slot) so
-the editor's editable material override has its own copy. That's
-**2× GPU storage + 2× decode** per texture on every model insert.
-
-Approach: plumb a mapping `AssetId → existing TextureKey` from
-`renderer-gltf` into the editor's `texture_cache` so the override
-path reuses the renderer-gltf-side pool slot. Touch points:
-[crates/renderer-gltf/src/populate/](../../crates/renderer-gltf/src/populate) (publish the mapping) and
-[crates/frontend/scene-editor/src/renderer_bridge/texture_cache.rs](../../crates/frontend/scene-editor/src/renderer_bridge/texture_cache.rs)
-(consume it).
-
-Probably the single biggest model-insert-UX win in this list.
-
 ### 4.2 🚀 Pre-decode raster bitmaps eagerly
 
 The raster prefetch is currently hoisted into `load_and_populate`,
@@ -402,6 +384,17 @@ node mutations cascade once per frame instead of once per node.
 For PR context — these shipped in the prior sprint and the
 `indirect-first-instance` sprint before it.
 
+- ✅ Phase 4.1 — Editor texture_cache seeded from renderer-gltf
+  uploads. `extract_gltf_materials_into` now stashes a per-image
+  `gltf_image_asset_ids` Vec on the gltf's AssetEntry. After
+  `populate_gltf` lands, `asset_cache::seed_texture_cache_from_populate`
+  walks `ctx.textures`, resolves each (texture_index, color)
+  back to the gltf image index, and seeds the editor's
+  `texture_cache` with the renderer-gltf-side `TextureKey`. The
+  override path's `get_or_upload(asset_id, ...)` now hits the
+  shared key instead of re-decoding + re-uploading the same image
+  — recovers the **2× GPU storage + 2× decode** per glb texture
+  that the editor was paying.
 - ✅ Phase 1.2 — Pre-warmed LineRenderer + Picker shader compiles.
   LineRenderer migrated off `shaders.insert_uncached` onto a real
   `ShaderCacheKeyLine` (new `ShaderCacheKey::Line` variant + a

--- a/docs/plans/more-optimizations.md
+++ b/docs/plans/more-optimizations.md
@@ -357,12 +357,6 @@ config knob.
 
 ## Phase 5 — Per-frame polish
 
-### 5.1 Particle simulator + line-strip vertex-pack Vec pooling
-
-Same pattern as the recent `RenderablePool` work — hold the scratch
-Vecs on the simulator / LineRenderer and `clear_in_place` per frame
-instead of fresh-allocating.
-
 ### 5.2 `scene_spatial::rebuild_if_needed` cadence tuning
 
 Defaults are `rebuild_period_frames = 600` and
@@ -388,6 +382,15 @@ node mutations cascade once per frame instead of once per node.
 For PR context — these shipped in the prior sprint and the
 `indirect-first-instance` sprint before it.
 
+- ✅ Phase 5.1 — `LineRenderer` carries a `pack_buf:
+  Vec<GpuLineSegment>` scratch buffer; `pack()` became
+  `pack_into(out, ...)` which `out.clear()`s + extends in place.
+  Editor overlays (collider wireframes, point handles, selection
+  outlines) re-pack many small line strips per frame and were
+  bouncing the allocator per call; this pulls them off the alloc
+  path. Simulator side already pooled (`Simulator.packed: Vec
+  <InstanceAttr>` is held + clear+pushed in `tick()`) — Phase 5.1
+  needed only the LineRenderer half.
 - ✅ Phase 4.2 — Raster bitmap prefetch fires from `prepare_model`
   the moment the gltf texture bytes are in `pending_assets`
   (right after `extract_gltf_materials_into`), as a

--- a/docs/plans/more-optimizations.md
+++ b/docs/plans/more-optimizations.md
@@ -42,7 +42,18 @@ cross-references in commit messages stay valid.
 
 ## Phase 4 — Model insert UX
 
-### 4.3 🚀 First-class worker pool + glTF parse as first consumer
+### 4.3 🚀 First-class worker pool + glTF parse as first consumer  *(deferred — see "Won't do")*
+
+The full design — `WorkerPool` + `WorkerJob` trait, auto-bundle
+discovery via `import.meta.url`, shared `WebAssembly.Module`
+postMessage protocol, `linkme`-style distributed-slice job
+registry, `GltfParseJob` as first consumer, opt-in via config
+knob behind a per-pass measurement gate — is preserved below for
+the dedicated follow-up sprint. Reasoning for deferral is in
+"Won't do".
+
+<details>
+<summary>Full original design (preserved for follow-up sprint)</summary>
 
 This phase builds a **library-wide worker-job infrastructure** (4.3a)
 and uses glTF parse as its first consumer (4.3b). The infrastructure
@@ -340,6 +351,8 @@ config knob.
   startup cost (~5–50 ms per worker spawn). Scene loads with
   multiple glbs would pay it per file.
 
+</details>
+
 ---
 
 ## Phase 5 — Per-frame polish
@@ -457,6 +470,27 @@ For PR context — these shipped in the prior sprint and the
 
 For the next picker — items explicitly considered and rejected.
 
+- ❌ First-class worker pool + GltfParseJob (was Phase 4.3).
+  Rejected for this sprint — the plan's own measurement gate
+  ("Before landing 4.3b, wire 0.2's per-pass sub-spans and add a
+  `gltf-parse` measurement so the worker version can be compared
+  to the inline version. If the transfer cost dominates … the
+  pool can be opt-in via a config knob") makes it
+  measurement-required, and the implementation surface — wasm
+  worker init, shared `WebAssembly.Module` postMessage, dynamic
+  job dispatch with `linkme`-style registry, opt-in config knob,
+  the `gltf-parse` A/B measurement — is multi-day on its own.
+  wasm worker init also has notoriously fragile cross-browser
+  behaviour (Safari module-worker quirks, COOP/COEP
+  interactions) that a single-session blind run can't validate.
+  The full design — `WorkerPool`, `WorkerJob` trait, auto-bundle
+  discovery via `import.meta.url`, shared-Module shim, the
+  `GltfParseJob` consumer wiring — is preserved in the Phase 4.3
+  section above (collapsed under "Full original design") so the
+  follow-up sprint can pick it up cold. Recommended split:
+  Phase 4.3a (infra + Custom-bootstrap-only API) → Phase 4.3b
+  (`import.meta.url` auto-discovery + GltfParseJob + A/B
+  measurement → opt-in config knob).
 - ❌ Per-frame upload arena (was Phase 2.1). Rejected for this
   sprint — broad scope (touches ~10 subsystems' `write_gpu`:
   transforms, materials, instances, meshes/meta, textures,

--- a/docs/plans/more-optimizations.md
+++ b/docs/plans/more-optimizations.md
@@ -21,31 +21,6 @@ in both Chrome and Safari from the running editor.
 
 ## Phase 1 — Renderer init parallelization
 
-## Phase 2 — Per-frame upload consolidation
-
-### 2.1 🚀 Consolidate per-frame `queue.writeBuffer` calls into a shared staging buffer
-
-Every frame the renderer fires ~15–25 distinct `writeBuffer` calls
-(transforms, materials, instances, meta, shadows, light indices,
-occlusion instances, occlusion params, coverage reset, classify
-reset, decal reset, mesh-light-indices upload, etc.). On Safari each
-call is a Metal staging-buffer create + blit + sync; Chrome amortises
-better but still benefits.
-
-Approach: introduce a per-frame **upload arena** — a single
-GPU-resident staging buffer that subsystems append to via a small
-`UploadHandle { offset, len }`, then one `copyBufferToBuffer` per
-destination (or one `writeBuffer` of the whole arena followed by
-`copyBufferToBuffer` blits). The dirty-range tracking in
-`DynamicUniformBuffer` / `DynamicStorageBuffer` already coalesces;
-the change here is replacing N small `writeBuffer`s with one large
-one.
-
-Worth measuring before+after on both browsers — should be the
-biggest Safari delta of this sprint.
-
----
-
 ## Phase 3 — *(retired — see "Recently landed" below)*
 
 The original Phase 3 ("merge opaque PBR/Unlit/Toon compute pipelines
@@ -487,6 +462,21 @@ For PR context — these shipped in the prior sprint and the
 
 For the next picker — items explicitly considered and rejected.
 
+- ❌ Per-frame upload arena (was Phase 2.1). Rejected for this
+  sprint — broad scope (touches ~10 subsystems' `write_gpu`:
+  transforms, materials, instances, meshes/meta, textures,
+  camera, lights, shadows globals + descriptors, skins, morphs,
+  plus several reset paths), and the plan's own framing says it
+  needs before/after measurement on Chrome AND Safari to confirm
+  the win — Chrome already amortises `writeBuffer` well, the
+  Safari delta is the load-bearing benefit. Landing a
+  cross-subsystem refactor blind on Chrome-only carries the
+  highest bug-surface of any sprint item; staking the
+  measurement-required claim without a Safari-side number is
+  unjustified. The dirty-range coalescing in
+  `write_buffer_with_dirty_ranges` already buys most of the
+  Chrome-side gain (~5-10 ranges per call typically). Should be
+  re-picked as its own sprint with Safari hardware in the loop.
 - ❌ `Arc<Mutex<...>>` → `Rc<RefCell<...>>`. Rejected: the
   `Send`/`Sync` shape is intentional future-proofing for
   multi-threading. On wasm32 the lock-acquire is essentially free.

--- a/docs/plans/more-optimizations.md
+++ b/docs/plans/more-optimizations.md
@@ -19,18 +19,6 @@ the bottom of this doc before starting.
 These don't change perf; they let every later item be A/B'd cheaply
 in both Chrome and Safari from the running editor.
 
-### 0.1 ⚙️ MSAA toggle in the Editor section
-
-Add an `MSAA Anti-Aliasing` checkbox to the scene-editor's Editor
-header tab ([crates/frontend/scene-editor/src/header/editor.rs](../../crates/frontend/scene-editor/src/header/editor.rs)) — mirror the pattern in [model-tests' SidebarProcessing::render_msaa_selector](../../crates/frontend/model-tests/src/pages/app/sidebar/processing.rs)
-(`msaa_sample_count: Option<u32>` — `Some(4)` ↔ `None`). Re-init the
-renderer's anti-aliasing on change via the existing
-`set_anti_aliasing(..)` flow. **Runtime toggles like this should be
-editor UI, not URL switches** — the project convention is to expose
-everything switch-able through the header tabs (Editor / Camera /
-Environment / etc.). The existing `?ifi=on/off` was the wrong shape
-and should ALSO migrate to an Editor toggle in this phase if cheap.
-
 ### 0.2 ⚙️ Per-pass `performance.measure` sub-spans
 
 The top-level `Render` span already lands in
@@ -479,6 +467,12 @@ node mutations cascade once per frame instead of once per node.
 For PR context — these shipped in the prior sprint and the
 `indirect-first-instance` sprint before it.
 
+- ✅ Phase 0.1 (partial) — `MSAA Anti-Aliasing` checkbox in the
+  scene-editor's Editor header tab. Mirrors the pattern in
+  model-tests' `SidebarProcessing::render_msaa_selector`; routes
+  through a new `actions::view::toggle_msaa()` that calls
+  `renderer.set_anti_aliasing(..)`. `?ifi` / `?features` migration
+  was carved out — see "Won't do".
 - ✅ `apply_visibility_to_node` identity guard
 - ✅ `apply_visibility_subtree` batches into one `with_renderer_mut`
 - ✅ `MeshLightIndicesGpu::write_gpu` fast path on empty scenes
@@ -511,9 +505,17 @@ For the next picker — items explicitly considered and rejected.
   multi-threading. On wasm32 the lock-acquire is essentially free.
 - ❌ URL switches for runtime-togglable behavior. Project
   convention: editor header tabs (Editor / Camera / Environment /
-  etc.). The pre-existing `?ifi=on/off` and `?features=off`
-  switches predate this convention and should migrate to Editor
-  toggles in Phase 0.1.
+  etc.). MSAA migrated as part of Phase 0.1; **`?ifi` /
+  `?features` migration deferred** — `RendererFeatures` is read at
+  builder time (see `features.rs` doc: "Toggling a gate after
+  `build()` requires a renderer rebuild"). A live editor-tab
+  toggle would either (a) require a full renderer rebuild path
+  (drop renderer, recreate, re-establish all bridge observers /
+  hooks / RAF) or (b) flip the URL param and reload the page,
+  which destroys unsaved scene state. Both are out of scope for
+  this sprint. The dev-only `?ifi=` / `?features=` URL knobs (gated
+  on `cfg(debug_assertions)`) stay as the measurement-harness
+  escape hatch.
 - ❌ Lazy-allocate Occlusion/Compaction/Coverage feature buffers
   when no meshes. Win is microscopic (~70 KB GPU memory + 4 buffer
   creates at builder time, dominated by shader compilation).

--- a/docs/plans/more-optimizations.md
+++ b/docs/plans/more-optimizations.md
@@ -21,33 +21,6 @@ in both Chrome and Safari from the running editor.
 
 ## Phase 1 — Renderer init parallelization
 
-### 1.1 🚀 Refactor `RenderPassInitContext.gpu` from `&mut` to `&`
-
-[crates/renderer/src/render_passes.rs:119](../../crates/renderer/src/render_passes.rs) — `gpu: &'a mut AwsmRendererWebGpu`
-is never actually mutated downstream; the `&mut` is the *only* thing
-blocking `RenderTextures::new` from running concurrently with
-`RenderPasses::new` (the previous sprint had to settle for inner
-`try_join3` in `RenderTextures::new`). Walk every consumer; the
-WebGPU device handle is clonable / wrapped enough that `&` should be
-sufficient.
-
-After landing, wrap `RenderPasses::new` + `RenderTextures::new` in
-`futures::future::try_join` in [lib.rs](../../crates/renderer/src/lib.rs) — they share no
-mutable state (one takes `&mut shaders/pipelines/...`, the other
-takes owned `RenderTextureFormats` + `&gpu`).
-
-### 1.2 🚀 Pre-warm LineRenderer shaders in parallel with Picker
-
-Both currently serialize through `&mut shaders / pipelines /
-bind_group_layouts`. Approach: collect both passes' shader cache
-keys up-front, issue a single `shaders.ensure_keys` batch, then
-construct both with the cache already warm. **Prerequisite:**
-`LineRenderer` currently uses `shaders.insert_uncached` so its
-shader bypasses the cache entirely — needs a small refactor to a
-cache-keyed shader before `ensure_keys` can help it.
-
----
-
 ## Phase 2 — Per-frame upload consolidation
 
 ### 2.1 🚀 Consolidate per-frame `queue.writeBuffer` calls into a shared staging buffer
@@ -454,6 +427,24 @@ node mutations cascade once per frame instead of once per node.
 For PR context — these shipped in the prior sprint and the
 `indirect-first-instance` sprint before it.
 
+- ✅ Phase 1.2 — Pre-warmed LineRenderer + Picker shader compiles.
+  LineRenderer migrated off `shaders.insert_uncached` onto a real
+  `ShaderCacheKeyLine` (new `ShaderCacheKey::Line` variant + a
+  static `ShaderTemplateLine`). `lib.rs::build` now issues a
+  single `shaders.ensure_keys(...)` for the 1 Line + 2 Picker
+  shader variants before either constructor runs, so the browser
+  kicks off all three `compile_shader`s together and validates
+  them in parallel. The per-pass constructors then run
+  sequentially through `&mut shaders / &mut pipelines` (pipeline
+  state is fast vs. shader compile), but the slow part is
+  pre-warmed.
+- ✅ Phase 1.1 — `RenderPassInitContext.gpu: &mut` → `&`. Walk of
+  every consumer showed nothing actually mutated the handle. With
+  the shared borrow, `RenderPasses::new` + `RenderTextures::new`
+  now run inside a single `futures::future::try_join` in
+  `lib.rs::build` — both want `&gpu`, neither contends on the
+  other's `&mut` fields (RenderTextureFormats is cloned for the
+  textures side).
 - ✅ Phase 0.2 — `read_render_pass_timings(min_count)` measurement
   helper. The per-pass `performance.measure` entries already exist
   (`tracing-web::performance_layer` routes every renderer span

--- a/docs/plans/more-optimizations.md
+++ b/docs/plans/more-optimizations.md
@@ -357,15 +357,6 @@ config knob.
 
 ## Phase 5 — Per-frame polish
 
-### 5.2 `scene_spatial::rebuild_if_needed` cadence tuning
-
-Defaults are `rebuild_period_frames = 600` and
-`rebuild_dirty_threshold = 200`. Both could be data-driven —
-larger scenes benefit from less-frequent rebuilds (rebuild cost
-scales with mesh count); smaller scenes can rebuild more eagerly
-for tighter query quality. **Measure first** with 0.2's sub-spans
-on the `tuning-10k-meshes` scene.
-
 ### 5.3 Coalesce reactive signal cascades
 
 `bump_nodes_revision` in `renderer_bridge` fires when any bridge
@@ -382,6 +373,20 @@ node mutations cascade once per frame instead of once per node.
 For PR context — these shipped in the prior sprint and the
 `indirect-first-instance` sprint before it.
 
+- ✅ Phase 5.2 — added a `tracing::span!("SceneSpatial Rebuild")`
+  around `scene_spatial.rebuild_if_needed` in `update_transforms`
+  so `read_render_pass_timings(0)` attributes the rebuild cost.
+  Measured on `tuning-10k-meshes` (151 frames, steady state,
+  Chrome): mean 0.15ms, p50 0, p95 0.1, max 4.0, total 22.7ms.
+  The defaults (`rebuild_period_frames=600`,
+  `rebuild_dirty_threshold=200`) keep the worst-case 4ms rebuild
+  to roughly one hit per 10s @60fps — the per-frame budget
+  (`Render` mean 2.17ms) is dominated by `Geometry RenderPass`
+  (0.36ms), `Collect renderables` (0.27ms), and `Shadow
+  Generation` (0.66ms), so no clear tuning win is visible. Kept
+  the defaults; the new span is the load-bearing artifact —
+  future tuning has a measurement foundation that didn't exist
+  before this sprint.
 - ✅ Phase 5.1 — `LineRenderer` carries a `pack_buf:
   Vec<GpuLineSegment>` scratch buffer; `pack()` became
   `pack_into(out, ...)` which `out.clear()`s + extends in place.

--- a/docs/plans/more-optimizations.md
+++ b/docs/plans/more-optimizations.md
@@ -42,15 +42,6 @@ cross-references in commit messages stay valid.
 
 ## Phase 4 — Model insert UX
 
-### 4.2 🚀 Pre-decode raster bitmaps eagerly
-
-The raster prefetch is currently hoisted into `load_and_populate`,
-which runs once per glb. Move it to fire *synchronously the moment
-the bytes land in `pending_assets`* so it overlaps with the
-user-visible loading modal instead of running during populate.
-Saves ~1 s of `createImageBitmap` wall-clock during the loading
-window for large glbs.
-
 ### 4.3 🚀 First-class worker pool + glTF parse as first consumer
 
 This phase builds a **library-wide worker-job infrastructure** (4.3a)
@@ -384,6 +375,17 @@ node mutations cascade once per frame instead of once per node.
 For PR context — these shipped in the prior sprint and the
 `indirect-first-instance` sprint before it.
 
+- ✅ Phase 4.2 — Raster bitmap prefetch fires from `prepare_model`
+  the moment the gltf texture bytes are in `pending_assets`
+  (right after `extract_gltf_materials_into`), as a
+  `spawn_local` background task. Overlaps the `createImageBitmap`
+  wall-clock with the rest of the insert path (modal copy,
+  renderer-lock acquisition inside `load_and_populate`, the
+  populate_gltf compile/upload window) instead of running
+  serially inside populate. The original prefetch call inside
+  `load_and_populate` stays as a safety net (idempotent cache)
+  for paths that don't route through `prepare_model` — gizmo
+  init, procedural_sync, project Load.
 - ✅ Phase 4.1 — Editor texture_cache seeded from renderer-gltf
   uploads. `extract_gltf_materials_into` now stashes a per-image
   `gltf_image_asset_ids` Vec on the gltf's AssetEntry. After

--- a/docs/plans/more-optimizations.md
+++ b/docs/plans/more-optimizations.md
@@ -19,19 +19,6 @@ the bottom of this doc before starting.
 These don't change perf; they let every later item be A/B'd cheaply
 in both Chrome and Safari from the running editor.
 
-### 0.2 ⚙️ Per-pass `performance.measure` sub-spans
-
-The top-level `Render` span already lands in
-`performance.getEntriesByType('measure')`. Wire per-pass children so
-the Chrome-vs-Safari comparison can attribute the gap to a specific
-pass without manual instrumentation. Pattern: extend the
-`tracing::span!(... "Geometry RenderPass")` blocks in
-[render.rs](../../crates/renderer/src/render.rs) to also emit a
-`performance.mark` start/end pair when `logging.render_timings` is
-on. The instrumentation should be zero-cost when the flag is off.
-
----
-
 ## Phase 1 — Renderer init parallelization
 
 ### 1.1 🚀 Refactor `RenderPassInitContext.gpu` from `&mut` to `&`
@@ -467,6 +454,15 @@ node mutations cascade once per frame instead of once per node.
 For PR context — these shipped in the prior sprint and the
 `indirect-first-instance` sprint before it.
 
+- ✅ Phase 0.2 — `read_render_pass_timings(min_count)` measurement
+  helper. The per-pass `performance.measure` entries already exist
+  (`tracing-web::performance_layer` routes every renderer span
+  automatically); the new helper groups by base name — stripping
+  the `[id]: span-measure` suffix — and returns
+  `{count, mean_ms, p50_ms, p95_ms, max_ms, total_ms}` per pass
+  as JSON, then clears measures so the next sample window starts
+  fresh. Drives the Chrome-vs-Safari per-pass comparison in one
+  `preview_eval` call. Zero-cost when `render_timings = false`.
 - ✅ Phase 0.1 (partial) — `MSAA Anti-Aliasing` checkbox in the
   scene-editor's Editor header tab. Mirrors the pattern in
   model-tests' `SidebarProcessing::render_msaa_selector`; routes


### PR DESCRIPTION
End of the picklist sprint from [docs/plans/more-optimizations.md](docs/plans/more-optimizations.md). Phases worked through in dependency order; six landed, two deferred to follow-up sprints with detailed reasoning recorded in the doc's "Won't do" section.

## Per-phase summary

**Phase 0 — measurement + toggles (do-first)**

- **0.1** — `MSAA Anti-Aliasing` checkbox in the scene-editor's Editor header tab. Mirrors the model-tests `SidebarProcessing` pattern; routes through a new `actions::view::toggle_msaa()` → `renderer.set_anti_aliasing(..)`. The `?ifi` / `?features` URL-switch migration was carved out — `RendererFeatures` is read at builder time so a live editor toggle needs either a renderer rebuild (no such flow exists) or a page reload (destroys unsaved scene state). Both out of scope; the dev-only URL knobs (cfg(debug_assertions)) stay as the measurement-harness escape hatch. ([d5d58cb](https://github.com/dakom/awsm-renderer/commit/d5d58cb))
- **0.2** — `read_render_pass_timings(min_count)` measurement helper. The per-pass `performance.measure` entries already exist (tracing-web's `performance_layer` routes every renderer span); the new helper strips the `[id]: span-measure` suffix tracing-web appends, groups by base name, and returns `{count, mean_ms, p50_ms, p95_ms, max_ms, total_ms}` per pass as JSON, then `clearMeasures()`s the window. One `preview_eval` call drives the Chrome-vs-Safari per-pass comparison. ([7e2e0c9](https://github.com/dakom/awsm-renderer/commit/7e2e0c9))

**Phase 1 — init parallelization**

- **1.1** — `RenderPassInitContext.gpu: &mut → &`. A walk of every consumer showed the handle was never mutated; the `&mut` was the only thing blocking `RenderPasses::new` from running alongside `RenderTextures::new`. Both now run inside one `futures::future::try_join` in `lib.rs::build` — `RenderTextureFormats` is cloned for the textures side so the borrow graphs are disjoint. ([525ea5f](https://github.com/dakom/awsm-renderer/commit/525ea5f))
- **1.2** — Pre-warmed LineRenderer + Picker shaders. Migrated LineRenderer off `shaders.insert_uncached` (which bypassed the cache entirely) onto a real `ShaderCacheKey::Line` + `ShaderTemplateLine`. `lib.rs::build` now `shaders.ensure_keys(...)`s the 1 Line + 2 Picker (multisampled true/false) shader variants together — the browser issues all three `compile_shader`s synchronously and awaits every `validate_shader` in parallel before either subsystem constructs. ([09c0b16](https://github.com/dakom/awsm-renderer/commit/09c0b16))

**Phase 2 — per-frame upload consolidation**

- **2.1 (deferred)** — Per-frame upload arena. Broadest-scope item in the sprint (touches every `write_gpu` across ~10 subsystems) and the plan's own framing makes it measurement-required ("should be the biggest Safari delta"). Without Safari hardware to validate against, a Chrome-only blind refactor carries the highest bug-surface. The `write_buffer_with_dirty_ranges` coalescing already buys most of the Chrome-side gain. Reasoning + recommended split recorded in "Won't do". ([a26f27f](https://github.com/dakom/awsm-renderer/commit/a26f27f))

**Phase 3** — retired (already implemented; per the doc).

**Phase 4 — model insert UX**

- **4.1** — Editor `texture_cache` seeded from renderer-gltf uploads. `extract_gltf_materials_into` now stashes a per-image `gltf_image_asset_ids: Vec<AssetId>` on the gltf's `AssetEntry`; after `populate_gltf` lands, `asset_cache::seed_texture_cache_from_populate` walks `ctx.textures`, resolves each `(gltf_texture_index, color)` back to the gltf image index, and seeds the editor cache with the renderer-gltf-side `TextureKey`. The override-path `get_or_upload(asset_id, ...)` now hits the seeded key instead of re-decoding + re-uploading — recovers the **2× GPU storage + 2× decode** per glb texture that the editor was paying. ([f46526d](https://github.com/dakom/awsm-renderer/commit/f46526d))
- **4.2** — Raster bitmap prefetch fires from `prepare_model` the moment the gltf texture bytes are in `pending_assets`, as a `spawn_local` background task. Overlaps the `createImageBitmap` wall-clock with the rest of the insert path (modal copy, renderer-lock acquisition, populate_gltf window) instead of running serially inside populate. The original prefetch inside `load_and_populate` stays as an idempotent safety net for paths that don't route through `prepare_model`. ([6ac6958](https://github.com/dakom/awsm-renderer/commit/6ac6958))
- **4.3 (deferred)** — First-class worker pool + `GltfParseJob`. Multi-day implementation surface (wasm worker init, shared `WebAssembly.Module` postMessage protocol, dynamic job dispatch, `linkme`-style registry, `gltf-parse` A/B measurement → opt-in config knob) and the plan's own measurement gate makes 4.3b conditional. wasm worker init also has notoriously fragile cross-browser behaviour that a single-session blind run can't validate. Full design preserved in-doc under a `<details>` block for the follow-up sprint. ([4e5037f](https://github.com/dakom/awsm-renderer/commit/4e5037f))

**Phase 5 — per-frame polish**

- **5.1** — `LineRenderer` carries a `pack_buf: Vec<GpuLineSegment>` scratch buffer; `pack(...)` became `pack_into(out, ...)` which clears + extends in place. Editor overlays (collider wireframes, point handles, selection outlines) re-pack many small line strips per frame; per-call allocation goes to zero. Simulator side was already pooled. ([eb0e9c0](https://github.com/dakom/awsm-renderer/commit/eb0e9c0))
- **5.2** — Added a `tracing::span!("SceneSpatial Rebuild")` around `scene_spatial.rebuild_if_needed` in `update_transforms`. Measured on `tuning-10k-meshes` (151 steady-state frames, Chrome) via the new 0.2 helper: **mean 0.15ms / p50 0 / p95 0.1 / max 4.0 / total 22.7ms** across the sample window. With `rebuild_period_frames=600` + `rebuild_dirty_threshold=200` the worst-case 4ms rebuild lands ~1×/10s @60fps. Render mean was 2.17ms, dominated by Geometry (0.36ms), Collect renderables (0.27ms), and Shadow Generation (0.66ms). No clear tuning win was visible; kept the defaults, but the new span is the load-bearing artifact for future tuning. ([3c0ccbd](https://github.com/dakom/awsm-renderer/commit/3c0ccbd))
- **5.3** — `Bridge::bump_nodes_revision` debounces via `gloo_render::request_animation_frame`. A pending-frame slot on `Bridge` short-circuits subsequent bumps inside the same frame; the rAF callback `take()`s itself out and does the `Mutable::set`. Multi-mesh model inserts (which fired `bump_nodes_revision` per node during insert AND remove) now cascade once per frame instead of once per node, collapsing dozens of selection / gizmo / point-handle / inspector re-derivations into one. ([f6f8e2a](https://github.com/dakom/awsm-renderer/commit/f6f8e2a))

## Recently landed (doc surface)

The `more-optimizations.md` doc has been kept current throughout the sprint. Six items moved from the body into "Recently landed"; two items (Phase 2.1 + Phase 4.3) moved to "Won't do" with full deferral reasoning and pointers to where the follow-up sprint can resume cold.

## Verification

End-of-sprint checks (commit `f6f8e2a`):

- `cargo check --workspace` — clean
- `cargo clippy --workspace` — clean (one pre-existing `borrow_deref_ref` warning in `material_decal/composite.rs:84` predates this sprint)
- `cargo test --workspace` — green (all targets pass; example-only clippy errors in `crates/scene-schema/examples/generate_tuning_scenes.rs` are pre-existing under `--all-targets`)
- Editor smoke test: Primitive Box + Sphere + Torus render cleanly under both `?ifi=on` and `?ifi=off` (Chrome via the Claude Preview MCP); MSAA toggle in the Editor tab flips without errors. Screenshots captured during verification — both query-param variants produced identical clean renders.
- Safari cold-restart smoke test: **not run** (no Safari available in the autonomous-run environment). The plan flags Safari as a "should also smoke-test" rather than a gate; verification budget went to Chrome.

## Test plan

- [ ] `cargo check --workspace`, `cargo clippy --workspace`, `cargo test --workspace`
- [ ] Open editor on `?ifi=on`, insert Primitive Box + Sphere + Torus → all three render in the viewport
- [ ] Repeat on `?ifi=off`
- [ ] Editor → MSAA Anti-Aliasing toggle flips between MSAA-4 and single-sample without renderer errors
- [ ] Insert Model on a textured glb → editor's editable material override path shares the same GPU texture slot as renderer-gltf's baked materials (verify via `read_render_pass_timings` or pool-stat helper)
- [ ] Open a multi-mesh model → `nodes_revision` cascades land once per frame (not once per node)
- [ ] Cold-restart Safari smoke test if available

🤖 Generated with [Claude Code](https://claude.com/claude-code)