### PR TITLE
ci: make the publish tag step idempotent (resume a partial release)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -138,8 +138,15 @@ tasks:
           git commit -m "Release v{{.VERSION}}"
         fi
       # 3. Tag (annotated). Pushing this tag triggers the cargo-dist MCP-server
-      #    release on CI (.github/workflows/release.yml).
-      - git tag -a "v{{.VERSION}}" -m "v{{.VERSION}}"
+      #    release on CI (.github/workflows/release.yml). Idempotent like the
+      #    commit above: if the tag already exists (a re-run after a partial
+      #    release — e.g. crates.io rate-limited mid-publish), keep it and move on.
+      - |
+        if git rev-parse -q --verify "refs/tags/v{{.VERSION}}" >/dev/null; then
+          echo "  Tag v{{.VERSION}} already exists — keeping it (resuming a partial release)."
+        else
+          git tag -a "v{{.VERSION}}" -m "v{{.VERSION}}"
+        fi
       # 4. Publish the library crates to crates.io (the explicit, ordered set).
       - task: crates-publish
       # 5. Deploy both frontends to Cloudflare Pages (scene editor + model tester).


### PR DESCRIPTION
`task publish` creates the `v<version>` tag **before** publishing crates, so a crates.io failure mid-publish (e.g. the new-crate rate limit hit during the first `0.3.0` release) leaves the tag created locally — and re-running `task publish` then dies at `git tag -a` with *"tag already exists"*.

This skips the tag when it's already present (mirroring the already-idempotent commit step above it), so a re-run **resumes** cleanly: crates skip the already-published ones, then deploy + push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)