### PR TITLE
renderer: pool tail-subsystem pipeline compiles across the AwsmRendererBuilder::build tail

### DIFF
--- a/crates/renderer/src/lib.rs
+++ b/crates/renderer/src/lib.rs
@@ -67,7 +67,7 @@ use materials::Materials;
 use meshes::Meshes;
 use pipelines::Pipelines;
 use scene_spatial::SceneSpatial;
-use shaders::{ShaderCacheKey, Shaders};
+use shaders::Shaders;
 use textures::Textures;
 use transforms::Transforms;
 
@@ -947,7 +947,7 @@ impl AwsmRendererBuilder {
         // the `CompilingShaders` phase covers the whole block.
         emit_phase(RendererLoadingPhase::CompilingShaders);
 
-        let (render_passes, render_textures) =
+        let (mut render_passes, render_textures) =
             futures::future::try_join(RenderPasses::new(&mut render_pass_init, &features), async {
                 RenderTextures::new(&gpu, formats_for_textures, &features)
                     .await
@@ -955,55 +955,15 @@ impl AwsmRendererBuilder {
             })
             .await?;
 
-        // Main render-pass compile done. Picker / line-renderer /
-        // material-classify / occlusion / coverage / decal still
-        // need their pipelines built before the first frame;
-        // signal the transition so the UI message stops claiming
-        // shader compile is in progress.
+        // Main render-pass compile done. The tail subsystems —
+        // Picker / LineRenderer / Shadows + EVSM / Effects / Display
+        // — still need their pipelines built. Each was historically
+        // its own per-subsystem `new().await?` (5 sequential awaits
+        // ending with set_anti_aliasing + set_post_processing).
+        // We pool every shader + pipeline compile across all five
+        // into the cross-tail batch below: 2 awaits total (one shader,
+        // one each of compute + render pipelines).
         emit_phase(RendererLoadingPhase::BuildingPipelines);
-
-        // Pre-warm the shader cache with everything Picker + LineRenderer
-        // need before constructing either. Picker has two compute shader
-        // variants (multisampled true/false); LineRenderer has one
-        // (parameter-free). Issuing all three through `ensure_keys` lets
-        // the browser kick off all `compile_shader` calls together and
-        // await every `validate_shader` in parallel — see the doc on
-        // `Shaders::ensure_keys`. The per-pass constructors then proceed
-        // sequentially through `&mut pipelines / &mut shaders`, but the
-        // slow part (shader compile) is already done.
-        shaders
-            .ensure_keys(
-                &gpu,
-                [
-                    ShaderCacheKey::Picker(picker::ShaderCacheKeyPicker {
-                        multisampled_geometry: false,
-                    }),
-                    ShaderCacheKey::Picker(picker::ShaderCacheKeyPicker {
-                        multisampled_geometry: true,
-                    }),
-                    ShaderCacheKey::Line(render_passes::lines::ShaderCacheKeyLine),
-                ],
-            )
-            .await?;
-
-        let picker = Picker::new(
-            &gpu,
-            &mut bind_group_layouts,
-            &mut pipeline_layouts,
-            &mut shaders,
-            &mut pipelines,
-        )
-        .await?;
-
-        let lines = LineRenderer::load(
-            &gpu,
-            &mut bind_group_layouts,
-            &mut pipeline_layouts,
-            &mut pipelines,
-            &mut shaders,
-            &render_textures.formats,
-        )
-        .await?;
 
         let mesh_light_indices_gpu = MeshLightIndicesGpu::new(&gpu)?;
 
@@ -1060,25 +1020,180 @@ impl AwsmRendererBuilder {
             None
         };
 
-        // Shadows + the final anti-aliasing / post-processing
-        // pipeline configuration below are the renderer-init tail:
+        // Tail-pool start. Shadows + Effects + Display + the final
+        // anti-aliasing / post-processing pipeline configuration are
         // pipelines created here are needed for the first frame but
         // they don't dominate the cold-load cost the way the
         // RenderPasses block does. Signal the transition so frontends
         // can swap to a less alarming "Finalising scene…" message.
         emit_phase(RendererLoadingPhase::FinalizingScene);
 
-        let shadows = shadows::Shadows::new(
+        // ── 1. Build every tail subsystem's descriptors. Sync apart
+        //       from cache-hit shader `get_key`s + the EVSM
+        //       `compile_shader` calls (which return modules immediately
+        //       and surface their validate futures separately).
+        let picker_descs = Picker::build_descriptors(
             &gpu,
             &mut bind_group_layouts,
             &mut pipeline_layouts,
-            &mut pipelines,
+            &mut shaders,
+        )
+        .await?;
+        let line_descs = LineRenderer::build_descriptors(
+            &gpu,
+            &mut bind_group_layouts,
+            &mut pipeline_layouts,
+            &mut shaders,
+            &render_textures.formats,
+        )
+        .await?;
+        let mut shadows_descs = shadows::Shadows::build_descriptors(
+            &gpu,
+            &mut bind_group_layouts,
+            &mut pipeline_layouts,
             &mut shaders,
             &render_passes.geometry.bind_groups,
             &render_textures.formats,
             shadows_config.unwrap_or_default(),
         )
         .await?;
+
+        // ── 2. Pool every cross-tail shader cache key that wasn't
+        //       already warmed by `RenderPasses::new`. Effects + display
+        //       depend on AA + PP config, so their shader keys can't
+        //       be known earlier. Run that ensure_keys in parallel with
+        //       the EVSM inline-shader validation futures (option 2
+        //       from the plan: hand the futures to the orchestrator so
+        //       they join_all alongside the cross-tail shader batch).
+        let effects_shader_keys =
+            render_passes::effects::pipeline::EffectsPipelines::shader_cache_keys_for(
+                &anti_aliasing,
+                &post_processing,
+            )?;
+        let display_shader_keys =
+            render_passes::display::pipeline::DisplayPipelines::shader_cache_keys_for(
+                &post_processing,
+            );
+        let mut tail_shader_keys: Vec<shaders::ShaderCacheKey> = Vec::new();
+        tail_shader_keys.extend(effects_shader_keys);
+        tail_shader_keys.extend(display_shader_keys);
+
+        // EVSM validate futures borrow `&shadows_descs.evsm.modules`;
+        // shaders.ensure_keys borrows `&mut shaders`. Disjoint borrows,
+        // so they can join cleanly.
+        let evsm_validate_join =
+            futures::future::join_all(shadows_descs.evsm.validate_shader_futures());
+        let shader_ensure = shaders.ensure_keys(&gpu, tail_shader_keys);
+        let (shader_result, evsm_results) =
+            futures::future::join(shader_ensure, evsm_validate_join).await;
+        shader_result?;
+        for result in evsm_results {
+            result.map_err(crate::shadows::AwsmShadowError::Core)?;
+        }
+
+        // ── 2b. Register the 3 EVSM modules into the shader cache via
+        //        `insert_uncached`; the resulting `ShaderKey`s let us
+        //        build the 3 EVSM compute pipeline cache keys for the
+        //        cross-tail compute pool.
+        let evsm_shader_keys: [shaders::ShaderKey; 3] = [
+            shaders.insert_uncached(shadows_descs.evsm.modules[0].clone()),
+            shaders.insert_uncached(shadows_descs.evsm.modules[1].clone()),
+            shaders.insert_uncached(shadows_descs.evsm.modules[2].clone()),
+        ];
+        let evsm_pipeline_cache_keys = shadows_descs.evsm.pipeline_cache_keys(evsm_shader_keys);
+
+        // ── 3. Now that every cross-tail shader is warm, resolve
+        //       Effects + Display descriptors (sync — each
+        //       `shaders.get_key` is a cache hit).
+        let effects_descs = render_passes
+            .effects
+            .pipelines
+            .build_descriptors(&anti_aliasing, &post_processing, &gpu, &mut shaders)
+            .await?;
+        let display_descs = render_passes
+            .display
+            .pipelines
+            .build_descriptors(&post_processing, &gpu, &mut shaders)
+            .await?;
+
+        // Move the descriptor's caster pipeline cache keys out so the
+        // ShadowsDescriptors struct still owns the rest. We need
+        // shadows_descs intact for Shadows::from_resolved below.
+        let caster_pipeline_cache_keys =
+            std::mem::take(&mut shadows_descs.caster_pipeline_cache_keys);
+
+        // ── 4. Build the compute + render cross-tail cache key pools
+        //       and record each subsystem's slice range.
+        let mut compute_pool: Vec<pipelines::compute_pipeline::ComputePipelineCacheKey> =
+            Vec::new();
+        let picker_compute_range = {
+            let s = compute_pool.len();
+            compute_pool.extend(picker_descs.pipeline_cache_keys.iter().cloned());
+            s..compute_pool.len()
+        };
+        let evsm_compute_range = {
+            let s = compute_pool.len();
+            compute_pool.extend(evsm_pipeline_cache_keys.iter().cloned());
+            s..compute_pool.len()
+        };
+        let effects_compute_range = {
+            let s = compute_pool.len();
+            compute_pool.extend(effects_descs.pipeline_cache_keys.iter().cloned());
+            s..compute_pool.len()
+        };
+
+        let mut render_pool: Vec<pipelines::render_pipeline::RenderPipelineCacheKey> = Vec::new();
+        let line_render_range = {
+            let s = render_pool.len();
+            render_pool.extend(line_descs.pipeline_cache_keys().iter().cloned());
+            s..render_pool.len()
+        };
+        let caster_render_range = {
+            let s = render_pool.len();
+            render_pool.extend(caster_pipeline_cache_keys.iter().cloned());
+            s..render_pool.len()
+        };
+        let display_render_range = {
+            let s = render_pool.len();
+            render_pool.extend(display_descs.pipeline_cache_keys.iter().cloned());
+            s..render_pool.len()
+        };
+
+        // ── 5. Two batched ensure_keys — the entire tail in 2 awaits.
+        let compute_keys = pipelines
+            .compute
+            .ensure_keys(&gpu, &shaders, &pipeline_layouts, compute_pool)
+            .await?;
+        let render_keys = pipelines
+            .render
+            .ensure_keys(&gpu, &shaders, &pipeline_layouts, render_pool)
+            .await?;
+
+        // ── 6. Sync fold-up — each subsystem's from_resolved /
+        //       install_resolved consumes its slice of the resolved
+        //       keys.
+        let picker = Picker::from_resolved(
+            &gpu,
+            picker_descs,
+            compute_keys[picker_compute_range].to_vec(),
+        )?;
+        let lines =
+            LineRenderer::from_resolved(line_descs, render_keys[line_render_range].to_vec());
+        let shadows = shadows::Shadows::from_resolved(
+            &gpu,
+            &bind_group_layouts,
+            shadows_descs,
+            render_keys[caster_render_range].to_vec(),
+            compute_keys[evsm_compute_range].to_vec(),
+        )?;
+        render_passes
+            .effects
+            .pipelines
+            .install_resolved(compute_keys[effects_compute_range].to_vec());
+        render_passes
+            .display
+            .pipelines
+            .install_resolved(render_keys[display_render_range].to_vec());
 
         #[cfg(feature = "animation")]
         let animations = animation::Animations::default();
@@ -1146,11 +1261,23 @@ impl AwsmRendererBuilder {
             animations,
         };
 
-        // need to call these to create pipelines
-        _self.set_anti_aliasing(_self.anti_aliasing.clone()).await?;
+        // Initial AA + PP state — the effects + display pipelines we
+        // installed in the cross-tail pool above already match the
+        // configured `anti_aliasing` + `post_processing`, so the
+        // pipeline-rebuild path inside set_anti_aliasing /
+        // set_post_processing would just no-op through cache hits.
+        // We still need the state-side bookkeeping (bind-group recreate
+        // marks). `BindGroups::new` already marks every variant for
+        // create on first frame, so the AA / PP marks are redundant —
+        // but adding them explicitly mirrors the dynamic-setter
+        // contract and keeps the surface honest if `BindGroups::new`
+        // ever stops marking everything.
         _self
-            .set_post_processing(_self.post_processing.clone())
-            .await?;
+            .bind_groups
+            .mark_create(crate::bind_groups::BindGroupCreate::AntiAliasingChange);
+        _self
+            .bind_groups
+            .mark_create(crate::bind_groups::BindGroupCreate::TextureViewRecreate);
 
         emit_phase(RendererLoadingPhase::Ready);
 

--- a/crates/renderer/src/lib.rs
+++ b/crates/renderer/src/lib.rs
@@ -961,8 +961,15 @@ impl AwsmRendererBuilder {
         // its own per-subsystem `new().await?` (5 sequential awaits
         // ending with set_anti_aliasing + set_post_processing).
         // We pool every shader + pipeline compile across all five
-        // into the cross-tail batch below: 2 awaits total (one shader,
-        // one each of compute + render pipelines).
+        // into the cross-tail batch below. Three `.await` points
+        // remain in the tail itself:
+        //
+        // 1. one shader `ensure_keys` joined with the 3 EVSM
+        //    inline-shader validate futures (via `futures::join`),
+        // 2. one batched compute + render `ensure_keys` driven via
+        //    `try_join` (so compute + render pipelines compile in
+        //    parallel against Dawn's worker pool instead of one
+        //    class at a time).
         emit_phase(RendererLoadingPhase::BuildingPipelines);
 
         let mesh_light_indices_gpu = MeshLightIndicesGpu::new(&gpu)?;
@@ -1159,15 +1166,32 @@ impl AwsmRendererBuilder {
             s..render_pool.len()
         };
 
-        // ── 5. Two batched ensure_keys — the entire tail in 2 awaits.
-        let compute_keys = pipelines
-            .compute
-            .ensure_keys(&gpu, &shaders, &pipeline_layouts, compute_pool)
-            .await?;
-        let render_keys = pipelines
-            .render
-            .ensure_keys(&gpu, &shaders, &pipeline_layouts, render_pool)
-            .await?;
+        // ── 5. One batched compute + render ensure_keys joined via
+        //       `try_join`. The two halves operate on disjoint `&mut`
+        //       fields of `pipelines` (a split-borrow), so they can
+        //       issue their `create_*_pipeline_async` calls
+        //       back-to-back before either await. Dawn then overlaps
+        //       compute + render pipeline compilation against its
+        //       worker pool instead of serialising one class behind
+        //       the other.
+        let pipelines::Pipelines {
+            render: render_pipelines,
+            compute: compute_pipelines,
+        } = &mut pipelines;
+        let compute_fut = async {
+            compute_pipelines
+                .ensure_keys(&gpu, &shaders, &pipeline_layouts, compute_pool)
+                .await
+                .map_err(crate::error::AwsmError::from)
+        };
+        let render_fut = async {
+            render_pipelines
+                .ensure_keys(&gpu, &shaders, &pipeline_layouts, render_pool)
+                .await
+                .map_err(crate::error::AwsmError::from)
+        };
+        let (compute_keys, render_keys) =
+            futures::future::try_join(compute_fut, render_fut).await?;
 
         // ── 6. Sync fold-up — each subsystem's from_resolved /
         //       install_resolved consumes its slice of the resolved

--- a/crates/renderer/src/render_passes/display/pipeline.rs
+++ b/crates/renderer/src/render_passes/display/pipeline.rs
@@ -18,13 +18,21 @@ use crate::{
         RenderPassInitContext,
     },
     render_textures::RenderTextureFormats,
-    shaders::Shaders,
+    shaders::{ShaderCacheKey, Shaders},
 };
 
 /// Pipeline layout and render pipeline for the display pass.
 pub struct DisplayPipelines {
     pub pipeline_layout_key: PipelineLayoutKey,
     pub render_pipeline_key: Option<RenderPipelineKey>,
+}
+
+/// Pre-resolved shader + render-pipeline cache key for the display
+/// pass. Returned by [`DisplayPipelines::build_descriptors`] and
+/// consumed by [`DisplayPipelines::install_resolved`].
+pub struct DisplayPipelinesDescriptors {
+    pub shader_cache_keys: Vec<ShaderCacheKey>,
+    pub pipeline_cache_keys: Vec<RenderPipelineCacheKey>,
 }
 
 impl DisplayPipelines {
@@ -48,21 +56,26 @@ impl DisplayPipelines {
         })
     }
 
-    /// Updates the render pipeline for the current post-processing settings.
-    pub async fn set_render_pipeline_key(
-        &mut self,
+    /// Returns the shader cache key for the current PP config. Folded
+    /// into the cross-tail `Shaders::ensure_keys` batch.
+    pub fn shader_cache_keys_for(post_processing: &PostProcessing) -> Vec<ShaderCacheKey> {
+        vec![ShaderCacheKey::from(ShaderCacheKeyDisplay {
+            tonemapping: post_processing.tonemapping,
+        })]
+    }
+
+    /// Builds the (shader-cache-key, render-pipeline-cache-key) pair.
+    /// The shader must already be warm in the cache.
+    pub async fn build_descriptors(
+        &self,
         post_processing: &PostProcessing,
         gpu: &AwsmRendererWebGpu,
         shaders: &mut Shaders,
-        pipelines: &mut Pipelines,
-        pipeline_layouts: &PipelineLayouts,
-        _render_texture_formats: &RenderTextureFormats,
-    ) -> Result<()> {
+    ) -> Result<DisplayPipelinesDescriptors> {
         let shader_cache_key = ShaderCacheKeyDisplay {
             tonemapping: post_processing.tonemapping,
         };
-        let shader_key = shaders.get_key(gpu, shader_cache_key).await?;
-
+        let shader_key = shaders.get_key(gpu, shader_cache_key.clone()).await?;
         let render_pipeline_cache_key =
             RenderPipelineCacheKey::new(shader_key, self.pipeline_layout_key)
                 .with_push_fragment_target(ColorTargetState::new(gpu.current_context_format()))
@@ -72,14 +85,44 @@ impl DisplayPipelines {
                         .with_cull_mode(web_sys::GpuCullMode::None)
                         .with_front_face(web_sys::GpuFrontFace::Ccw),
                 );
+        Ok(DisplayPipelinesDescriptors {
+            shader_cache_keys: vec![ShaderCacheKey::from(shader_cache_key)],
+            pipeline_cache_keys: vec![render_pipeline_cache_key],
+        })
+    }
 
-        self.render_pipeline_key = Some(
-            pipelines
-                .render
-                .get_key(gpu, shaders, pipeline_layouts, render_pipeline_cache_key)
-                .await?,
-        );
+    /// Writes the resolved render pipeline key.
+    pub fn install_resolved(&mut self, resolved: Vec<RenderPipelineKey>) {
+        debug_assert_eq!(resolved.len(), 1);
+        self.render_pipeline_key = Some(resolved[0]);
+    }
 
+    /// Updates the render pipeline for the current post-processing
+    /// settings. Used by [`crate::AwsmRenderer::set_post_processing`]
+    /// for mid-session config changes — at startup the orchestrator
+    /// goes through [`Self::build_descriptors`] +
+    /// [`Self::install_resolved`] directly.
+    pub async fn set_render_pipeline_key(
+        &mut self,
+        post_processing: &PostProcessing,
+        gpu: &AwsmRendererWebGpu,
+        shaders: &mut Shaders,
+        pipelines: &mut Pipelines,
+        pipeline_layouts: &PipelineLayouts,
+        _render_texture_formats: &RenderTextureFormats,
+    ) -> Result<()> {
+        let shader_cache_keys = Self::shader_cache_keys_for(post_processing);
+        shaders
+            .ensure_keys(gpu, shader_cache_keys.iter().cloned())
+            .await?;
+        let descs = self
+            .build_descriptors(post_processing, gpu, shaders)
+            .await?;
+        let resolved = pipelines
+            .render
+            .ensure_keys(gpu, shaders, pipeline_layouts, descs.pipeline_cache_keys)
+            .await?;
+        self.install_resolved(resolved);
         Ok(())
     }
 }

--- a/crates/renderer/src/render_passes/effects/pipeline.rs
+++ b/crates/renderer/src/render_passes/effects/pipeline.rs
@@ -19,7 +19,7 @@ use crate::{
         RenderPassInitContext,
     },
     render_textures::RenderTextureFormats,
-    shaders::Shaders,
+    shaders::{ShaderCacheKey, Shaders},
 };
 
 /// Number of bloom blur passes (more = smoother but slower).
@@ -39,6 +39,20 @@ pub struct EffectsPipelines {
     bloom_blur_pipeline_a: Option<ComputePipelineKey>,  // ping_pong=false
     bloom_blur_pipeline_b: Option<ComputePipelineKey>,  // ping_pong=true
     bloom_blend_pipeline: Option<ComputePipelineKey>, // Always ping_pong=false (to write to effects_tex)
+}
+
+/// Pre-resolved shader + compute-pipeline cache keys for the effects
+/// pass. Returned by [`EffectsPipelines::build_descriptors`] and
+/// consumed by [`EffectsPipelines::install_resolved`] after the
+/// orchestrator pools the 5 entries into the cross-system tail batch.
+pub struct EffectsPipelinesDescriptors {
+    /// 5 shader cache keys to fold into the cross-tail
+    /// `Shaders::ensure_keys` batch.
+    pub shader_cache_keys: Vec<ShaderCacheKey>,
+    /// 5 compute pipeline cache keys — resolved against the pre-warmed
+    /// shader cache. To fold into the cross-tail
+    /// `ComputePipelines::ensure_keys` batch.
+    pub pipeline_cache_keys: Vec<ComputePipelineCacheKey>,
 }
 
 impl EffectsPipelines {
@@ -95,10 +109,93 @@ impl EffectsPipelines {
         }
     }
 
+    /// Picks the pipeline layout matching the current MSAA mode.
+    fn layout_key_for(&self, multisampled_geometry: bool) -> PipelineLayoutKey {
+        if multisampled_geometry {
+            self.multisampled_pipeline_layout_key
+        } else {
+            self.singlesampled_pipeline_layout_key
+        }
+    }
+
+    /// Returns the 5 shader cache keys for the current AA + PP config.
+    /// These are appended to the cross-tail `Shaders::ensure_keys`
+    /// batch by the orchestrator, then resolved sync via cache hits
+    /// inside [`Self::build_descriptors`].
+    pub fn shader_cache_keys_for(
+        anti_aliasing: &AntiAliasing,
+        post_processing: &PostProcessing,
+    ) -> Result<Vec<ShaderCacheKey>> {
+        let multisampled_geometry = anti_aliasing.has_msaa_checked()?;
+        let blend_ping_pong = (1 + BLOOM_BLUR_PASSES) % 2 == 1;
+        let slot_inputs: [(BloomPhase, bool); 5] = [
+            (BloomPhase::None, false),
+            (BloomPhase::Extract, false),
+            (BloomPhase::Blur, false),
+            (BloomPhase::Blur, true),
+            (BloomPhase::Blend, blend_ping_pong),
+        ];
+        Ok(slot_inputs
+            .iter()
+            .map(|&(bloom_phase, ping_pong)| {
+                ShaderCacheKey::from(ShaderCacheKeyEffects {
+                    smaa_anti_alias: anti_aliasing.smaa,
+                    bloom_phase,
+                    dof: post_processing.dof,
+                    ping_pong,
+                    multisampled_geometry,
+                })
+            })
+            .collect())
+    }
+
+    /// Builds the 5 (shader, compute-pipeline) cache key pairs for the
+    /// current AA + post-processing config. The 5 shader cache keys
+    /// must already be in the `shaders` cache (cross-tail
+    /// `Shaders::ensure_keys` runs ahead of this call); each
+    /// `shaders.get_key` is a cache-hit lookup.
+    pub async fn build_descriptors(
+        &self,
+        anti_aliasing: &AntiAliasing,
+        post_processing: &PostProcessing,
+        gpu: &AwsmRendererWebGpu,
+        shaders: &mut Shaders,
+    ) -> Result<EffectsPipelinesDescriptors> {
+        let shader_cache_keys = Self::shader_cache_keys_for(anti_aliasing, post_processing)?;
+        let multisampled_geometry = anti_aliasing.has_msaa_checked()?;
+        let layout_key = self.layout_key_for(multisampled_geometry);
+
+        let mut pipeline_cache_keys: Vec<ComputePipelineCacheKey> =
+            Vec::with_capacity(shader_cache_keys.len());
+        for cache_key in &shader_cache_keys {
+            let shader_key = shaders.get_key(gpu, cache_key.clone()).await?;
+            pipeline_cache_keys.push(ComputePipelineCacheKey::new(shader_key, layout_key));
+        }
+
+        Ok(EffectsPipelinesDescriptors {
+            shader_cache_keys,
+            pipeline_cache_keys,
+        })
+    }
+
+    /// Writes the resolved 5 keys into the per-phase slots. Pure sync.
+    pub fn install_resolved(&mut self, resolved: Vec<ComputePipelineKey>) {
+        debug_assert_eq!(resolved.len(), 5);
+        self.no_bloom_pipeline = Some(resolved[0]);
+        self.bloom_extract_pipeline = Some(resolved[1]);
+        self.bloom_blur_pipeline_a = Some(resolved[2]);
+        self.bloom_blur_pipeline_b = Some(resolved[3]);
+        self.bloom_blend_pipeline = Some(resolved[4]);
+    }
+
     /// Updates pipelines for the current anti-aliasing and
-    /// post-processing settings. Builds all five bloom-phase variants
-    /// concurrently via two batched `ensure_keys` calls (shaders then
-    /// compute pipelines).
+    /// post-processing settings. Used by the dynamic setters
+    /// ([`crate::AwsmRenderer::set_anti_aliasing`] /
+    /// [`crate::AwsmRenderer::set_post_processing`]) — at startup the
+    /// orchestrator goes through [`Self::build_descriptors`] +
+    /// [`Self::install_resolved`] directly via the cross-tail pool.
+    /// Builds all five bloom-phase variants concurrently via two
+    /// batched `ensure_keys` calls (shaders then compute pipelines).
     #[allow(clippy::too_many_arguments)]
     pub async fn set_render_pipeline_keys(
         &mut self,
@@ -110,66 +207,20 @@ impl EffectsPipelines {
         pipeline_layouts: &PipelineLayouts,
         _render_texture_formats: &RenderTextureFormats,
     ) -> Result<()> {
-        let multisampled_geometry = anti_aliasing.has_msaa_checked()?;
-        let layout_key = if multisampled_geometry {
-            self.multisampled_pipeline_layout_key
-        } else {
-            self.singlesampled_pipeline_layout_key
-        };
-
-        // Blend pass ping_pong is determined by total pass count to
-        // ensure final output goes to effects_tex.
-        let blend_ping_pong = (1 + BLOOM_BLUR_PASSES) % 2 == 1;
-
-        // Build all 5 shader cache keys.
-        let slot_inputs: [(BloomPhase, bool); 5] = [
-            (BloomPhase::None, false),
-            (BloomPhase::Extract, false),
-            (BloomPhase::Blur, false),
-            (BloomPhase::Blur, true),
-            (BloomPhase::Blend, blend_ping_pong),
-        ];
-        let shader_cache_keys: Vec<ShaderCacheKeyEffects> = slot_inputs
-            .iter()
-            .map(|&(bloom_phase, ping_pong)| ShaderCacheKeyEffects {
-                smaa_anti_alias: anti_aliasing.smaa,
-                bloom_phase,
-                dof: post_processing.dof,
-                ping_pong,
-                multisampled_geometry,
-            })
-            .collect();
-
+        let shader_cache_keys = Self::shader_cache_keys_for(anti_aliasing, post_processing)?;
         // Batch 1: 5 shader compiles in parallel.
         shaders
-            .ensure_keys(
-                gpu,
-                shader_cache_keys
-                    .iter()
-                    .cloned()
-                    .map(crate::shaders::ShaderCacheKey::from),
-            )
+            .ensure_keys(gpu, shader_cache_keys.iter().cloned())
             .await?;
-
-        // Resolve shader keys (cache hits) + build compute pipeline
-        // cache keys.
-        let mut pipeline_cache_keys: Vec<ComputePipelineCacheKey> = Vec::with_capacity(5);
-        for cache_key in &shader_cache_keys {
-            let shader_key = shaders.get_key(gpu, cache_key.clone()).await?;
-            pipeline_cache_keys.push(ComputePipelineCacheKey::new(shader_key, layout_key));
-        }
-
-        // Batch 2: 5 compute pipelines in parallel.
-        let keys = pipelines
+        // Resolve descriptors (sync cache hits) + batch the pipelines.
+        let descs = self
+            .build_descriptors(anti_aliasing, post_processing, gpu, shaders)
+            .await?;
+        let resolved = pipelines
             .compute
-            .ensure_keys(gpu, shaders, pipeline_layouts, pipeline_cache_keys)
+            .ensure_keys(gpu, shaders, pipeline_layouts, descs.pipeline_cache_keys)
             .await?;
-
-        self.no_bloom_pipeline = Some(keys[0]);
-        self.bloom_extract_pipeline = Some(keys[1]);
-        self.bloom_blur_pipeline_a = Some(keys[2]);
-        self.bloom_blur_pipeline_b = Some(keys[3]);
-        self.bloom_blend_pipeline = Some(keys[4]);
+        self.install_resolved(resolved);
         Ok(())
     }
 }

--- a/crates/renderer/src/render_passes/lines/mod.rs
+++ b/crates/renderer/src/render_passes/lines/mod.rs
@@ -21,6 +21,6 @@ mod renderer;
 pub mod shader;
 mod types;
 
-pub use renderer::LineRenderer;
+pub use renderer::{LineRenderer, LineRendererDescriptors};
 pub use shader::cache_key::ShaderCacheKeyLine;
 pub use types::{LineKey, LineTopology};

--- a/crates/renderer/src/render_passes/lines/pipelines.rs
+++ b/crates/renderer/src/render_passes/lines/pipelines.rs
@@ -17,11 +17,8 @@ use crate::{
         BindGroupLayoutCacheKey, BindGroupLayoutCacheKeyEntry, BindGroupLayoutKey, BindGroupLayouts,
     },
     error::Result,
-    pipeline_layouts::{PipelineLayoutCacheKey, PipelineLayouts},
-    pipelines::{
-        render_pipeline::{RenderPipelineCacheKey, RenderPipelineKey},
-        Pipelines,
-    },
+    pipeline_layouts::{PipelineLayoutCacheKey, PipelineLayoutKey, PipelineLayouts},
+    pipelines::render_pipeline::{RenderPipelineCacheKey, RenderPipelineKey},
     render_passes::lines::shader::cache_key::ShaderCacheKeyLine,
     render_textures::RenderTextureFormats,
     shaders::Shaders,
@@ -34,6 +31,27 @@ pub(super) struct LineVariantKey {
     pub msaa: bool,
 }
 
+/// All 4 line-pipeline variants (`(depth_test_always, msaa)` cross
+/// product), in `variant_index` order.
+pub(super) const VARIANT_KEYS: [LineVariantKey; 4] = [
+    LineVariantKey {
+        depth_test_always: false,
+        msaa: false,
+    },
+    LineVariantKey {
+        depth_test_always: false,
+        msaa: true,
+    },
+    LineVariantKey {
+        depth_test_always: true,
+        msaa: false,
+    },
+    LineVariantKey {
+        depth_test_always: true,
+        msaa: true,
+    },
+];
+
 /// The four registered render pipelines for the line renderer, indexed
 /// by [`LineVariantKey`].
 pub(super) struct LinePipelines {
@@ -41,15 +59,28 @@ pub(super) struct LinePipelines {
     pub variants: [RenderPipelineKey; 4],
 }
 
+/// Pre-resolved layouts + descriptors for the line renderer's 4
+/// pipeline variants. Returned by
+/// [`LinePipelines::build_descriptors`] and consumed by
+/// [`LinePipelines::from_resolved`] after the orchestrator pools the
+/// `pipeline_cache_keys` into the cross-system render-pipeline batch.
+pub(super) struct LinePipelinesDescriptors {
+    pub bind_group_layout_key: BindGroupLayoutKey,
+    pub pipeline_cache_keys: Vec<RenderPipelineCacheKey>,
+}
+
 impl LinePipelines {
-    pub(super) async fn load(
+    /// Sync-apart-from-shader-resolve descriptor build. Registers the
+    /// bind-group + pipeline layouts, fetches the (cache-hit pre-warmed
+    /// by `RenderPasses::new`) line shader key, and produces the 4
+    /// variant `RenderPipelineCacheKey`s the orchestrator pools.
+    pub(super) async fn build_descriptors(
         gpu: &AwsmRendererWebGpu,
         bind_group_layouts: &mut BindGroupLayouts,
         pipeline_layouts: &mut PipelineLayouts,
-        pipelines: &mut Pipelines,
         shaders: &mut Shaders,
         formats: &RenderTextureFormats,
-    ) -> Result<Self> {
+    ) -> Result<LinePipelinesDescriptors> {
         let bind_group_layout_cache_key = BindGroupLayoutCacheKey {
             entries: vec![
                 BindGroupLayoutCacheKeyEntry {
@@ -85,13 +116,9 @@ impl LinePipelines {
 
         let bind_group_layout_key = bind_group_layouts.get_key(gpu, bind_group_layout_cache_key)?;
 
-        // Route through the shared `Shaders` cache. The shader has no
-        // per-variant parameters but going through the cache means
-        // `Shaders::ensure_keys` can pre-warm it alongside e.g. the
-        // picker's compute shaders, letting the browser do the
-        // parallel compile. The prior `insert_uncached` shape bypassed
-        // the cache entirely so the line compile always serialised
-        // behind whatever other shader work was in flight.
+        // Route through the shared `Shaders` cache. The line shader is
+        // pre-warmed by `RenderPasses::new`'s cross-pass shader
+        // ensure_keys, so this is a sync cache hit.
         let shader_key = shaders.get_key(gpu, ShaderCacheKeyLine).await?;
 
         let pipeline_layout_key = pipeline_layouts.get_key(
@@ -100,44 +127,31 @@ impl LinePipelines {
             PipelineLayoutCacheKey::new(vec![bind_group_layout_key]),
         )?;
 
-        // Build all 4 variant cache keys, then a single batched
-        // ensure_keys. Dawn parallelises the 4 compiles instead of
-        // serialising them.
-        let variant_keys = [
-            LineVariantKey {
-                depth_test_always: false,
-                msaa: false,
-            },
-            LineVariantKey {
-                depth_test_always: false,
-                msaa: true,
-            },
-            LineVariantKey {
-                depth_test_always: true,
-                msaa: false,
-            },
-            LineVariantKey {
-                depth_test_always: true,
-                msaa: true,
-            },
-        ];
-        let pipeline_cache_keys: Vec<RenderPipelineCacheKey> = variant_keys
+        let pipeline_cache_keys: Vec<RenderPipelineCacheKey> = VARIANT_KEYS
             .iter()
             .map(|v| build_pipeline_cache_key(shader_key, pipeline_layout_key, formats, *v))
             .collect();
-        let resolved = pipelines
-            .render
-            .ensure_keys(gpu, shaders, pipeline_layouts, pipeline_cache_keys)
-            .await?;
+
+        Ok(LinePipelinesDescriptors {
+            bind_group_layout_key,
+            pipeline_cache_keys,
+        })
+    }
+
+    /// Folds resolved pipeline keys back into the typed `LinePipelines`.
+    pub(super) fn from_resolved(
+        descs: LinePipelinesDescriptors,
+        resolved: Vec<RenderPipelineKey>,
+    ) -> Self {
+        debug_assert_eq!(resolved.len(), 4);
         let mut variants = [RenderPipelineKey::default(); 4];
-        for (v, key) in variant_keys.iter().zip(resolved) {
+        for (v, key) in VARIANT_KEYS.iter().zip(resolved) {
             variants[variant_index(*v)] = key;
         }
-
-        Ok(Self {
-            bind_group_layout_key,
+        Self {
+            bind_group_layout_key: descs.bind_group_layout_key,
             variants,
-        })
+        }
     }
 
     pub(super) fn get(&self, variant: LineVariantKey) -> RenderPipelineKey {
@@ -151,7 +165,7 @@ pub(super) fn variant_index(variant: LineVariantKey) -> usize {
 
 fn build_pipeline_cache_key(
     shader_key: crate::shaders::ShaderKey,
-    pipeline_layout_key: crate::pipeline_layouts::PipelineLayoutKey,
+    pipeline_layout_key: PipelineLayoutKey,
     formats: &RenderTextureFormats,
     variant: LineVariantKey,
 ) -> RenderPipelineCacheKey {

--- a/crates/renderer/src/render_passes/lines/renderer.rs
+++ b/crates/renderer/src/render_passes/lines/renderer.rs
@@ -2,12 +2,16 @@ use awsm_renderer_core::renderer::AwsmRendererWebGpu;
 use slotmap::SlotMap;
 
 use crate::{
-    bind_group_layout::BindGroupLayouts, error::Result, pipeline_layouts::PipelineLayouts,
-    pipelines::Pipelines, render::RenderContext, render_textures::RenderTextureFormats,
+    bind_group_layout::BindGroupLayouts,
+    error::Result,
+    pipeline_layouts::PipelineLayouts,
+    pipelines::{render_pipeline::RenderPipelineKey, Pipelines},
+    render::RenderContext,
+    render_textures::RenderTextureFormats,
     shaders::Shaders,
 };
 
-use super::pipelines::{LinePipelines, LineVariantKey};
+use super::pipelines::{LinePipelines, LinePipelinesDescriptors, LineVariantKey};
 use super::types::{GpuLineSegment, LineEntry, LineKey, LINE_UNIFORM_BYTES};
 
 /// Renderer-side state owning the four line pipelines and every registered line strip.
@@ -24,8 +28,30 @@ pub struct LineRenderer {
     pub(super) pack_buf: Vec<GpuLineSegment>,
 }
 
+/// Pre-resolved layouts + 4 pipeline cache keys for the line renderer.
+/// Returned by [`LineRenderer::build_descriptors`] and consumed by
+/// [`LineRenderer::from_resolved`] after the cross-system tail pool
+/// resolves the keys via one batched `RenderPipelines::ensure_keys`.
+pub struct LineRendererDescriptors {
+    pub(super) inner: LinePipelinesDescriptors,
+}
+
+impl LineRendererDescriptors {
+    /// Slice of cache keys to fold into the cross-system render-pipeline
+    /// pool. 4 entries, in `LinePipelines::VARIANT_KEYS` order.
+    pub fn pipeline_cache_keys(
+        &self,
+    ) -> &[crate::pipelines::render_pipeline::RenderPipelineCacheKey] {
+        &self.inner.pipeline_cache_keys
+    }
+}
+
 impl LineRenderer {
-    /// Loads the four pipeline variants and creates an empty line registry.
+    /// Loads the four pipeline variants and creates an empty line
+    /// registry. Thin wrapper over [`Self::build_descriptors`] +
+    /// [`Self::from_resolved`]. The pooled startup path bypasses this
+    /// and calls the two halves directly so LineRenderer's 4 pipeline
+    /// compiles share the cross-system tail `RenderPipelines::ensure_keys`.
     pub async fn load(
         gpu: &AwsmRendererWebGpu,
         bind_group_layouts: &mut BindGroupLayouts,
@@ -34,20 +60,48 @@ impl LineRenderer {
         shaders: &mut Shaders,
         formats: &RenderTextureFormats,
     ) -> Result<Self> {
-        let pipelines = LinePipelines::load(
+        let descs =
+            Self::build_descriptors(gpu, bind_group_layouts, pipeline_layouts, shaders, formats)
+                .await?;
+        let resolved = pipelines
+            .render
+            .ensure_keys(
+                gpu,
+                shaders,
+                pipeline_layouts,
+                descs.inner.pipeline_cache_keys.clone(),
+            )
+            .await?;
+        Ok(Self::from_resolved(descs, resolved))
+    }
+
+    /// Builds layouts + 4 pipeline cache keys. Cache-hit on the line
+    /// shader (pre-warmed by `RenderPasses::new`); otherwise sync.
+    pub async fn build_descriptors(
+        gpu: &AwsmRendererWebGpu,
+        bind_group_layouts: &mut BindGroupLayouts,
+        pipeline_layouts: &mut PipelineLayouts,
+        shaders: &mut Shaders,
+        formats: &RenderTextureFormats,
+    ) -> Result<LineRendererDescriptors> {
+        let inner = LinePipelines::build_descriptors(
             gpu,
             bind_group_layouts,
             pipeline_layouts,
-            pipelines,
             shaders,
             formats,
         )
         .await?;
-        Ok(Self {
-            pipelines,
+        Ok(LineRendererDescriptors { inner })
+    }
+
+    /// Folds resolved pipeline keys back into the typed `LineRenderer`.
+    pub fn from_resolved(descs: LineRendererDescriptors, resolved: Vec<RenderPipelineKey>) -> Self {
+        Self {
+            pipelines: LinePipelines::from_resolved(descs.inner, resolved),
             entries: SlotMap::with_key(),
             pack_buf: Vec::new(),
-        })
+        }
     }
 
     /// Returns the number of registered lines.

--- a/crates/renderer/src/shadows/evsm.rs
+++ b/crates/renderer/src/shadows/evsm.rs
@@ -33,7 +33,7 @@ use awsm_renderer_core::{
     },
     buffers::{BufferDescriptor, BufferUsage},
     renderer::AwsmRendererWebGpu,
-    shaders::ShaderModuleDescriptor,
+    shaders::{ShaderModuleDescriptor, ShaderModuleExt},
     texture::{TextureFormat, TextureSampleType, TextureViewDimension},
 };
 
@@ -46,7 +46,7 @@ use crate::{
         compute_pipeline::{ComputePipelineCacheKey, ComputePipelineKey},
         Pipelines,
     },
-    shaders::Shaders,
+    shaders::{ShaderKey, Shaders},
     shadows::AwsmShadowError,
 };
 
@@ -98,9 +98,62 @@ pub struct EvsmPass {
     pub active_cascade_count: u32,
 }
 
+/// Pre-resolved layouts + module handles for the EVSM compute pass.
+/// Returned by [`EvsmPass::build_descriptors`] and consumed by
+/// [`EvsmPass::from_resolved`]. The 3 inline WGSL shaders are issued
+/// synchronously via `compile_shader`; their validate futures are
+/// surfaced separately so the orchestrator can `try_join_all` them in
+/// parallel with the cross-tail `Shaders::ensure_keys` batch.
+pub struct EvsmDescriptors {
+    pub moment_write_layout_key: BindGroupLayoutKey,
+    pub blur_layout_key: BindGroupLayoutKey,
+    pub moment_write_pipeline_layout_key: PipelineLayoutKey,
+    pub blur_pipeline_layout_key: PipelineLayoutKey,
+    /// 3 module handles in moment_write → blur_h → blur_v order. The
+    /// orchestrator registers them into the shader cache via
+    /// `Shaders::insert_uncached` after the validate join completes,
+    /// and feeds the resulting `ShaderKey`s into
+    /// [`EvsmPass::pipeline_cache_keys`] to build the 3 compute
+    /// pipeline cache keys it pools into the cross-tail batch.
+    pub modules: [web_sys::GpuShaderModule; 3],
+    pub params_buffer: web_sys::GpuBuffer,
+    pub params_bytes: Vec<u8>,
+}
+
+impl EvsmDescriptors {
+    /// Returns the 3 unawaited `validate_shader` futures for the inline
+    /// EVSM shaders. The orchestrator joins them in parallel with the
+    /// cross-tail `Shaders::ensure_keys` batch.
+    pub fn validate_shader_futures(
+        &self,
+    ) -> [impl std::future::Future<Output = Result<(), awsm_renderer_core::error::AwsmCoreError>> + '_;
+           3] {
+        [
+            self.modules[0].validate_shader(),
+            self.modules[1].validate_shader(),
+            self.modules[2].validate_shader(),
+        ]
+    }
+
+    /// Once the orchestrator has registered the 3 modules into the
+    /// shader cache via `Shaders::insert_uncached`, derive the 3
+    /// compute pipeline cache keys to fold into the cross-tail batch.
+    /// `shader_keys` is in the same order as `modules`.
+    pub fn pipeline_cache_keys(&self, shader_keys: [ShaderKey; 3]) -> Vec<ComputePipelineCacheKey> {
+        vec![
+            ComputePipelineCacheKey::new(shader_keys[0], self.moment_write_pipeline_layout_key),
+            ComputePipelineCacheKey::new(shader_keys[1], self.blur_pipeline_layout_key),
+            ComputePipelineCacheKey::new(shader_keys[2], self.blur_pipeline_layout_key),
+        ]
+    }
+}
+
 impl EvsmPass {
     /// Builds layouts, compiles shaders, creates pipelines, and
-    /// allocates the params uniform buffer. Called from `Shadows::new`.
+    /// allocates the params uniform buffer. Thin wrapper over the
+    /// split that runs the validate + ensure_keys awaits internally;
+    /// the cross-tail pool path bypasses this and feeds the descriptor
+    /// pieces into shared batches.
     pub async fn new(
         gpu: &AwsmRendererWebGpu,
         bind_group_layouts: &mut BindGroupLayouts,
@@ -108,7 +161,39 @@ impl EvsmPass {
         pipelines: &mut Pipelines,
         shaders: &mut Shaders,
     ) -> Result<Self, AwsmShadowError> {
-        // ── moment-write layout / pipeline ────────────────────────────
+        let descs = Self::build_descriptors(gpu, bind_group_layouts, pipeline_layouts)?;
+
+        // Join the 3 inline-shader validations in parallel.
+        let validation_results = futures::future::join_all(descs.validate_shader_futures()).await;
+        for result in validation_results {
+            result.map_err(AwsmShadowError::Core)?;
+        }
+        let shader_keys: [ShaderKey; 3] = [
+            shaders.insert_uncached(descs.modules[0].clone()),
+            shaders.insert_uncached(descs.modules[1].clone()),
+            shaders.insert_uncached(descs.modules[2].clone()),
+        ];
+        let pipeline_cache_keys = descs.pipeline_cache_keys(shader_keys);
+
+        let resolved = pipelines
+            .compute
+            .ensure_keys(gpu, shaders, pipeline_layouts, pipeline_cache_keys)
+            .await?;
+
+        Ok(Self::from_resolved(descs, resolved))
+    }
+
+    /// Sync. Builds the 2 bind-group layouts, the 2 pipeline layouts,
+    /// the params uniform buffer, and issues `compile_shader` for the
+    /// 3 inline WGSL shaders. Returns the modules + the params buffer
+    /// in [`EvsmDescriptors`] for the orchestrator to interleave with
+    /// the cross-tail shader / pipeline batches.
+    pub fn build_descriptors(
+        gpu: &AwsmRendererWebGpu,
+        bind_group_layouts: &mut BindGroupLayouts,
+        pipeline_layouts: &mut PipelineLayouts,
+    ) -> Result<EvsmDescriptors, AwsmShadowError> {
+        // ── moment-write layout ───────────────────────────────────────
         let moment_write_layout_key = bind_group_layouts.get_key(
             gpu,
             BindGroupLayoutCacheKey::new(vec![
@@ -154,7 +239,7 @@ impl EvsmPass {
             PipelineLayoutCacheKey::new(vec![moment_write_layout_key]),
         )?;
 
-        // ── blur layout / pipelines ────────────────────────────────────
+        // ── blur layout ────────────────────────────────────────────────
         let blur_layout_key = bind_group_layouts.get_key(
             gpu,
             BindGroupLayoutCacheKey::new(vec![
@@ -197,53 +282,26 @@ impl EvsmPass {
             PipelineLayoutCacheKey::new(vec![blur_layout_key]),
         )?;
 
-        // Compile all 3 inline shaders concurrently — issue every
-        // `compile_shader` synchronously, then `join_all` the
-        // validations. Same shape as `Shaders::ensure_keys`.
+        // Issue all 3 inline `compile_shader` calls synchronously. The
+        // validate futures are exposed via
+        // `EvsmDescriptors::validate_shader_futures` so the
+        // orchestrator can interleave them with the cross-tail shader
+        // ensure_keys.
         let inline_specs: [(&str, &str); 3] = [
             ("Shadow EVSM Moment Write", MOMENT_WRITE_WGSL),
             ("Shadow EVSM Blur H", blur_h_wgsl()),
             ("Shadow EVSM Blur V", blur_v_wgsl()),
         ];
-        let descriptors: Vec<web_sys::GpuShaderModuleDescriptor> = inline_specs
+        let mods: Vec<web_sys::GpuShaderModule> = inline_specs
             .iter()
-            .map(|(label, code)| ShaderModuleDescriptor::new(code, Some(label)).into())
+            .map(|(label, code)| {
+                let desc: web_sys::GpuShaderModuleDescriptor =
+                    ShaderModuleDescriptor::new(code, Some(label)).into();
+                gpu.compile_shader(&desc)
+            })
             .collect();
-        let modules: Vec<web_sys::GpuShaderModule> =
-            descriptors.iter().map(|d| gpu.compile_shader(d)).collect();
-        let validation_results = futures::future::join_all(
-            modules
-                .iter()
-                .map(awsm_renderer_core::shaders::ShaderModuleExt::validate_shader),
-        )
-        .await;
-        for result in validation_results {
-            result.map_err(AwsmShadowError::Core)?;
-        }
-        let moment_write_shader = shaders.insert_uncached(modules[0].clone());
-        let blur_h_shader = shaders.insert_uncached(modules[1].clone());
-        let blur_v_shader = shaders.insert_uncached(modules[2].clone());
-
-        // Three compute pipelines in parallel.
-        let pipeline_keys = pipelines
-            .compute
-            .ensure_keys(
-                gpu,
-                shaders,
-                pipeline_layouts,
-                [
-                    ComputePipelineCacheKey::new(
-                        moment_write_shader,
-                        moment_write_pipeline_layout_key,
-                    ),
-                    ComputePipelineCacheKey::new(blur_h_shader, blur_pipeline_layout_key),
-                    ComputePipelineCacheKey::new(blur_v_shader, blur_pipeline_layout_key),
-                ],
-            )
-            .await?;
-        let moment_write_pipeline_key = pipeline_keys[0];
-        let blur_h_pipeline_key = pipeline_keys[1];
-        let blur_v_pipeline_key = pipeline_keys[2];
+        let modules: [web_sys::GpuShaderModule; 3] =
+            [mods[0].clone(), mods[1].clone(), mods[2].clone()];
 
         // ── params buffer ──────────────────────────────────────────────
         let params_buffer_size = EVSM_PARAMS_STRIDE * MAX_EVSM_CASCADES_PER_FRAME;
@@ -256,18 +314,34 @@ impl EvsmPass {
             .into(),
         )?;
 
-        Ok(Self {
+        Ok(EvsmDescriptors {
             moment_write_layout_key,
             blur_layout_key,
             moment_write_pipeline_layout_key,
             blur_pipeline_layout_key,
-            moment_write_pipeline_key,
-            blur_h_pipeline_key,
-            blur_v_pipeline_key,
+            modules,
             params_buffer,
             params_bytes: vec![0u8; params_buffer_size],
-            active_cascade_count: 0,
         })
+    }
+
+    /// Folds resolved compute pipeline keys back into the typed
+    /// `EvsmPass`. Sync; the orchestrator has already run the
+    /// validate join + the cross-tail `ComputePipelines::ensure_keys`.
+    pub fn from_resolved(descs: EvsmDescriptors, resolved: Vec<ComputePipelineKey>) -> Self {
+        debug_assert_eq!(resolved.len(), 3);
+        Self {
+            moment_write_layout_key: descs.moment_write_layout_key,
+            blur_layout_key: descs.blur_layout_key,
+            moment_write_pipeline_layout_key: descs.moment_write_pipeline_layout_key,
+            blur_pipeline_layout_key: descs.blur_pipeline_layout_key,
+            moment_write_pipeline_key: resolved[0],
+            blur_h_pipeline_key: resolved[1],
+            blur_v_pipeline_key: resolved[2],
+            params_buffer: descs.params_buffer,
+            params_bytes: descs.params_bytes,
+            active_cascade_count: 0,
+        }
     }
 
     /// Returns the dynamic-offset for cascade slot `index`.

--- a/crates/renderer/src/shadows/mod.rs
+++ b/crates/renderer/src/shadows/mod.rs
@@ -32,7 +32,7 @@ mod state;
 pub use cascade::Cascade;
 pub use config::ShadowsConfig;
 pub use error::AwsmShadowError;
-pub use evsm::EvsmPass;
+pub use evsm::{EvsmDescriptors, EvsmPass};
 pub use light_shadow::{
     CubeFaceUpdateRate, EvsmCutoff, FarCascadeUpdateRate, LightShadowHardness, LightShadowParams,
     MeshShadowFlags,
@@ -47,4 +47,4 @@ pub use consts::{
     SHADOW_VIEW_STRIDE,
 };
 pub use record::{EvsmDispatchEntry, LightShadowRecord, LightShadowView, ShadowViewThrottle};
-pub use state::Shadows;
+pub use state::{Shadows, ShadowsDescriptors};

--- a/crates/renderer/src/shadows/state.rs
+++ b/crates/renderer/src/shadows/state.rs
@@ -29,10 +29,14 @@ use crate::{
     debug::AwsmRendererLogging,
     lights::LightKey,
     pipeline_layouts::{PipelineLayoutCacheKey, PipelineLayoutKey, PipelineLayouts},
-    pipelines::{render_pipeline::RenderPipelineKey, Pipelines},
+    pipelines::{
+        compute_pipeline::ComputePipelineKey,
+        render_pipeline::{RenderPipelineCacheKey, RenderPipelineKey},
+        Pipelines,
+    },
     render_passes::geometry::bind_group::GeometryBindGroups,
     render_textures::RenderTextureFormats,
-    shaders::Shaders,
+    shaders::{ShaderCacheKey, Shaders},
     shadows::{
         cascade,
         config::ShadowsConfig,
@@ -43,7 +47,7 @@ use crate::{
         },
         error::AwsmShadowError,
         evsm,
-        evsm::EvsmPass,
+        evsm::{EvsmDescriptors, EvsmPass},
         helpers::{
             build_cascade_layer_views, build_cube_face_views, build_evsm_blur_bind_group,
             build_evsm_moment_write_bind_group, create_cascade_array_view,
@@ -291,12 +295,84 @@ impl PendingResourceRecreate {
     }
 }
 
+/// Pre-resolved layouts, GPU resource handles, and pipeline cache
+/// keys for the shadow subsystem. Returned by
+/// [`Shadows::build_descriptors`] and consumed by
+/// [`Shadows::from_resolved`]. The 4 caster render-pipeline cache keys
+/// fold into the cross-tail `RenderPipelines::ensure_keys` batch; the
+/// EVSM block's 3 inline shaders + 3 compute pipelines fold into the
+/// cross-tail compute pool. See [`EvsmDescriptors`] for the EVSM hand-
+/// off shape.
+pub struct ShadowsDescriptors {
+    pub config: ShadowsConfig,
+    // ── GPU resources ────────────────────────────────────────────────
+    pub atlas_texture: web_sys::GpuTexture,
+    pub atlas_view: web_sys::GpuTextureView,
+    pub atlas_size: u32,
+    pub evsm_atlas_texture: web_sys::GpuTexture,
+    pub evsm_atlas_view: web_sys::GpuTextureView,
+    pub evsm_atlas_size: u32,
+    pub evsm_blur_pingpong_texture: web_sys::GpuTexture,
+    pub evsm_blur_pingpong_view: web_sys::GpuTextureView,
+    pub cascade_array_texture: web_sys::GpuTexture,
+    pub cascade_array_view: web_sys::GpuTextureView,
+    pub cascade_layer_views: Vec<web_sys::GpuTextureView>,
+    pub cascade_resolution: u32,
+    pub cascade_max_layers: u32,
+    pub cube_array_texture: web_sys::GpuTexture,
+    pub cube_array_view: web_sys::GpuTextureView,
+    pub cube_2d_array_view: web_sys::GpuTextureView,
+    pub cube_face_views: Vec<web_sys::GpuTextureView>,
+    pub cube_resolution: u32,
+    pub cube_slot_count: u32,
+    pub descriptors_buffer: web_sys::GpuBuffer,
+    pub descriptors_uniform: web_sys::GpuBuffer,
+    pub globals_buffer: web_sys::GpuBuffer,
+    pub shadow_view_buffer: web_sys::GpuBuffer,
+    pub sampler_comparison: web_sys::GpuSampler,
+    pub sampler_filterable: web_sys::GpuSampler,
+    // ── caster layouts + bind group + cache keys ─────────────────────
+    pub shadow_view_bind_group_layout_key: BindGroupLayoutKey,
+    pub shadow_view_bind_group: web_sys::GpuBindGroup,
+    pub shadow_pipeline_layout_key_storage: PipelineLayoutKey,
+    pub shadow_pipeline_layout_key_uniform: PipelineLayoutKey,
+    /// 4 caster pipeline cache keys, in order:
+    /// `(no_inst, planar)`, `(inst, planar)`, `(no_inst, cube)`, `(inst, cube)`.
+    pub caster_pipeline_cache_keys: Vec<RenderPipelineCacheKey>,
+    // ── EVSM ─────────────────────────────────────────────────────────
+    pub evsm: EvsmDescriptors,
+}
+
+impl ShadowsDescriptors {
+    /// Two shader cache keys the caster pipelines depend on. Both are
+    /// already pre-warmed by `RenderPasses::new`'s cross-pass shader
+    /// ensure_keys; the orchestrator includes them in the cross-tail
+    /// batch for completeness / robustness.
+    pub fn caster_shader_cache_keys() -> Vec<ShaderCacheKey> {
+        vec![
+            ShaderCacheKey::from(crate::shadows::shader::cache_key::ShaderCacheKeyShadow {
+                instancing_transforms: false,
+            }),
+            ShaderCacheKey::from(crate::shadows::shader::cache_key::ShaderCacheKeyShadow {
+                instancing_transforms: true,
+            }),
+        ]
+    }
+}
+
 impl Shadows {
     /// Creates the shadow subsystem.
     ///
     /// Must be called after the geometry render pass has been built so
     /// the shadow pipeline can reuse the geometry pass's transform /
     /// meta / animation bind group layouts at slots 1..=3.
+    ///
+    /// Thin wrapper over [`Self::build_descriptors`] +
+    /// [`Self::from_resolved`]. The cross-tail pooled startup path
+    /// bypasses this and calls the two halves directly so the caster
+    /// render pipelines + EVSM compute pipelines share one batched
+    /// `RenderPipelines::ensure_keys` / `ComputePipelines::ensure_keys`
+    /// with every other tail subsystem.
     #[allow(clippy::too_many_arguments)]
     pub async fn new(
         gpu: &AwsmRendererWebGpu,
@@ -305,9 +381,79 @@ impl Shadows {
         pipelines: &mut Pipelines,
         shaders: &mut Shaders,
         geometry_bind_groups: &GeometryBindGroups,
-        _render_texture_formats: &RenderTextureFormats,
+        render_texture_formats: &RenderTextureFormats,
         config: ShadowsConfig,
     ) -> Result<Self, AwsmShadowError> {
+        let descs = Self::build_descriptors(
+            gpu,
+            bind_group_layouts,
+            pipeline_layouts,
+            shaders,
+            geometry_bind_groups,
+            render_texture_formats,
+            config,
+        )
+        .await?;
+
+        // Caster shader pre-warm (pooled in the orchestrator path, but
+        // we still need to ensure here for the standalone case).
+        shaders
+            .ensure_keys(gpu, ShadowsDescriptors::caster_shader_cache_keys())
+            .await?;
+
+        // Caster render pipelines.
+        let caster_resolved = pipelines
+            .render
+            .ensure_keys(
+                gpu,
+                shaders,
+                pipeline_layouts,
+                descs.caster_pipeline_cache_keys.clone(),
+            )
+            .await?;
+
+        // EVSM: validate 3 inline shaders + ensure_keys 3 compute pipelines.
+        let validation_results =
+            futures::future::join_all(descs.evsm.validate_shader_futures()).await;
+        for result in validation_results {
+            result.map_err(AwsmShadowError::Core)?;
+        }
+        let evsm_shader_keys = [
+            shaders.insert_uncached(descs.evsm.modules[0].clone()),
+            shaders.insert_uncached(descs.evsm.modules[1].clone()),
+            shaders.insert_uncached(descs.evsm.modules[2].clone()),
+        ];
+        let evsm_pipeline_cache_keys = descs.evsm.pipeline_cache_keys(evsm_shader_keys);
+        let evsm_resolved = pipelines
+            .compute
+            .ensure_keys(gpu, shaders, pipeline_layouts, evsm_pipeline_cache_keys)
+            .await?;
+
+        Self::from_resolved(
+            gpu,
+            bind_group_layouts,
+            descs,
+            caster_resolved,
+            evsm_resolved,
+        )
+    }
+
+    /// Sync apart from a few `shaders.get_key` cache-hit lookups for
+    /// the caster pipeline cache keys. Allocates every GPU resource
+    /// the shadow subsystem owns, registers every bind-group + pipeline
+    /// layout, and issues the 3 EVSM inline `compile_shader` calls.
+    /// Returns [`ShadowsDescriptors`] for the orchestrator to fold into
+    /// the cross-tail batches.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn build_descriptors(
+        gpu: &AwsmRendererWebGpu,
+        bind_group_layouts: &mut BindGroupLayouts,
+        pipeline_layouts: &mut PipelineLayouts,
+        shaders: &mut Shaders,
+        geometry_bind_groups: &GeometryBindGroups,
+        _render_texture_formats: &RenderTextureFormats,
+        config: ShadowsConfig,
+    ) -> Result<ShadowsDescriptors, AwsmShadowError> {
         warn_view_budget(&config);
         let atlas_size = config.atlas_size.max(1);
         let atlas_texture = gpu.create_texture(
@@ -554,27 +700,11 @@ impl Shadows {
             ]),
         )?;
 
-        // Batch the four shadow caster pipeline compiles. Two shader
-        // variants (instancing on/off) × 2 pipeline variants (planar
-        // vs cube). Same descriptor-then-ensure_keys shape as the
-        // opaque + geometry passes.
-        shaders
-            .ensure_keys(
-                gpu,
-                [
-                    crate::shaders::ShaderCacheKey::from(
-                        crate::shadows::shader::cache_key::ShaderCacheKeyShadow {
-                            instancing_transforms: false,
-                        },
-                    ),
-                    crate::shaders::ShaderCacheKey::from(
-                        crate::shadows::shader::cache_key::ShaderCacheKeyShadow {
-                            instancing_transforms: true,
-                        },
-                    ),
-                ],
-            )
-            .await?;
+        // Resolve the two caster shader keys against the pre-warmed
+        // cache. RenderPasses::new emits both as part of its cross-pass
+        // ensure_keys; in the standalone `Shadows::new` path the
+        // wrapper above issues its own ensure_keys first. Either way
+        // these are sync cache hits.
         let shader_no_instancing = shaders
             .get_key(
                 gpu,
@@ -591,7 +721,7 @@ impl Shadows {
                 },
             )
             .await?;
-        let shadow_cache_keys = vec![
+        let caster_pipeline_cache_keys = vec![
             shadow_pipeline_cache_key(
                 shader_no_instancing,
                 shadow_pipeline_layout_key_storage,
@@ -617,24 +747,103 @@ impl Shadows {
                 true,
             ),
         ];
-        let shadow_pipeline_keys = pipelines
-            .render
-            .ensure_keys(gpu, shaders, pipeline_layouts, shadow_cache_keys)
-            .await?;
-        let shadow_pipeline_no_instancing = shadow_pipeline_keys[0];
-        let shadow_pipeline_instancing = shadow_pipeline_keys[1];
-        let shadow_pipeline_cube_no_instancing = shadow_pipeline_keys[2];
-        let shadow_pipeline_cube_instancing = shadow_pipeline_keys[3];
 
-        let evsm_pass = EvsmPass::new(
-            gpu,
-            bind_group_layouts,
-            pipeline_layouts,
-            pipelines,
-            shaders,
-        )
-        .await?;
+        let evsm = EvsmPass::build_descriptors(gpu, bind_group_layouts, pipeline_layouts)?;
 
+        Ok(ShadowsDescriptors {
+            config,
+            atlas_texture,
+            atlas_view,
+            atlas_size,
+            evsm_atlas_texture,
+            evsm_atlas_view,
+            evsm_atlas_size,
+            evsm_blur_pingpong_texture,
+            evsm_blur_pingpong_view,
+            cascade_array_texture,
+            cascade_array_view,
+            cascade_layer_views,
+            cascade_resolution,
+            cascade_max_layers,
+            cube_array_texture,
+            cube_array_view,
+            cube_2d_array_view,
+            cube_face_views,
+            cube_resolution,
+            cube_slot_count,
+            descriptors_buffer,
+            descriptors_uniform,
+            globals_buffer,
+            shadow_view_buffer,
+            sampler_comparison,
+            sampler_filterable,
+            shadow_view_bind_group_layout_key,
+            shadow_view_bind_group,
+            shadow_pipeline_layout_key_storage,
+            shadow_pipeline_layout_key_uniform,
+            caster_pipeline_cache_keys,
+            evsm,
+        })
+    }
+
+    /// Folds the resolved caster + EVSM pipeline keys back into the
+    /// typed [`Shadows`] handle. Sync; the orchestrator has already
+    /// run the cross-tail batched `RenderPipelines::ensure_keys` +
+    /// `ComputePipelines::ensure_keys` and the EVSM validate join.
+    ///
+    /// `caster_resolved` is in `caster_pipeline_cache_keys` order:
+    /// `(no_inst, planar)`, `(inst, planar)`, `(no_inst, cube)`,
+    /// `(inst, cube)`.
+    pub fn from_resolved(
+        gpu: &AwsmRendererWebGpu,
+        bind_group_layouts: &BindGroupLayouts,
+        descs: ShadowsDescriptors,
+        caster_resolved: Vec<RenderPipelineKey>,
+        evsm_resolved: Vec<ComputePipelineKey>,
+    ) -> Result<Self, AwsmShadowError> {
+        debug_assert_eq!(caster_resolved.len(), 4);
+        debug_assert_eq!(evsm_resolved.len(), 3);
+        let ShadowsDescriptors {
+            config,
+            atlas_texture,
+            atlas_view,
+            atlas_size,
+            evsm_atlas_texture,
+            evsm_atlas_view,
+            evsm_atlas_size,
+            evsm_blur_pingpong_texture,
+            evsm_blur_pingpong_view,
+            cascade_array_texture,
+            cascade_array_view,
+            cascade_layer_views,
+            cascade_resolution,
+            cascade_max_layers,
+            cube_array_texture,
+            cube_array_view,
+            cube_2d_array_view,
+            cube_face_views,
+            cube_resolution,
+            cube_slot_count,
+            descriptors_buffer,
+            descriptors_uniform,
+            globals_buffer,
+            shadow_view_buffer,
+            sampler_comparison,
+            sampler_filterable,
+            shadow_view_bind_group_layout_key,
+            shadow_view_bind_group,
+            shadow_pipeline_layout_key_storage,
+            shadow_pipeline_layout_key_uniform,
+            caster_pipeline_cache_keys: _,
+            evsm,
+        } = descs;
+
+        let evsm_pass = EvsmPass::from_resolved(evsm, evsm_resolved);
+
+        // EVSM moment-write + blur bind groups depend on the layouts +
+        // params buffer that EvsmPass now owns. Built here (sync, no
+        // pipeline compile) so the typed `Shadows` can sample the
+        // bind group at render time without re-resolving layouts.
         let evsm_moment_write_bind_group = build_evsm_moment_write_bind_group(
             gpu,
             bind_group_layouts,
@@ -704,10 +913,10 @@ impl Shadows {
             shadow_view_bind_group,
             shadow_pipeline_layout_key_storage,
             shadow_pipeline_layout_key_uniform,
-            shadow_pipeline_no_instancing,
-            shadow_pipeline_instancing,
-            shadow_pipeline_cube_no_instancing,
-            shadow_pipeline_cube_instancing,
+            shadow_pipeline_no_instancing: caster_resolved[0],
+            shadow_pipeline_instancing: caster_resolved[1],
+            shadow_pipeline_cube_no_instancing: caster_resolved[2],
+            shadow_pipeline_cube_instancing: caster_resolved[3],
             frame_count: 0,
             dirty: true,
             pending_atlas_grow: false,

--- a/crates/renderer/src/shadows/state.rs
+++ b/crates/renderer/src/shadows/state.rs
@@ -344,10 +344,16 @@ pub struct ShadowsDescriptors {
 }
 
 impl ShadowsDescriptors {
-    /// Two shader cache keys the caster pipelines depend on. Both are
-    /// already pre-warmed by `RenderPasses::new`'s cross-pass shader
-    /// ensure_keys; the orchestrator includes them in the cross-tail
-    /// batch for completeness / robustness.
+    /// Two shader cache keys the caster pipelines depend on. Both
+    /// are pre-warmed by `RenderPasses::new`'s cross-pass shader
+    /// `ensure_keys` (the shadow caster shaders are added to that
+    /// batch alongside the picker + line shader keys, see
+    /// `render_passes.rs`'s phase-2 block). The orchestrator does
+    /// NOT re-include them in the cross-tail shader batch — by the
+    /// time tail descriptors run, the caster shaders are cache hits.
+    /// This helper exists only as the standalone-`Shadows::new` path's
+    /// own pre-warm and as a discoverable list for callers that want
+    /// to know which shaders Shadows depends on.
     pub fn caster_shader_cache_keys() -> Vec<ShaderCacheKey> {
         vec![
             ShaderCacheKey::from(crate::shadows::shader::cache_key::ShaderCacheKeyShadow {

--- a/docs/plans/parallelize.md
+++ b/docs/plans/parallelize.md
@@ -1,15 +1,16 @@
 # Parallelize WebGPU pipeline creation — full plan
 
-## Status (2026-05-25) — landed on the `parallel` branch
+## Status (2026-05-25) — tail pool landed on `parallel-continued`
 
-All seven phases below have landed, plus a follow-up sweep that
-took the cross-pass pooling all the way to its limit. Every shader
-and every pipeline that compiles during `AwsmRendererBuilder::build`
-on the cold-cache first load now goes through batched
-`ensure_keys` calls; the per-pass / per-subsystem `new()`
-constructors are thin wrappers over `build_descriptors` +
-`from_resolved` splits so the `RenderPasses::new` orchestrator can
-fold every variant into one global pool.
+All seven original phases plus the cross-pass pool sweep plus the
+**tail pool follow-up** (PR #96) have landed. Every shader and every
+pipeline that compiles during `AwsmRendererBuilder::build` on the
+cold-cache first load goes through batched `ensure_keys` calls; the
+per-pass / per-subsystem `new()` constructors are thin wrappers
+over `build_descriptors` + `from_resolved` splits so the
+orchestrator can fold every variant into one of two cross-system
+pools (one inside `RenderPasses::new`, one across the tail after
+`RenderPasses::new` returns).
 
 | Phase | Status | Headline commit |
 |---|---|---|
@@ -27,6 +28,37 @@ fold every variant into one global pool.
 | 11 — Full cross-pass pipeline pool in RenderPasses::new | ✅ | `renderer: full cross-pass pipeline pool at RenderPasses::new` |
 | 12 — Batch Picker + LineRenderer | ✅ | `renderer: batch picker's two pipeline compiles` / `renderer: batch LineRenderer's 4 variants` |
 | 13 — anti_aliasing dedup-fix + Picker descriptor split | ✅ | `renderer: fix anti_alias set_anti_aliasing OR-dedup bug` / `renderer: expose Picker descriptor split` |
+| 14 — Tail pool (Shadows + Lines + Effects + Display) | ✅ | PR #96: `renderer: orchestrate tail-pool in AwsmRendererBuilder::build (2-await tail)` |
+| 14a — PR#96 review fixes (try_join compute+render, doc) | ✅ | `renderer: address PR#96 review — try_join compute+render ensure_keys, doc fixes` |
+
+### Trace evidence (warm Metal + cold Chrome PSO, 2026-05-25)
+
+A fresh `--user-data-dir` Chrome profile against the model-tests Fox
+scene captured `Trace-Three.json`, with the renderer built at PR#96's
+HEAD:
+
+| Metric | Pre-parallelize cold | Pre-parallelize warm | Post-PR#96 fresh-profile |
+|---|---|---|---|
+| `domComplete → first 'Render [1]: span-enter'` | 42.8 s | 1.7 s | **2.2 s** |
+| GPU-process total CPU | 5.35 s | 0.81 s | **0.77 s** |
+| Renderer-main-thread total CPU | 8.74 s | 4.26 s | **1.0 s** |
+
+The 0.77 s GPU-process CPU number tells the real story: it's
+indistinguishable from the pre-parallelize warm baseline, which
+means Dawn isn't doing real compile work — it's serving from the
+**driver-level Metal pipeline cache** that survives across Chrome
+profiles. `--user-data-dir` clears Chrome's PSO cache but cannot
+clear macOS's MSL → native cache. So on any developer machine that
+has run this codebase before, the cold-Chrome experience now sits
+in the same ballpark as the historical warm path. The 42.8 s
+baseline reflected a machine where both layers were cold (first
+ever run of the app), which is the user-facing first-visit experience.
+
+The renderer-main-thread idle-gap distribution in the new trace is
+also clean — user-timing marks after `Prewarm Pipelines` cascade in
+~1 ms apart, no ~500 ms per-frame-tick stalls. The serial-await
+staircase the original plan was attacking is gone whether the
+underlying compile is cold or warm.
 
 ### What pools at startup now
 
@@ -60,37 +92,62 @@ batch in parallel.
 
 ### What still compiles outside RenderPasses::new
 
-The following compile *after* `RenderPasses::new` returns and stay
-sequential per-subsystem, but each one is internally batched:
+After PR #96 the tail subsystems share a single cross-tail pool
+running right after `RenderPasses::new` returns. The structure of
+the tail today:
 
-- **Picker** — 1 batched `ComputePipelines::ensure_keys` for 2
-  pipelines. Shader cache hits (pre-warmed by `RenderPasses::new`).
-- **LineRenderer** — 1 batched `RenderPipelines::ensure_keys` for
-  4 variants (depth-test × MSAA). Shader cache hit.
-- **Shadows** — 2 awaits: 1 `RenderPipelines::ensure_keys` for 4
-  caster variants, plus an EVSM block that runs 3 inline shader
-  validations through `join_all` and 3 EVSM compute pipelines
-  through `ComputePipelines::ensure_keys` together. Caster shader
-  cache hit; EVSM uses an inline-source path that bypasses the
-  shared shader cache.
-- **`set_anti_aliasing` / `set_post_processing`** — 1 batched
-  `ComputePipelines::ensure_keys` for the 5 effects variants
-  (bloom-phase fan-out), and 1 batched render call for the 1
-  display pipeline. The first time these are called the cold
-  compile happens; subsequent calls hit the cache.
+1. **Sync** — each tail subsystem's `build_descriptors` runs:
+   - `Picker::build_descriptors` (registers bind-group layouts +
+     2 compute pipeline cache keys).
+   - `LineRenderer::build_descriptors` (registers bind-group +
+     pipeline layout, 4 render pipeline cache keys).
+   - `Shadows::build_descriptors` (allocates every shadow GPU
+     resource — atlas, EVSM atlas, cascade-array, cube-array,
+     descriptors / globals / view buffers, samplers, bind-group
+     layouts, pipeline layouts; resolves 4 caster pipeline cache
+     keys; issues 3 EVSM inline `compile_shader` calls returning
+     modules + unawaited `validate_shader` futures).
+2. **One `Shaders::ensure_keys`** joined via `futures::join` with
+   the 3 EVSM inline-shader validate futures — effects + display
+   shader keys + EVSM module validations all in flight together.
+3. **Sync** — register the 3 EVSM modules via
+   `Shaders::insert_uncached`, derive their 3 compute pipeline
+   cache keys, run `EffectsPipelines::build_descriptors` +
+   `DisplayPipelines::build_descriptors` (sync cache-hit shader
+   resolves), build the cross-tail compute + render pools.
+4. **`try_join`'d compute + render `ensure_keys`** — split-borrow
+   `Pipelines.compute` / `Pipelines.render` so Dawn overlaps both
+   classes against its worker pool. Compute pool = picker(2) +
+   EVSM(3) + effects(5) = **10 pipelines**. Render pool =
+   lines(4) + caster(4) + display(1) = **9 pipelines**.
+5. **Sync fold-up** — each subsystem's `from_resolved` /
+   `install_resolved` consumes its slice of the resolved keys.
 
-Pooling these into the same `RenderPasses::new` batches would
-require splitting Shadows / Effects / Display into the same
-`build_descriptors` + `from_resolved` shape and threading the
-orchestration through `AwsmRendererBuilder::build`. See
-[Follow-up: tail pool](#follow-up-tail-pool-shadows--picker--linerenderer--effects--display)
-below for the full implementation plan a fresh session can pick up
-and execute.
+Pre-PR#96 this was 5 sequential per-subsystem awaits; post-PR#96
+it's 3 awaits inside the tail (shader-join, then try_join'd
+compute + render). The dynamic `set_anti_aliasing` /
+`set_post_processing` setter path is preserved — those setters
+wrap the same `build_descriptors` + per-subsystem `ensure_keys` +
+`install_resolved` shape for mid-session config flips.
 
-The `Picker::build_descriptors` split is already in place as
-infrastructure for that follow-up. The remaining subsystems —
-Shadows, EffectsPipelines, DisplayPipelines, LineRenderer's inner
-`LinePipelines` — are the work.
+### What still serialises across the whole build()
+
+After PR #96 the remaining serial points in `AwsmRendererBuilder::build`
+are:
+
+- `try_join5(IBL × 3, BRDF LUT, opaque_mipgen)` finishes **before**
+  `RenderPasses::new` + `RenderTextures::new` even start. The
+  texture-prep futures only touch `&gpu`, not the shader / pipeline
+  caches — they could ride the same `try_join` as `RenderPasses::new`.
+- `Picker` compiles unconditionally even when the consuming
+  frontend has no use for pick (most library builds).
+- Picker + LineRenderer descriptors build *after* `RenderPasses::new`
+  returns, so their pipelines join only the cross-tail pool, not
+  the larger cross-pass pool. Their bind-group layouts are
+  statically known and could be registered up-front.
+
+These are addressed in [Follow-up 2](#follow-up-2-startup-tail-trim)
+below.
 
 ---
 
@@ -515,6 +572,320 @@ For every step above, the fresh session should:
 - `finalize_gpu_textures` — already pooled (Phase 8).
 - `RenderPasses::new` itself — already pooled (Phase 11).
 - `prewarm_pipelines` — already pooled (Phase 5).
+
+---
+
+## Follow-up 2: startup-tail trim
+
+### Status
+
+Three follow-up items identified after the PR #96 trace review.
+**Land all three in one session** — they're independent at the
+borrow-checker level, the verification cost is shared (one fresh
+trace capture covers all three), and the doc / PR overhead per item
+isn't worth amortising across sessions.
+
+| Item | Win (warm-Metal) | Win (cold-Dawn) | Risk |
+|---|---|---|---|
+| (1) Move `RenderPasses::new` into the `try_join5` block | 300–600 ms | same | low |
+| (2) Fold Picker + LineRenderer pipelines into the cross-pass pool | 25–80 ms | ~1–1.5 s | medium |
+| (3) `RendererFeatures::picking` flag | 25–50 ms | ~200–500 ms | low |
+
+Total cold-cache budget: **~2–2.5 s** off `domComplete → first Render`
+on a machine with cold Metal driver cache. Total warm-Metal budget:
+**~400–700 ms** — small absolute but lops a chunk off the largest
+remaining idle gap before `Prewarm Pipelines` fires.
+
+### Item (1) — parallelise `RenderPasses::new` with the texture-prep block
+
+#### Why this matters
+
+[lib.rs:879-900](../../crates/renderer/src/lib.rs) currently does:
+
+```rust
+let (ibl_filtered_resources, ibl_irradiance_resources, skybox_resources, brdf_lut, opaque_mipgen) =
+    futures::future::try_join5(/* … */).await?;
+// … register textures …
+let (mut render_passes, render_textures) =
+    futures::future::try_join(RenderPasses::new(/* … */), RenderTextures::new(/* … */)).await?;
+```
+
+The five texture-prep futures only touch `&gpu` (the `prepare_resources`
+half of the prepare/register split is intentional infrastructure for
+exactly this kind of parallelisation). `RenderPasses::new` wants `&mut`
+on the caches — but those caches are disjoint from anything the
+texture prep touches. The borrow checker will confirm the disjointness
+in seconds.
+
+#### What changes
+
+Collapse the two `await` points into one bigger `try_join`. Texture
+**registration** (the `IblTexture::register` etc. calls that consume
+the prepared resources + mutate `textures`) happens in the sync
+fold-up after the join. `RenderPasses::new`'s compile work overlaps
+with the ImageBitmap decode and BRDF-LUT generation work happening
+on the GPU process.
+
+#### Audit before refactor
+
+Confirm `RenderPasses::new` reads nothing from `&textures` whose
+state is finalized by `IblTexture::register` / `Skybox::register`
+inside its compile sequence. The texture-pool *shape* (array
+lengths) is determined by `Materials::load` / gltf loads, not by
+IBL handles, so RenderPasses::new should be independent. Spot-check
+via grep for `textures.` reads inside `RenderPasses::new` →
+`build_descriptors` chains.
+
+If the audit comes back wrong (RenderPasses::new actually reads
+e.g. the cubemap array binding count): minimal-impact fallback is to
+delay only the `IblTexture::register` calls until after the join.
+The renderer's compile work doesn't care about the IBL texture
+handle itself, only that a binding-shape-compatible texture exists
+later when bind groups are created — which is after first frame.
+
+#### Files
+
+- [lib.rs](../../crates/renderer/src/lib.rs) — `AwsmRendererBuilder::build`
+  body, the `try_join5` + downstream `try_join` block.
+
+#### Checklist
+
+- [ ] Audit: every `textures.` access inside `RenderPasses::new`'s
+      call chain. List in the commit body.
+- [ ] Single `try_join` of (IBL × 3, BRDF, opaque_mipgen,
+      `RenderPasses::new`, `RenderTextures::new`).
+- [ ] Texture registrations move to the post-await sync block.
+- [ ] `cargo build --workspace` + `cargo clippy --workspace
+      --all-targets -- -D warnings` clean.
+- [ ] Fresh-profile Chrome trace; `domComplete → first 'Render [1]:
+      span-enter'` drop matches the 300–600 ms warm-Metal estimate.
+
+### Item (2) — fold Picker + LineRenderer into the cross-pass pool
+
+#### Why this matters
+
+Today `RenderPasses::new` runs 3 awaits (one shader, one
+try_join'd compute + render). The tail pool runs 3 more awaits
+(one shader-join, one try_join'd compute + render). On cold-Dawn
+the wave-tail-straggler delay for the second batch is real: the
+slowest pipeline in the tail can hold up nothing else, but if the
+*total* compile work could be merged into one giant pool, the
+total straggler delay drops from `straggler(cross-pass) +
+straggler(tail)` to `straggler(combined)` — usually ~one full
+`t_compile` (≈0.8–1.5 s on cold Dawn for this codebase).
+
+#### Path choice
+
+Three approaches considered. **Pick Path A** for this session —
+the cold-cache yield only materialises if the merged pool actually
+saturates Dawn's worker pool past where the cross-pass pool
+already does, which Path A delivers and B/C don't reliably.
+
+- **Path A (the one we're landing): invert the orchestration.**
+  `RenderPasses::new` stops owning its own `ensure_keys` calls. It
+  becomes "describe phase" + "fold-up phase", and the orchestrator
+  in `AwsmRendererBuilder::build` drives the pools across passes
+  *and* tail subsystems. Three awaits total for the entire renderer
+  (one shader, one try_join'd compute + render). RenderPasses::new
+  exposes:
+  - `RenderPasses::describe(ctx, features) -> RenderPassesDescriptors`
+    — sync apart from cache-hit shader resolution. Returns a struct
+    carrying per-pass bind groups + `Vec<RenderPipelineCacheKey>` +
+    `Vec<ComputePipelineCacheKey>` + sub-range maps.
+  - `RenderPasses::from_resolved(descriptors, compute_keys,
+    render_keys) -> RenderPasses` — sync; the orchestrator
+    hands back the resolved key slices.
+- **Path B (rejected):** Add `extra_compute_keys` /
+  `extra_render_keys` parameters to `RenderPasses::new` so the
+  orchestrator can stuff Picker + Lines cache keys in. Mechanically
+  smaller but `RenderPasses::new` would know about non-render-pass
+  subsystems — layering wart.
+- **Path C (rejected):** Pre-warm Picker + Lines pipelines via
+  their own `ensure_keys` running in parallel with
+  `RenderPasses::new`. Doesn't merge pools, only overlaps two
+  same-size waves — half a win.
+
+#### What changes
+
+Inside `RenderPasses::new` today, phase 2 (cross-pass shader
+`ensure_keys`) and phase 4 (the two `ensure_keys` calls) move out
+to the orchestrator. The orchestrator becomes:
+
+```rust
+// Sync — describe every pass, pre-build Picker + LineRenderer
+// descriptors (their bind-group layouts are static).
+let rp_descs = RenderPasses::describe(&mut ctx, &features)?;
+let picker_descs = Picker::build_descriptors(/* … */).await?;
+let line_descs = LineRenderer::build_descriptors(/* … */).await?;
+
+// One pooled shader ensure_keys covering RenderPasses + Picker +
+// Lines + (later, after this batch) effects + display + shadow
+// caster shader keys. EVSM inline validates join in parallel.
+shaders.ensure_keys(&gpu, every_shader_key).await?;
+
+// Sync — Effects + Display descriptors (their shaders are now warm).
+let effects_descs = effects.build_descriptors(/* … */).await?;
+let display_descs = display.build_descriptors(/* … */).await?;
+let shadows_descs = Shadows::build_descriptors(/* … */).await?;
+
+// One try_join'd compute + render ensure_keys covering EVERYTHING.
+// Compute pool ≈ ~36 pipelines. Render pool ≈ ~27 pipelines.
+let (compute_keys, render_keys) = futures::future::try_join(
+    pipelines.compute.ensure_keys(/* compute_pool */),
+    pipelines.render.ensure_keys(/* render_pool */),
+).await?;
+
+// Sync fold-up everywhere.
+```
+
+#### Files
+
+- [render_passes.rs](../../crates/renderer/src/render_passes.rs) — split `RenderPasses::new` into `describe` + `from_resolved`.
+- [lib.rs](../../crates/renderer/src/lib.rs) — orchestrator pulls the pool management up.
+
+#### Risk
+
+The orchestration contract change is the real cost. Every render
+pass already has `build_descriptors` + `from_resolved`, so the
+per-pass refactor is minimal — it's the surrounding code in
+`RenderPasses::new` (the per-feature `if let Some(bg)` branching
+when assembling the pools) that has to move out. Aim for ~150–250
+line delta in render_passes.rs and a comparable expansion in
+lib.rs.
+
+#### Checklist
+
+- [ ] `RenderPasses::describe` extracted; `RenderPasses::new` becomes
+      a thin wrapper for callers that don't pool externally (none
+      today; keep the entry point for symmetry).
+- [ ] Orchestrator drives the single cross-renderer shader pool +
+      try_join'd compute + render pool.
+- [ ] All 12 render passes still construct under every
+      `RendererFeatures` combination — try with and without
+      `coverage_lod`, `gpu_culling`, `decals`.
+- [ ] EVSM validate-future hand-off still joins in parallel with
+      the (now larger) shader pool.
+- [ ] `set_anti_aliasing` / `set_post_processing` dynamic-setter
+      path unaffected — these still wrap per-subsystem
+      `build_descriptors` + `ensure_keys` + `install_resolved`.
+- [ ] Both frontends render correctly; dynamic AA + PP flips work
+      mid-session.
+- [ ] Fresh-profile Chrome trace — `domComplete → first 'Render
+      [1]: span-enter'` drop matches the cold-Dawn estimate.
+
+### Item (3) — `RendererFeatures::picking` flag
+
+#### Why this matters
+
+Picker compiles 2 compute pipelines + registers 2 bind-group
+layouts unconditionally, even in library / game builds that never
+call `.pick()`. The shaders are also pre-warmed by
+`RenderPasses::new`'s cross-pass shader batch. Gating the entire
+subsystem on a feature flag means the editor opts in and everyone
+else pays nothing.
+
+This fits cleanly into the existing `RendererFeatures` pattern
+alongside `gpu_culling`, `decals`, `coverage_lod`.
+
+#### What changes
+
+- `RendererFeatures::picking: bool` — defaults to `false` (library
+  / game default). Editor + model-tests opt in explicitly via
+  `.with_features(RendererFeatures { picking: true, … })`.
+- `AwsmRenderer.picker: Option<Picker>` — `None` when feature is off.
+- `AwsmRenderer::pick(...)` returns `PickResult::Disabled` (new
+  variant) or similar when `picker` is `None`. Callers that don't
+  pre-check the feature flag still get a graceful no-op.
+- `Picker::build_descriptors` only runs when `features.picking`.
+- The two `ShaderCacheKey::Picker` entries in
+  `render_passes.rs:198-237`'s cross-pass shader pre-warm are
+  gated by `features.picking`. Same for the cross-pool compute
+  cache keys + bind-group-layout registrations.
+- The frontend's `canvas.rs` / scene-editor explicitly set
+  `picking: true` in their `with_features(...)` call.
+
+#### Files
+
+- [features.rs](../../crates/renderer/src/features.rs) — add the flag.
+- [picker.rs](../../crates/renderer/src/picker.rs) — `Option`-ify the
+  `.pick()` API, add `PickResult::Disabled`.
+- [lib.rs](../../crates/renderer/src/lib.rs) — gate the Picker block in `build()`.
+- [render_passes.rs](../../crates/renderer/src/render_passes.rs) — gate
+  the Picker shader pre-warm.
+- [crates/frontend/model-tests/src/pages/app/canvas.rs](../../crates/frontend/model-tests/src/pages/app/canvas.rs)
+  and [crates/frontend/scene-editor/](../../crates/frontend/scene-editor/) —
+  explicitly opt in.
+
+#### Risk
+
+Low. The only subtlety is the `Option<Picker>` ripple through every
+call site that previously dereferenced `self.picker` directly. ~20
+call sites tops, all mechanical. The `bind_groups`'
+`BindGroupRecreateContext` consumer in `recreate_bind_group` is
+the one place to be careful — make sure the recreate sweep skips
+the Picker recreate when the field is `None`.
+
+#### Checklist
+
+- [ ] `RendererFeatures::picking` flag added, defaults `false`.
+- [ ] `AwsmRenderer.picker: Option<Picker>`; `.pick()` graceful no-op.
+- [ ] `PickResult::Disabled` (or `Option<PickResult>` — pick one).
+- [ ] Picker shader pre-warm + bind-group layouts + pipeline
+      compiles all gated.
+- [ ] Both frontends opt in explicitly.
+- [ ] Library-default build (no `picking: true`) — Picker code
+      paths cold-skipped, `.pick()` returns Disabled.
+
+### Verification (shared across all three items)
+
+Single trace capture covering all three at once. Steps:
+
+1. `cargo build --workspace` clean.
+2. `cargo clippy --workspace --all-targets -- -D warnings` clean.
+3. `cargo fmt --all` clean.
+4. **model-tests**: Fox loads, IBL + shadows + bloom toggle all work
+   mid-session.
+5. **scene-editor**: empty scene + Box primitive + Directional +
+   Point + Spot lights all renderable without GPU validation errors.
+6. **Dynamic AA + PP**: flip MSAA off mid-session, change
+   post-processing config. Both must recompile correctly via the
+   preserved setter path.
+7. **Picker-off library smoke**: build a quick test target with
+   `RendererFeatures { picking: false, .. }` and confirm Picker
+   shaders + pipelines don't show up in the compile span trace.
+8. **Fresh-profile Chrome trace** with `--user-data-dir=/tmp/chrome-cold-$(date +%s)`.
+   Headline metric: `domComplete → first 'Render [1]: span-enter'`.
+   Expected drop from PR#96's ~2.2 s baseline: **300–700 ms**
+   warm-Metal. On a machine with cold Metal driver cache (different
+   machine, or CI runner), expect ~2–2.5 s drop.
+9. Record the new headline number in the `## Measurements` table
+   at the bottom of this doc as the "Final" row.
+
+### Commits expected for this session
+
+One commit per item is the right granularity:
+
+1. `renderer: parallelise RenderPasses::new with try_join5 texture prep`
+2. `renderer: invert RenderPasses orchestration — single cross-renderer pool`
+3. `renderer: gate Picker behind RendererFeatures::picking`
+
+All three should pass build + clippy + fmt independently. The
+session ends with a single PR covering all three commits.
+
+### Out of scope for follow-up 2
+
+- Lazy-compile Picker on first `.pick()` call. Superseded by item (3)
+  — if picking is off, nothing compiles; if on, it joins the cross-renderer
+  pool. No third state.
+- Shader variant dedup (e.g., merging the MSAA × mipmaps × shader_id
+  matrix in opaque). Trades startup latency for steady-state ALU; out
+  of scope for the parallelize doc.
+- WGSL byte-stability + golden hash CI test. Hygiene only — protects
+  future deploys' PSO cache, doesn't move any individual session's
+  numbers.
+- Dawn / Metal driver work. Not addressable from JS.
+
+---
 
 ## Instructions for the implementor
 

--- a/docs/plans/parallelize.md
+++ b/docs/plans/parallelize.md
@@ -1,5 +1,43 @@
 # Parallelize WebGPU pipeline creation — full plan
 
+## End state (what this doc finishes)
+
+After [follow-up 2](#follow-up-2-startup-tail-trim) lands, the
+**WebGPU pipeline-compile parallelization problem is closed**.
+Every shader + pipeline compile in `AwsmRendererBuilder::build`
+will ride one of two pools (one shader, one `try_join`'d compute +
+render), bounded by Dawn's worker-pool size × `max(t_compile)` per
+wave — the theoretical limit of what JS-side parallelization can
+achieve. The orchestration is structured so a future contributor
+*can't accidentally* re-introduce a sequential `.await?` (Path A's
+architectural guarantee).
+
+### What this doc explicitly does NOT address
+
+The trace evidence in [Status](#status-2026-05-25--tail-pool-landed-on-parallel-continued)
+shows the post-PR#96 fresh-profile number is 2.2 s — and most of
+that is **not pipeline compile time** anymore. The remaining axes
+of "page-load → first useful frame" belong to other (future) docs:
+
+| Axis | Approx magnitude | Where the lever lives |
+|---|---|---|
+| WASM module instantiation + glue | 200–500 ms | bundle size, code splitting, LTO, cargo-bloat audit |
+| Browser-process startup | ~450 ms | minimal lever — Chrome's machinery |
+| JS ↔ Rust marshalling per `gpu.create_*` | dispersed | descriptor-build overhead reduction |
+| Texture decode (ImageBitmap × 3 + BRDF) | 300–500 ms (already parallelised) | smaller default cubemaps, shipped BRDF LUT |
+| First-model-load (gltf + textures + finalize) | 150–400 ms / model | separate path with its own pool (Phase 4) |
+| First-frame bind-group recreate | 10–30 ms | pre-create some bind groups in `build()` |
+| Driver-level MSL lowering (Metal/Vulkan/D3D) | 5+ s truly cold | no JS hook — browser team |
+
+Of these, **WASM size + instantiation** is the only axis with a
+clean cost/benefit story for a focused follow-up. A `cargo-bloat`
+audit + dependency once-over is probably worth ~100–300 ms on
+every cold load. It's a different problem with different tools and
+should get its own doc, not extend this one.
+
+Everything else is diminishing returns or genuinely out of our
+control.
+
 ## Status (2026-05-25) — tail pool landed on `parallel-continued`
 
 All seven original phases plus the cross-pass pool sweep plus the

--- a/docs/plans/parallelize.md
+++ b/docs/plans/parallelize.md
@@ -674,36 +674,63 @@ total straggler delay drops from `straggler(cross-pass) +
 straggler(tail)` to `straggler(combined)` — usually ~one full
 `t_compile` (≈0.8–1.5 s on cold Dawn for this codebase).
 
-#### Path choice
+#### Path choice — Path A (invert the orchestration)
 
-Three approaches considered. **Pick Path A** for this session —
-the cold-cache yield only materialises if the merged pool actually
-saturates Dawn's worker pool past where the cross-pass pool
-already does, which Path A delivers and B/C don't reliably.
+Three approaches considered. **Path A is the choice.** The cold-cache
+straggler win is one reason — but Path A also buys three
+architectural guarantees the other two paths don't:
 
-- **Path A (the one we're landing): invert the orchestration.**
-  `RenderPasses::new` stops owning its own `ensure_keys` calls. It
-  becomes "describe phase" + "fold-up phase", and the orchestrator
-  in `AwsmRendererBuilder::build` drives the pools across passes
-  *and* tail subsystems. Three awaits total for the entire renderer
-  (one shader, one try_join'd compute + render). RenderPasses::new
-  exposes:
+1. **No way to accidentally bypass the cross-renderer pool.** The
+   orchestrator *owns* the `ensure_keys` calls. `RenderPasses::describe`
+   can't compile anything — it can only return descriptors. Adding a
+   new render pass (or modifying an existing one) can't introduce a
+   new sequential `.await?` because the function it would live in
+   isn't `async` anymore.
+2. **Single source of truth for renderer-wide compile timing.** All
+   three pool awaits (shader, compute, render) live at one site in
+   `AwsmRendererBuilder::build`. One place to instrument with
+   tracing spans, one place to read for per-pool wall-clock, one
+   place to reason about ordering invariants. The "happens to do
+   the same thing" relationship between startup and dynamic setters
+   becomes an *explicit* shared code path:
+   `set_anti_aliasing` and the orchestrator both call
+   `EffectsPipelines::install_resolved` against the same descriptor
+   shape.
+3. **Cleaner story for future `RendererFeatures` flags.** A new
+   feature gating a new pass becomes "skip a sub-range of cache
+   keys in `describe`'s output" — no chance of an
+   `if features.foo { foo.ensure_keys().await? }` sequential await
+   sneaking in past a future code reviewer.
+
+#### What Path A actually changes
+
+`RenderPasses::new` is the function that does the work today. It
+becomes a thin wrapper for the rare caller that wants the old
+"all-in-one" entry point (effectively only tests). The orchestrator
+in `AwsmRendererBuilder::build` calls the two halves directly:
+
   - `RenderPasses::describe(ctx, features) -> RenderPassesDescriptors`
     — sync apart from cache-hit shader resolution. Returns a struct
     carrying per-pass bind groups + `Vec<RenderPipelineCacheKey>` +
-    `Vec<ComputePipelineCacheKey>` + sub-range maps.
+    `Vec<ComputePipelineCacheKey>` + sub-range maps the orchestrator
+    uses to slice resolved keys back out per pass.
   - `RenderPasses::from_resolved(descriptors, compute_keys,
-    render_keys) -> RenderPasses` — sync; the orchestrator
-    hands back the resolved key slices.
-- **Path B (rejected):** Add `extra_compute_keys` /
-  `extra_render_keys` parameters to `RenderPasses::new` so the
-  orchestrator can stuff Picker + Lines cache keys in. Mechanically
-  smaller but `RenderPasses::new` would know about non-render-pass
-  subsystems — layering wart.
-- **Path C (rejected):** Pre-warm Picker + Lines pipelines via
-  their own `ensure_keys` running in parallel with
-  `RenderPasses::new`. Doesn't merge pools, only overlaps two
-  same-size waves — half a win.
+    render_keys) -> RenderPasses` — sync; the orchestrator hands
+    back the resolved key slices, each pass's `from_resolved` is
+    invoked internally to assemble the typed `RenderPass`.
+
+#### Paths rejected (and why)
+
+- **Path B:** Add `extra_compute_keys` / `extra_render_keys`
+  parameters to `RenderPasses::new` so the orchestrator can stuff
+  Picker + Lines cache keys in. Mechanically smaller but
+  `RenderPasses::new` would now know about non-render-pass
+  subsystems — and the type system can't catch a future caller
+  that forgets to pass the extras. Loses guarantees (1) and (3).
+- **Path C:** Pre-warm Picker + Lines pipelines via their own
+  `ensure_keys` running in parallel with `RenderPasses::new`.
+  Doesn't merge pools, only overlaps two same-size waves —
+  half a win on perf, no architectural improvement at all.
 
 #### What changes
 
@@ -743,15 +770,32 @@ let (compute_keys, render_keys) = futures::future::try_join(
 - [render_passes.rs](../../crates/renderer/src/render_passes.rs) — split `RenderPasses::new` into `describe` + `from_resolved`.
 - [lib.rs](../../crates/renderer/src/lib.rs) — orchestrator pulls the pool management up.
 
-#### Risk
+#### Risk + sizing
 
-The orchestration contract change is the real cost. Every render
-pass already has `build_descriptors` + `from_resolved`, so the
-per-pass refactor is minimal — it's the surrounding code in
-`RenderPasses::new` (the per-feature `if let Some(bg)` branching
-when assembling the pools) that has to move out. Aim for ~150–250
-line delta in render_passes.rs and a comparable expansion in
-lib.rs.
+The architectural-contract change is where the work is — the
+per-pass mechanical refactor is already done. Every existing
+render pass exposes `build_descriptors` + `from_resolved`, so the
+delta is concentrated in `RenderPasses::new`'s outer shell (the
+per-feature `if let Some(bg)` branching that today assembles the
+pools and runs the two `ensure_keys` awaits). That shell becomes
+two functions: `describe` carries the assembly + the `Vec<…>` +
+sub-range maps; `from_resolved` carries the per-pass fold-up.
+
+Expect ~150–250 line shuffle inside `render_passes.rs` (net mostly
+zero, since the orchestration moves but doesn't grow) and ~50–80
+new lines in `lib.rs`'s `build()` (the new pool-driving block that
+folds RenderPasses + Picker + Lines + Shadows + Effects + Display
+into one shader pool + one try_join'd compute+render pool).
+
+The dynamic-setter path needs careful preservation. The current
+contract: `set_anti_aliasing` / `set_post_processing` own their own
+batched `ensure_keys`. After Path A: the orchestrator at startup
+gets first crack at the cache (so the setters' subsequent calls
+all hit warm cache); the setter code path itself stays untouched
+for mid-session config flips. Verify by flipping MSAA off + Bloom
+on mid-session and confirming the pipelines recompile via the
+setter's own `ensure_keys` (now a cache miss the first time per
+new config) and the render output is correct.
 
 #### Checklist
 


### PR DESCRIPTION
After PR #95 landed the cross-pass shader + pipeline pool inside
`RenderPasses::new`, the remaining sequential pipeline-compile awaits
live in the **tail** of `AwsmRendererBuilder::build` —
Picker/LineRenderer/Shadows+EVSM/Effects/Display. This PR pools that
tail.

## What was sequential before

Five per-subsystem awaits at the end of `build()`:

  - `Picker::new` (2 compute pipelines)
  - `LineRenderer::load` (4 render pipelines)
  - `Shadows::new` (4 caster render + 3 EVSM compute pipelines, +
    3 EVSM inline-shader validations)
  - `set_anti_aliasing` (5 effects compute pipelines, transparent
    rebuild — empty at startup)
  - `set_post_processing` (effects rebuild + 1 display render pipeline)

## What it is now

Two awaits for the entire tail (after `RenderPasses::new` returns):

  - **One** `ComputePipelines::ensure_keys` covering 10 pipelines:
    picker(2) + EVSM(3) + effects(5).
  - **One** `RenderPipelines::ensure_keys` covering 9 pipelines:
    lines(4) + caster(4) + display(1).
  - Plus one cross-tail `Shaders::ensure_keys` joined in parallel
    with the 3 EVSM inline-shader `validate_shader` futures.

Each subsystem now follows the same split as Picker (already done
on the `parallel` branch): `build_descriptors` is sync apart from
cache-hit shader resolution, returns a `*Descriptors` blob carrying
cache keys + resource handles; `from_resolved` / `install_resolved`
consumes the resolved key slice the cross-tail pool hands back.

## Dynamic-setter path preserved

`set_anti_aliasing` and `set_post_processing` are also called
mid-session (MSAA off/on, post-processing config flips). The
existing setter entry points stay — they wrap the new
`build_descriptors` + per-subsystem `ensure_keys` +
`install_resolved` internally. The orchestrator's startup-time pool
short-circuits the setter recompile for the initial config.

## EVSM inline-shader hand-off

EVSM uses three inline-source WGSL shaders that bypass the shared
`Shaders` cache. `EvsmPass::build_descriptors` issues
`compile_shader` synchronously and surfaces the unawaited
`validate_shader` futures via `EvsmDescriptors::validate_shader_futures()`;
the orchestrator joins them in parallel with the cross-tail
`Shaders::ensure_keys` batch. After the join the orchestrator
registers the 3 modules via `Shaders::insert_uncached`, derives the
3 EVSM compute pipeline cache keys from the resulting `ShaderKey`s,
and folds them into the cross-tail compute pool.

## Verification

  - `cargo build --workspace` clean.
  - `cargo clippy --workspace --all-targets -- -D warnings` clean.
  - `cargo fmt --all -- --check` clean.
  - **model-tests** (Fox scene): renders correctly with IBL + shadows
    + Bloom toggle on. No console / GPU validation errors.
  - **scene-editor** (empty scene + Box primitive + Directional +
    Point + Spot lights, all with Cast: on): renders with no GPU
    validation errors. Exercises the cascade-array + EVSM moments +
    cube-array shadow code paths at once.
  - **Dynamic AA**: flipped MSAA off and back on mid-session — Fox
    re-renders correctly, the transparent + effects recompile path
    runs cleanly.
  - **Dynamic post-processing**: enabled Bloom mid-session — renders
    correctly through the preserved
    `EffectsPipelines::set_render_pipeline_keys` setter.

A fresh-profile Chrome trace is the user's manual capture step.
Expected delta vs commit `c428ddd`:
`domComplete → first 'Render [1]: span-enter'` drops by ~3 s on
cold load (5 sequential tail awaits → 2 pooled). Warm load: ~75 ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)