### PR TITLE
fix(publish): add awsm-renderer-lod-bake to crates publish list

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -198,7 +198,7 @@ tasks:
     cmds:
       - |
         set -eu
-        CRATES="awsm-renderer-curves awsm-renderer-geometry awsm-renderer-tangents awsm-renderer-scene awsm-renderer-core awsm-renderer-materials awsm-renderer-particles awsm-renderer-meshgen awsm-renderer awsm-renderer-glb-export awsm-renderer-gltf awsm-renderer-gltf-convert awsm-renderer-scene-loader"
+        CRATES="awsm-renderer-curves awsm-renderer-geometry awsm-renderer-tangents awsm-renderer-scene awsm-renderer-core awsm-renderer-materials awsm-renderer-particles awsm-renderer-meshgen awsm-renderer awsm-renderer-glb-export awsm-renderer-gltf awsm-renderer-gltf-convert awsm-renderer-lod-bake awsm-renderer-scene-loader"
         # Workspace version (first `version = "…"` inside [workspace.package]).
         VERSION="$(awk '/^\[workspace\.package\]/{f=1} f&&/^version = /{gsub(/[",]/,"");print $3;exit}' Cargo.toml)"
         case "{{.PUBLISH_ARGS}}" in *--dry-run*) DRY=1;; *) DRY=0;; esac


### PR DESCRIPTION
## What

`task publish -- 0.4.1` failed at `awsm-renderer-scene-loader` with:

```
error: failed to prepare local package for uploading
Caused by:
  no matching package named `awsm-renderer-lod-bake` found
```

`scene-loader` depends on `awsm-renderer-lod-bake`, but that crate was missing from the explicit, ordered `CRATES` list in `_crates-publish` (Taskfile.yml). Since the list — not `--workspace` — drives what gets published, `lod-bake` never went out, and `scene-loader`'s publish couldn't resolve it on the crates.io index.

## Fix

Add `awsm-renderer-lod-bake` to the publish list, positioned just before `awsm-renderer-scene-loader`. It's a leaf crate (only external deps: `glam`, `serde`) and `scene-loader` is its only in-workspace dependent, so leaf-first ordering holds.

## Release status

The release was resumed after this fix and completed:
- `awsm-renderer-lod-bake@0.4.1` and `awsm-renderer-scene-loader@0.4.1` published to crates.io (rest were already up).
- Both frontends deployed to Cloudflare Pages.
- Tag `v0.4.1` pushed (triggers the cargo-dist MCP binary release on CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)