### PR TITLE
Resolve open review threads from PR #109

### DIFF
--- a/crates/frontend/material-editor/src/host.rs
+++ b/crates/frontend/material-editor/src/host.rs
@@ -444,7 +444,22 @@ impl RendererRecompileSink {
     /// rationale as `prewarm_holding_borrow`).
     #[allow(clippy::await_holding_refcell_ref)]
     async fn try_apply_inner(&mut self, reg: MaterialRegistration) -> Result<(), String> {
-        let mut guard = self.handle.borrow_mut();
+        // A fire-and-forget `prewarm_holding_borrow` spawned by a *previous*
+        // compile may still be holding the renderer borrow across its own
+        // `wait_for_pipelines_ready().await`. This path is driven by user
+        // keystrokes (debounced recompile), so colliding with that in-flight
+        // prewarm is plausible — a plain `borrow_mut()` would *panic* (single
+        // threaded, so it can't block). Acquire via `try_borrow_mut` instead,
+        // yielding to the event loop until the prewarm releases. Yield-and-
+        // retry rather than skip-this-edit: the user's latest edit must still
+        // apply. The borrow is free in the overwhelmingly common case, so this
+        // loop runs exactly once.
+        let mut guard = loop {
+            match self.handle.try_borrow_mut() {
+                Ok(guard) => break guard,
+                Err(_) => gloo_timers::future::TimeoutFuture::new(0).await,
+            }
+        };
         let host = match guard.as_mut() {
             Some(h) => h,
             None => {

--- a/crates/frontend/material-editor/src/state.rs
+++ b/crates/frontend/material-editor/src/state.rs
@@ -194,7 +194,7 @@ pub enum Starter {
     /// View-angle "soft glass" — the worked **transparent** example
     /// (`alpha_mode = Blend`). Demonstrates the transparent contract:
     /// `TransparentShadingInput` (world normal + `surface_to_camera`)
-    /// and a `TransparentShadingOutput(vec4)` with a Schlick-ish alpha.
+    /// and a `TransparentShadingOutput(vec4)` with a linear view-angle alpha.
     SoftGlass,
 }
 
@@ -354,8 +354,9 @@ return OpaqueShadingOutput(input.material.tint, 1.0);
 /// is more opaque at grazing angles. Mirrors
 /// `docs/dynamic-materials/contract-transparent.md` § Example.
 const SOFT_GLASS_WGSL: &str = r#"// soft-glass — the worked transparent material (alpha_mode = Blend).
-// Schlick-ish view-angle alpha: more opaque at grazing angles (edges of
-// curved surfaces), more transparent face-on. The output alpha drives the
+// Linear view-angle alpha: more opaque at grazing angles (edges of
+// curved surfaces), more transparent face-on — a straight `mix` on
+// `cos_theta`, not a Schlick `pow(1 - cos_theta, 5)` term. The output alpha drives the
 // standard (src.a, 1-src.a) blend; the kernel composites the opaque
 // background behind us automatically.
 let cos_theta = clamp(dot(input.world_normal, input.surface_to_camera), 0.0, 1.0);

--- a/crates/renderer/src/instances.rs
+++ b/crates/renderer/src/instances.rs
@@ -611,3 +611,84 @@ pub enum AwsmInstanceError {
     #[error("[instance] buffer capacity overflow: {0}")]
     BufferCapacityOverflow(String),
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use glam::{Quat, Vec3};
+
+    /// Regression for the per-instance transform stride bug fixed in
+    /// `5d34e71` (PR #109). The GPU per-instance vertex buffer is bound at a
+    /// 64-byte `mat4x4<f32>` stride; before the fix the offsets used the
+    /// 112-byte node-transform stride (matrix + normal matrix), so every
+    /// instance *after the first* was packed 48 bytes too far apart and the
+    /// GPU read garbage for it — garbling the geometry of any mesh with >1
+    /// instance.
+    ///
+    /// Exercise ≥2 instances (the >1 case is exactly what was broken) and
+    /// confirm each one lands on the 64-byte boundary and round-trips, so the
+    /// stride can never silently regress to the 112-byte node stride again.
+    #[test]
+    fn per_instance_transforms_packed_at_64_byte_stride() {
+        // The stride constant itself: equal to the GPU-bound vertex stride,
+        // and explicitly NOT the 112-byte node stride.
+        assert_eq!(INSTANCE_TRANSFORM_BYTE_SIZE, 64);
+        assert_eq!(
+            INSTANCE_TRANSFORM_BYTE_SIZE,
+            crate::meshes::buffer_info::MeshBufferVertexInfo::INSTANCING_BYTE_SIZE,
+        );
+        assert_ne!(
+            INSTANCE_TRANSFORM_BYTE_SIZE,
+            crate::transforms::Transforms::BYTE_SIZE,
+            "per-instance stride must not be the 112-byte node-transform stride",
+        );
+
+        // Three distinct instances, each with a different translation/scale so
+        // a wrong stride would read a neighbour's bytes and fail the compare.
+        let transforms = vec![
+            Transform {
+                translation: Vec3::new(1.0, 2.0, 3.0),
+                rotation: Quat::IDENTITY,
+                scale: Vec3::splat(1.0),
+            },
+            Transform {
+                translation: Vec3::new(-4.0, 5.0, -6.0),
+                rotation: Quat::from_rotation_y(std::f32::consts::FRAC_PI_3),
+                scale: Vec3::new(2.0, 0.5, 1.5),
+            },
+            Transform {
+                translation: Vec3::new(7.0, -8.0, 9.0),
+                rotation: Quat::from_rotation_x(std::f32::consts::FRAC_PI_4),
+                scale: Vec3::splat(3.0),
+            },
+        ];
+
+        let bytes = Instances::transforms_to_bytes(&transforms);
+        assert_eq!(
+            bytes.len(),
+            transforms.len() * INSTANCE_TRANSFORM_BYTE_SIZE,
+            "packed buffer must be exactly one 64-byte entry per instance",
+        );
+
+        // Read each instance back at the 64-byte stride (the same offset math
+        // the GPU vertex fetch uses) and confirm it round-trips.
+        for (index, expected) in transforms.iter().enumerate() {
+            let offset = index * INSTANCE_TRANSFORM_BYTE_SIZE;
+            let slice = &bytes[offset..offset + INSTANCE_TRANSFORM_BYTE_SIZE];
+            let values_f32 = unsafe {
+                std::slice::from_raw_parts(
+                    slice.as_ptr() as *const f32,
+                    INSTANCE_TRANSFORM_BYTE_SIZE / 4,
+                )
+            };
+            let got = Mat4::from_cols_slice(values_f32).to_cols_array();
+            let want = expected.to_matrix().to_cols_array();
+            for (g, w) in got.iter().zip(want.iter()) {
+                assert!(
+                    (g - w).abs() < 1e-6,
+                    "instance {index} matrix mismatch at the 64-byte stride: got {got:?}, want {want:?}",
+                );
+            }
+        }
+    }
+}

--- a/docs/dynamic-materials/contract-transparent.md
+++ b/docs/dynamic-materials/contract-transparent.md
@@ -180,8 +180,9 @@ Same list as opaque — see
 //
 // alpha_mode: Blend, double_sided: true
 
-// Schlick-ish view-angle alpha — more opaque at grazing angles
-// (edges of curved surfaces), more transparent face-on. The output
+// Linear view-angle alpha — more opaque at grazing angles
+// (edges of curved surfaces), more transparent face-on. A straight
+// `mix` on `cos_theta`, not a Schlick `pow(1 - cos_theta, 5)` term. The output
 // alpha drives the standard (src.a, 1-src.a) blend the transparent
 // pass uses; the kernel composites the dst (opaque background)
 // behind us automatically, so the dynamic shader doesn't have to


### PR DESCRIPTION
Follow-up to [#109](https://github.com/dakom/awsm-renderer/pull/109) (already merged), resolving its five open Copilot review threads. Three needed a code/doc change (one commit each); two were addressed by explanation and resolved without a commit.

## Commits

### 1. `test(instances)` — lock per-instance transform stride (`0554f57`)
Thread [3338787664](https://github.com/dakom/awsm-renderer/pull/109#discussion_r3338787664) flagged that the 112→64-byte per-instance stride fix (commit `5d34e71` on #109) is a **latent-bug fix orthogonal to the scanline removal** and lacked a ≥2-instance regression test. #109's description can't be amended post-merge, so noting it here: that stride bug garbled the geometry of *any* mesh with >1 instance and was fixed independently of the scanline work.

Added `instances::tests::per_instance_transforms_packed_at_64_byte_stride`: packs ≥2 distinct instances through `transforms_to_bytes`, reads each back at the 64-byte stride and asserts it round-trips, and guards the stride constant against silently regressing to `Transforms::BYTE_SIZE` (112).

### 2. `docs(transparent)` — "linear" not "Schlick-ish" alpha (`ac89379`)
Thread [3338787687](https://github.com/dakom/awsm-renderer/pull/109#discussion_r3338787687): the Soft Glass example computes its view-angle alpha with a straight `mix(edge_alpha, face_alpha, cos_theta)` — linear, not a Schlick `pow(1 - cos_theta, 5)` term. Renamed the comments in `state.rs` (starter) and `contract-transparent.md` so the prose matches the code.

### 3. `fix(material-editor)` — `try_borrow_mut` in `try_apply` (`8b3a8aa`)
Thread [3338787722](https://github.com/dakom/awsm-renderer/pull/109#discussion_r3338787722): `try_apply_inner` is keystroke-driven and holds the renderer `RefCell` borrow across the transparent-pipeline compile await. A fire-and-forget `prewarm_holding_borrow` from a previous compile can still hold that borrow across its own await, so a plain `borrow_mut()` at entry could panic (wasm is single-threaded — it can't block). Now acquires via `try_borrow_mut`, yielding to the event loop until the prewarm releases, rather than skipping (so the user's latest edit still applies). The borrow is free in the common case, so the loop runs once.

## Resolved without a commit

- **Shadow test fixtures** ([3338689399](https://github.com/dakom/awsm-renderer/pull/109#discussion_r3338689399)) — already removed in `674c28f` on #109.
- **`is_launchable_material` pre-filter** ([3338787701](https://github.com/dakom/awsm-renderer/pull/109#discussion_r3338787701)) — moot: the relaunch loop's `launchable` set comes only from `registered_material_shader_ids()`, which yields one id per entry already in `self.materials`, so `find_material_by_shader_id` returns `Some` for every id it iterates. The suggested filter would be a no-op.

## Verification
- `cargo fmt --all --check` + `cargo clippy --all --all-features --tests -- -D warnings` clean.
- `cargo test --all-features` green (new instances test passes; full suite unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)