### PR TITLE
ci: bump GitHub Actions to Node-24 releases

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -35,13 +35,18 @@ jobs:
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
+      # Install Trunk from its official release binary (rather than
+      # jetli/trunk-action, which still ships as a Node-20 action) — keeps the
+      # workflow free of deprecation warnings.
       - name: Install Trunk
-        uses: jetli/trunk-action@v0.5.0
-        with:
-          version: "latest"
+        run: |
+          set -euo pipefail
+          curl -fsSL https://github.com/trunk-rs/trunk/releases/download/v0.21.14/trunk-x86_64-unknown-linux-gnu.tar.gz \
+            | tar -xz -C "$HOME/.cargo/bin"
+          trunk --version
 
       - name: Install Task
-        uses: go-task/setup-task@v1
+        uses: go-task/setup-task@v2
 
       # `envsubst` ships with gettext-base; preinstalled on
       # ubuntu-latest at time of writing but cheap to ensure.
@@ -80,7 +85,7 @@ jobs:
           cp .build-artifacts/pages/index.html .build-artifacts/pages/404.html
 
       - name: Upload artifacts
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           name: github-pages
           path: ./.build-artifacts/pages
@@ -101,4 +106,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Clears the Node-20 deprecation warnings on the `pages` and `tests` workflows.

- `actions/checkout` v4 → v6
- `actions/upload-pages-artifact` v3 → v5
- `actions/deploy-pages` v4 → v5
- `go-task/setup-task` v1 → v2
- `jetli/trunk-action` (still a Node-20 action with no Node-24 release) → install Trunk from its pinned release binary (`v0.21.14`)

`Swatinem/rust-cache@v2` and `dtolnay/rust-toolchain@stable` were already current. Mirrors the same change already merged in awsm-audio (where both workflows are green with zero deprecation annotations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)