### PR TITLE
Rename the recommended MCP server key to `awsm-scene`

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,6 +1,6 @@
 {
   "mcpServers": {
-    "awsm-editor": {
+    "awsm-scene": {
       "type": "http",
       "url": "http://127.0.0.1:9086/mcp"
     }

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ From source (needs Rust): `cargo install --git https://github.com/awsm-fun/awsm-
    ```json
    {
      "mcpServers": {
-       "awsm-editor": { "type": "http", "url": "http://127.0.0.1:9086/mcp" }
+       "awsm-scene": { "type": "http", "url": "http://127.0.0.1:9086/mcp" }
      }
    }
    ```

--- a/docs/DEBUGGING-PREVIEW.md
+++ b/docs/DEBUGGING-PREVIEW.md
@@ -37,7 +37,7 @@ renderer load never touches the Claude app.
 
 > **Driving the editor specifically?** Prefer the **MCP bridge** over raw
 > `javascript_tool`: run `task mcp-dev`, load the editor at
-> `http://localhost:9085/?mcp=http://127.0.0.1:9086`, and call the `awsm-editor`
+> `http://localhost:9085/?mcp=http://127.0.0.1:9086`, and call the `awsm-scene`
 > MCP tools (`get_snapshot`, `node_set_transform`, `screenshot_scene`, …). That
 > path goes through the editor's command/query authority instead of poking the
 > DOM. See the README's "Driving the editor from an AI agent" section and

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -82,7 +82,7 @@ sync, and undo/redo/coalescing all work as in the UI.
    ```json
    {
      "mcpServers": {
-       "awsm-editor": { "type": "http", "url": "http://127.0.0.1:9086/mcp" }
+       "awsm-scene": { "type": "http", "url": "http://127.0.0.1:9086/mcp" }
      }
    }
    ```


### PR DESCRIPTION
The bundled .mcp.json registered the server as `awsm-editor`; the in-app Help modal already recommends `awsm-scene`. Standardize on `awsm-scene` across .mcp.json and the README / MCP / debugging docs so copy-paste setup matches the guide. Crate names (awsm-editor, awsm-editor-protocol) are unchanged — this is only the agent-facing server label.