### PR TITLE
Editor MCP UX: surface Help at top of connect modal + copy buttons on…

### DIFF
--- a/packages/frontend/editor/Cargo.toml
+++ b/packages/frontend/editor/Cargo.toml
@@ -80,4 +80,6 @@ features = [
     "Url",
     "BroadcastChannel",
     "MessageEvent",
+    # navigator().clipboard().write_text() — the help modal's copy buttons.
+    "Clipboard",
 ]

--- a/packages/frontend/editor/src/app.rs
+++ b/packages/frontend/editor/src/app.rs
@@ -855,11 +855,27 @@ fn open_mcp_modal() {
             .style("display", "flex")
             .style("flex-direction", "column")
             .style("gap", "14px")
+            // Header: title on the left, Help on the right (easy to spot — the
+            // guide is the first thing a new user wants).
             .child(html!("div", {
-                .style("font-size", "15px")
-                .style("font-weight", "600")
-                .style("color", "var(--text-0)")
-                .text("MCP server")
+                .style("display", "flex")
+                .style("align-items", "center")
+                .style("justify-content", "space-between")
+                .style("gap", "8px")
+                .child(html!("div", {
+                    .style("font-size", "15px")
+                    .style("font-weight", "600")
+                    .style("color", "var(--text-0)")
+                    .text("MCP server")
+                }))
+                .child(Btn::new()
+                    .label("Help")
+                    .icon("help")
+                    .variant(BtnVariant::Ghost)
+                    .size(BtnSize::Sm)
+                    .title("How the MCP works — open the guide")
+                    .on_click(|| { Modal::close(); crate::help_modal::open_help_mcp(); })
+                    .render())
             }))
             .child(html!("div", {
                 .style("font-size", "12.5px")
@@ -953,21 +969,13 @@ fn open_mcp_modal() {
             // Live work display — the activity feed (narration + panel spotlight)
             // that lets you watch the agent build. Also under Settings.
             .child(row("Follow agent activity", toggle(crate::engine::activity_feed::enabled())))
-            // Action: Help on the left; Connect / Connecting… / Disconnect on the
-            // right, by live status.
+            // Action: Connect / Connecting… / Disconnect, by live status. (Help
+            // lives in the header now.)
             .child(html!("div", {
                 .style("display", "flex")
-                .style("justify-content", "space-between")
+                .style("justify-content", "flex-end")
                 .style("align-items", "center")
                 .style("margin-top", "4px")
-                .child(Btn::new()
-                    .label("Help")
-                    .icon("help")
-                    .variant(BtnVariant::Ghost)
-                    .size(BtnSize::Md)
-                    .title("How the MCP works — open the guide")
-                    .on_click(|| { Modal::close(); crate::help_modal::open_help_mcp(); })
-                    .render())
                 .child_signal(crate::remote::status().signal().map(clone!(addr => move |st| {
                     Some(match st {
                         RemoteStatus::Connected => Btn::new()

--- a/packages/frontend/editor/src/help_modal.rs
+++ b/packages/frontend/editor/src/help_modal.rs
@@ -87,20 +87,68 @@ fn p(text: &str) -> Dom {
     })
 }
 
-/// A monospace code / command block (multi-line, horizontally scrollable).
-fn code(text: &str) -> Dom {
+/// A monospace code / command block (multi-line, horizontally scrollable) with a
+/// clipboard button in its top-right corner — the install/connect commands are
+/// long and awkward to select by hand. The button flashes ✓ on a successful copy.
+fn code(text: &'static str) -> Dom {
+    let copied = Mutable::new(false);
     html!("div", {
-        .class("mono")
-        .style("font-size", "11.5px")
-        .style("color", "var(--text-1)")
-        .style("background", "var(--bg-3)")
-        .style("border", "1px solid var(--line-soft)")
-        .style("border-radius", "var(--r1)")
-        .style("padding", "7px 9px")
-        .style("overflow-x", "auto")
-        .style("white-space", "pre")
-        .text(text)
+        .style("position", "relative")
+        .child(html!("div", {
+            .class("mono")
+            .style("font-size", "11.5px")
+            .style("color", "var(--text-1)")
+            .style("background", "var(--bg-3)")
+            .style("border", "1px solid var(--line-soft)")
+            .style("border-radius", "var(--r1)")
+            // Extra right padding so long lines don't run under the copy button.
+            .style("padding", "7px 34px 7px 9px")
+            .style("overflow-x", "auto")
+            .style("white-space", "pre")
+            .text(text)
+        }))
+        .child(html!("button", {
+            .style("position", "absolute")
+            .style("top", "5px")
+            .style("right", "5px")
+            .style("display", "inline-flex")
+            .style("align-items", "center")
+            .style("justify-content", "center")
+            .style("width", "22px")
+            .style("height", "22px")
+            .style("padding", "0")
+            .style("cursor", "pointer")
+            .style("border-radius", "var(--r1)")
+            .style("background", "var(--bg-2)")
+            .style("border", "1px solid var(--line-soft)")
+            .style("font-size", "12px")
+            .style("line-height", "1")
+            .style_signal("color", copied.signal().map(|c| {
+                if c { "var(--ok)" } else { "var(--text-2)" }
+            }))
+            .attr("title", "Copy to clipboard")
+            .text_signal(copied.signal().map(|c| if c { "\u{2713}" } else { "\u{1F4CB}" }))
+            .event(clone!(copied => move |_: events::Click| {
+                copy_to_clipboard(text);
+                copied.set(true);
+                spawn_local(clone!(copied => async move {
+                    gloo_timers::future::TimeoutFuture::new(1200).await;
+                    copied.set(false);
+                }));
+            }))
+        }))
     })
+}
+
+/// Write `text` to the OS clipboard (fire-and-forget; the promise is driven to
+/// completion so the browser doesn't log an unhandled rejection).
+fn copy_to_clipboard(text: &str) {
+    if let Some(win) = web_sys::window() {
+        let promise = win.navigator().clipboard().write_text(text);
+        spawn_local(async move {
+            let _ = wasm_bindgen_futures::JsFuture::from(promise).await;
+        });
+    }
 }
 
 /// A vertical stack wrapping one tab's content.


### PR DESCRIPTION
… commands

- Move the connect modal's Help button from the bottom action row up into the header (top-right, next to the "MCP server" title) so it's easy to find; the bottom row now just holds Connect/Disconnect.
- Add a clipboard button to each command block in the Help modal (install / run / connect commands are long and awkward to hand-select). Flashes ✓ on copy. Mirrors the audio editor's help-modal prior art; enables the web-sys Clipboard feature.