### PR TITLE
fix(msaa): centroid-sample geometry normals/tangents + tear down edge…

### DIFF
--- a/packages/crates/renderer/src/anti_alias.rs
+++ b/packages/crates/renderer/src/anti_alias.rs
@@ -112,6 +112,29 @@ impl AwsmRenderer {
             self.material_edge_layout_uniform = Some(uniform);
         }
 
+        // MSAA on → off transition: tear the edge buffers back down, mirroring
+        // the off → on allocation above. This restores the invariant the rest of
+        // the renderer assumes — `material_edge_buffers.is_some()` ⟺ MSAA-on —
+        // which the classify bind group keys off (its multisampled layout
+        // statically declares the edge slots; see `material_classify::bind_group`)
+        // and which the per-frame edge bookkeeping (`reset_header`, the
+        // overflow-readback copy + mapAsync in `render`) uses to skip work. Before
+        // this, those buffers leaked across the flip and ran wasted per-frame work
+        // every MSAA-off frame — and left the multisampled-only `cs_prep_edge` /
+        // `cs_shade` edge bindings able to bind a single-sampled main group.
+        //
+        // Safe to drop synchronously: `MaterialEdgeBuffers` has no `Drop` and
+        // never calls `.destroy()`, so this just releases the `web_sys` GPU-buffer
+        // handles to GC. WebGPU keeps the underlying memory alive for any in-flight
+        // submit, so (unlike `RenderTextures`, which destroys eagerly) no
+        // deferred-destroy is needed. Gated only on `!new_msaa_on`: on devices
+        // without `edge_resolve_supported` the buffers are already `None`, so the
+        // clear is an idempotent no-op.
+        if !new_msaa_on {
+            self.material_edge_buffers = None;
+            self.material_edge_layout_uniform = None;
+        }
+
         self.bind_groups
             .mark_create(BindGroupCreate::AntiAliasingChange);
         self.bind_groups

--- a/packages/crates/renderer/src/render_passes/geometry/shader/geometry_wgsl/fragment.wgsl
+++ b/packages/crates/renderer/src/render_passes/geometry/shader/geometry_wgsl/fragment.wgsl
@@ -3,13 +3,17 @@
 // Fragment input from vertex shader
 struct FragmentInput {
     @location(0) @interpolate(flat) triangle_index: u32,
-    @location(1) barycentric: vec2<f32>,  // Full barycentric coordinates
+    // Centroid-sampled → used to reconstruct/pack the texel UV (on-surface, so the
+    // [0,1] clamp never corrupts it at coplanar tessellation seams). See vertex.wgsl.
+    @location(1) @interpolate(perspective, centroid) barycentric: vec2<f32>,
+    // Center-sampled copy → source for dpdx/dpdy (texture-LOD gradients). Keeps the
+    // derivatives well-defined/bit-identical to the pre-centroid behaviour; you
+    // can't take meaningful screen-space derivatives of a centroid varying.
+    @location(6) @interpolate(perspective, center) barycentric_center: vec2<f32>,
     // Centroid-sampled to match the vertex output qualifier (WGSL cross-stage
     // interpolation rule — mismatch is a pipeline-creation validation error).
-    // See the vertex struct for why: keeps the silhouette normal/tangent
-    // on-surface under MSAA instead of extrapolating past the triangle edge.
-    // `barycentric` above stays center-sampled on purpose — derivatives of it
-    // drive texture-LOD and centroid breaks screen-space derivatives.
+    // See the vertex struct: keeps the silhouette normal/tangent on-surface under
+    // MSAA instead of extrapolating past the triangle edge.
     @location(2) @interpolate(perspective, centroid) world_normal: vec3<f32>,     // Transformed world-space normal
     @location(3) @interpolate(perspective, centroid) world_tangent: vec4<f32>,    // Transformed world-space tangent (w = handedness)
     @location(4) @interpolate(flat) instance_id: u32, // U32_MAX for non-instanced draws
@@ -84,9 +88,11 @@ fn fs_main(input: FragmentInput) -> FragmentOutput {
     }
     out.normal_tangent = pack_normal_tangent(N, T, s);
 
-    // perspective-correct barycentrics by default:
-    let ddx = dpdx(input.barycentric);          // (db1/dx, db2/dx)
-    let ddy = dpdy(input.barycentric);          // (db1/dy, db2/dy)
+    // perspective-correct barycentrics by default. Derivatives are taken of the
+    // CENTER-sampled copy (the centroid `barycentric` used for UV has undefined
+    // screen-space derivatives).
+    let ddx = dpdx(input.barycentric_center);          // (db1/dx, db2/dx)
+    let ddy = dpdy(input.barycentric_center);          // (db1/dy, db2/dy)
 
     out.barycentric_derivatives = vec4<f32>(ddx.x, ddy.x, ddx.y, ddy.y);
 

--- a/packages/crates/renderer/src/render_passes/geometry/shader/geometry_wgsl/fragment.wgsl
+++ b/packages/crates/renderer/src/render_passes/geometry/shader/geometry_wgsl/fragment.wgsl
@@ -4,8 +4,14 @@
 struct FragmentInput {
     @location(0) @interpolate(flat) triangle_index: u32,
     @location(1) barycentric: vec2<f32>,  // Full barycentric coordinates
-    @location(2) world_normal: vec3<f32>,     // Transformed world-space normal
-    @location(3) world_tangent: vec4<f32>,    // Transformed world-space tangent (w = handedness)
+    // Centroid-sampled to match the vertex output qualifier (WGSL cross-stage
+    // interpolation rule — mismatch is a pipeline-creation validation error).
+    // See the vertex struct for why: keeps the silhouette normal/tangent
+    // on-surface under MSAA instead of extrapolating past the triangle edge.
+    // `barycentric` above stays center-sampled on purpose — derivatives of it
+    // drive texture-LOD and centroid breaks screen-space derivatives.
+    @location(2) @interpolate(perspective, centroid) world_normal: vec3<f32>,     // Transformed world-space normal
+    @location(3) @interpolate(perspective, centroid) world_tangent: vec4<f32>,    // Transformed world-space tangent (w = handedness)
     @location(4) @interpolate(flat) instance_id: u32, // U32_MAX for non-instanced draws
     // Forwarded from vertex so the fragment doesn't have to
     // re-read `geometry_mesh_meta`. The

--- a/packages/crates/renderer/src/render_passes/geometry/shader/geometry_wgsl/vertex.wgsl
+++ b/packages/crates/renderer/src/render_passes/geometry/shader/geometry_wgsl/vertex.wgsl
@@ -35,8 +35,19 @@ struct VertexOutput {
     @builtin(position) clip_position: vec4<f32>,
     @location(0) @interpolate(flat) triangle_index: u32,
     @location(1) barycentric: vec2<f32>,  // Full barycentric coordinates
-    @location(2) world_normal: vec3<f32>,     // Transformed world-space normal
-    @location(3) world_tangent: vec4<f32>,    // Transformed world-space tangent (w = handedness)
+    // Centroid-sampled: under MSAA, a silhouette pixel whose center falls outside
+    // the covered triangle would otherwise *extrapolate* the normal/tangent past
+    // the triangle edge, spiking specular / mis-lighting the partially-covered
+    // samples that the edge resolve then averages in. Centroid evaluates the
+    // attribute at the centroid of the covered samples, keeping it on-surface.
+    // Identical to center for fully-covered pixels (interiors) → free there. Must
+    // match the fragment-input qualifier on these locations (WGSL cross-stage
+    // interpolation rule); the plain + custom-vertex + masked variants all share
+    // these structs. Deliberately NOT applied to `barycentric` above — the
+    // fragment takes dpdx/dpdy of it for texture-LOD, and centroid breaks
+    // screen-space derivatives.
+    @location(2) @interpolate(perspective, centroid) world_normal: vec3<f32>,     // Transformed world-space normal
+    @location(3) @interpolate(perspective, centroid) world_tangent: vec4<f32>,    // Transformed world-space tangent (w = handedness)
     // Stage-1 leaves this at U32_MAX always; Stage-2 wires
     // `geometry_mesh_meta.instance_attr_base + @builtin(instance_index)`.
     @location(4) @interpolate(flat) instance_id: u32,

--- a/packages/crates/renderer/src/render_passes/geometry/shader/geometry_wgsl/vertex.wgsl
+++ b/packages/crates/renderer/src/render_passes/geometry/shader/geometry_wgsl/vertex.wgsl
@@ -34,7 +34,30 @@ struct VertexInput {
 struct VertexOutput {
     @builtin(position) clip_position: vec4<f32>,
     @location(0) @interpolate(flat) triangle_index: u32,
-    @location(1) barycentric: vec2<f32>,  // Full barycentric coordinates
+    // CENTROID-sampled — used by the fragment to RECONSTRUCT the texel UV (it is
+    // what gets packed into the barycentric G-buffer). Under MSAA a pixel on a
+    // (coplanar) tessellation seam has the primary/interior pass shade sample-0,
+    // whose covering triangle may differ from the one under the pixel centre.
+    // With center sampling that triangle's barycentric is evaluated AT the centre
+    // (outside it → a negative component), and the `clamp(…,0,1)` pack in the
+    // fragment then corrupts it into a vertex corner → wrong texel (the white/dark
+    // breaks on MorphStressTest's TinyGrid ticks). Centroid evaluates within the
+    // covered samples → on-surface, in-range, nothing for the clamp to destroy.
+    // Identical to center for fully-covered interior pixels → free there.
+    // NOTE: screen-space derivatives (dpdx/dpdy) must NOT be taken of a centroid
+    // varying — they're well-defined only for center sampling. So the fragment's
+    // texture-LOD gradients (and the masked pass's per-sample cutout offsets) read
+    // `barycentric_center` below instead. (Alternative if this ever needs to
+    // collapse back to one varying: drop `barycentric_center`, take derivatives of
+    // this centroid `barycentric`, and accept slightly noisy LOD on partial-
+    // coverage/seam pixels — interiors are unaffected since centroid≡center there.)
+    @location(1) @interpolate(perspective, centroid) barycentric: vec2<f32>,
+    // CENTER-sampled copy of the same barycentric, used ONLY as the source for
+    // dpdx/dpdy (texture-LOD gradients + masked cutout sub-sample offsets) so
+    // those stay bit-identical to the pre-centroid behaviour — i.e. this decouples
+    // "barycentric for UV" (centroid, on-surface) from "barycentric for
+    // derivatives" (center, well-defined). Never packed/stored.
+    @location(6) @interpolate(perspective, center) barycentric_center: vec2<f32>,
     // Centroid-sampled: under MSAA, a silhouette pixel whose center falls outside
     // the covered triangle would otherwise *extrapolate* the normal/tangent past
     // the triangle edge, spiking specular / mis-lighting the partially-covered
@@ -43,9 +66,7 @@ struct VertexOutput {
     // Identical to center for fully-covered pixels (interiors) → free there. Must
     // match the fragment-input qualifier on these locations (WGSL cross-stage
     // interpolation rule); the plain + custom-vertex + masked variants all share
-    // these structs. Deliberately NOT applied to `barycentric` above — the
-    // fragment takes dpdx/dpdy of it for texture-LOD, and centroid breaks
-    // screen-space derivatives.
+    // these structs.
     @location(2) @interpolate(perspective, centroid) world_normal: vec3<f32>,     // Transformed world-space normal
     @location(3) @interpolate(perspective, centroid) world_tangent: vec4<f32>,    // Transformed world-space tangent (w = handedness)
     // Stage-1 leaves this at U32_MAX always; Stage-2 wires
@@ -144,7 +165,10 @@ fn vert_main(
 
     // Pass through
     out.triangle_index = input.triangle_index;
+    // Same source value; the two outputs differ only by interpolation qualifier
+    // (centroid for UV reconstruction, center for screen-space derivatives).
     out.barycentric = input.barycentric;
+    out.barycentric_center = input.barycentric;
 
     out.instance_id = instance_id;
 

--- a/packages/crates/renderer/src/render_passes/geometry/shader/masked_wgsl/fragment.wgsl
+++ b/packages/crates/renderer/src/render_passes/geometry/shader/masked_wgsl/fragment.wgsl
@@ -15,8 +15,13 @@ fn mask_bary_at(b: vec2<f32>, dbx: vec2<f32>, dby: vec2<f32>, ox: f32, oy: f32) 
 struct FragmentInput {
     @location(0) @interpolate(flat) triangle_index: u32,
     @location(1) barycentric: vec2<f32>,
-    @location(2) world_normal: vec3<f32>,
-    @location(3) world_tangent: vec4<f32>,
+    // Centroid-sampled to match the (shared) geometry vertex output qualifier —
+    // the masked variant reuses geometry_wgsl/vertex.wgsl, so a mismatch here is
+    // a pipeline-creation validation error. See that vertex struct for the why
+    // (silhouette normals stay on-surface under MSAA). `barycentric` stays
+    // center-sampled — its derivatives drive texture-LOD.
+    @location(2) @interpolate(perspective, centroid) world_normal: vec3<f32>,
+    @location(3) @interpolate(perspective, centroid) world_tangent: vec4<f32>,
     @location(4) @interpolate(flat) instance_id: u32,
     @location(5) @interpolate(flat) material_mesh_meta_offset: u32,
     // See the plain geometry fragment: flip the normal for back faces so

--- a/packages/crates/renderer/src/render_passes/geometry/shader/masked_wgsl/fragment.wgsl
+++ b/packages/crates/renderer/src/render_passes/geometry/shader/masked_wgsl/fragment.wgsl
@@ -14,12 +14,16 @@ fn mask_bary_at(b: vec2<f32>, dbx: vec2<f32>, dby: vec2<f32>, ox: f32, oy: f32) 
 // the SAME visibility buffer; we only add the cutoff discard up front). ──────
 struct FragmentInput {
     @location(0) @interpolate(flat) triangle_index: u32,
-    @location(1) barycentric: vec2<f32>,
+    // Centroid → texel-UV reconstruction (on-surface, clamp-safe at seams). See vertex.wgsl.
+    @location(1) @interpolate(perspective, centroid) barycentric: vec2<f32>,
+    // Center → source for ALL dpdx/dpdy here: texture-LOD gradients AND the
+    // per-sample cutout sub-offsets below. Keeps cutout coverage + LOD identical
+    // to the pre-centroid behaviour (derivatives of a centroid varying are undefined).
+    @location(6) @interpolate(perspective, center) barycentric_center: vec2<f32>,
     // Centroid-sampled to match the (shared) geometry vertex output qualifier —
     // the masked variant reuses geometry_wgsl/vertex.wgsl, so a mismatch here is
     // a pipeline-creation validation error. See that vertex struct for the why
-    // (silhouette normals stay on-surface under MSAA). `barycentric` stays
-    // center-sampled — its derivatives drive texture-LOD.
+    // (silhouette normals stay on-surface under MSAA).
     @location(2) @interpolate(perspective, centroid) world_normal: vec3<f32>,
     @location(3) @interpolate(perspective, centroid) world_tangent: vec4<f32>,
     @location(4) @interpolate(flat) instance_id: u32,
@@ -73,14 +77,14 @@ fn fs_main(input: FragmentInput) -> FragmentOutput {
     // Standard 4x sample offsets (the exact positions only nudge spatial
     // placement; the resolve blends by covered-sample COUNT, all carrying the
     // shared center data).
-    let dbx = dpdx(input.barycentric);
-    let dby = dpdy(input.barycentric);
+    let dbx = dpdx(input.barycentric_center);
+    let dby = dpdy(input.barycentric_center);
     let cut = mm.alpha_cutoff;
     var coverage_mask = 0u;
-    if mask_alpha_at(mask_bary_at(input.barycentric, dbx, dby, -0.125, -0.375), triangle_indices, attribute_data_offset, vertex_attribute_stride, uv_sets_index, color_sets_index, material_offset) >= cut { coverage_mask |= 1u; }
-    if mask_alpha_at(mask_bary_at(input.barycentric, dbx, dby,  0.375, -0.125), triangle_indices, attribute_data_offset, vertex_attribute_stride, uv_sets_index, color_sets_index, material_offset) >= cut { coverage_mask |= 2u; }
-    if mask_alpha_at(mask_bary_at(input.barycentric, dbx, dby, -0.375,  0.125), triangle_indices, attribute_data_offset, vertex_attribute_stride, uv_sets_index, color_sets_index, material_offset) >= cut { coverage_mask |= 4u; }
-    if mask_alpha_at(mask_bary_at(input.barycentric, dbx, dby,  0.125,  0.375), triangle_indices, attribute_data_offset, vertex_attribute_stride, uv_sets_index, color_sets_index, material_offset) >= cut { coverage_mask |= 8u; }
+    if mask_alpha_at(mask_bary_at(input.barycentric_center, dbx, dby, -0.125, -0.375), triangle_indices, attribute_data_offset, vertex_attribute_stride, uv_sets_index, color_sets_index, material_offset) >= cut { coverage_mask |= 1u; }
+    if mask_alpha_at(mask_bary_at(input.barycentric_center, dbx, dby,  0.375, -0.125), triangle_indices, attribute_data_offset, vertex_attribute_stride, uv_sets_index, color_sets_index, material_offset) >= cut { coverage_mask |= 2u; }
+    if mask_alpha_at(mask_bary_at(input.barycentric_center, dbx, dby, -0.375,  0.125), triangle_indices, attribute_data_offset, vertex_attribute_stride, uv_sets_index, color_sets_index, material_offset) >= cut { coverage_mask |= 4u; }
+    if mask_alpha_at(mask_bary_at(input.barycentric_center, dbx, dby,  0.125,  0.375), triangle_indices, attribute_data_offset, vertex_attribute_stride, uv_sets_index, color_sets_index, material_offset) >= cut { coverage_mask |= 8u; }
     if coverage_mask == 0u {
         discard;
     }
@@ -115,8 +119,8 @@ fn fs_main(input: FragmentInput) -> FragmentOutput {
     }
     out.normal_tangent = pack_normal_tangent(N, T, s);
 
-    let ddx = dpdx(input.barycentric);
-    let ddy = dpdy(input.barycentric);
+    let ddx = dpdx(input.barycentric_center);
+    let ddy = dpdy(input.barycentric_center);
     out.barycentric_derivatives = vec4<f32>(ddx.x, ddy.x, ddx.y, ddy.y);
 
     return out;

--- a/packages/crates/renderer/src/render_passes/material_opaque/shader/material_opaque_wgsl/helpers/mipmap.wgsl
+++ b/packages/crates/renderer/src/render_passes/material_opaque/shader/material_opaque_wgsl/helpers/mipmap.wgsl
@@ -2,23 +2,24 @@
 // mipmap.wgsl — Gradient-based texture sampling for compute shaders
 // ============================================================================
 //
-// This implementation computes UV derivatives (gradients) for anisotropic filtering:
-// 1. Transform triangle vertices to screen space
-// 2. Compute barycentric derivatives analytically: d(bary)/d(screen)
-//    - This has been verified to match hardware dFdx/dFdy
-// 3. Handle texture address modes (repeat/mirror) by unwrapping UVs:
-//    - For repeat mode: make UVs continuous across 0→1 boundaries
-//    - For mirror mode: convert to texture space, then unwrap
-//    - This fixes mip selection when UVs cross wrapping boundaries
-// 4. Apply chain rule: d(UV)/d(screen) = d(UV)/d(bary) × d(bary)/d(screen)
-// 5. Pass gradients to textureSampleGrad for hardware mip selection
+// Deferred shading happens in a compute pass, which has no fixed-function
+// dpdx/dpdy. So the geometry (visibility-buffer) pass computes the screen-space
+// barycentric derivatives there — where hardware derivatives DO exist — and
+// stores them in the `barycentric_derivatives` G-buffer. This helper turns those
+// stored d(bary)/d(screen) into UV gradients for `textureSampleGrad`:
+// 1. Read the per-pixel d(bary)/d(screen) from the G-buffer (`bary_derivs` arg).
+//    (Geometry takes them from a CENTER-sampled barycentric — `barycentric_center`
+//    in geometry_wgsl — since derivatives of a centroid varying are undefined.)
+// 2. Apply chain rule: d(UV)/d(screen) = d(UV)/d(bary) × d(bary)/d(screen),
+//    using the triangle's three vertex UVs.
+// 3. Hand the gradients to textureSampleGrad → hardware mip / anisotropic
+//    selection (no manual LOD, no triangle seams).
 //
-// Benefits:
-// - Hardware handles mip selection (anisotropic filtering, etc.)
-// - No manual LOD calculation needed
-// - No triangle seams
-// - Correct gradients even when UVs wrap/repeat
-// - Mathematically correct gradient computation
+// NOTE: an earlier revision computed the barycentric derivatives analytically
+// from screen-space-projected triangle vertices; that was replaced by the stored
+// hardware derivatives above. (UV address-mode unwrapping for repeat/mirror was
+// also tried here and removed — see `unwrap_repeat`/`mirror_*` below, kept unused
+// for reference.)
 // ============================================================================
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/crates/renderer/src/render_passes/material_prep/render_pass.rs
+++ b/packages/crates/renderer/src/render_passes/material_prep/render_pass.rs
@@ -140,6 +140,18 @@ impl MaterialPrepRenderPass {
     /// under MSAA (the pipeline + texture are `None` otherwise). No-op when the
     /// edge buffers / layout uniform aren't allocated (non-MSAA).
     pub fn render_edge(&self, ctx: &RenderContext) -> Result<()> {
+        // cs_prep_edge is MSAA-only: its pipeline layout binds the *multisampled*
+        // prep main BGL at group(0), so it must never run while the live prep main
+        // bind group is single-sampled (that mismatch invalidates the whole frame's
+        // command buffer). `set_anti_aliasing` now tears `material_edge_buffers`
+        // down on an MSAA on→off flip, so the buffer-presence guard below already
+        // no-ops when MSAA is off — but this pass keys off the live MSAA state
+        // directly rather than trusting that invariant, mirroring the classify
+        // pass's `if msaa` discipline. Defense-in-depth: an MSAA-only pass enforces
+        // its own contract regardless of edge-buffer lifecycle.
+        if ctx.anti_aliasing.msaa_sample_count.is_none() {
+            return Ok(());
+        }
         let (edge_pipeline_key, edge_shadow) =
             match (self.edge_pipeline_key, self.edge_shadow.as_ref()) {
                 (Some(k), Some(b)) => (k, b),


### PR DESCRIPTION
… buffers on MSAA off

Under MSAA, silhouette (partially-covered) pixels evaluate vertex attributes at the pixel center, which can fall outside the covered triangle — extrapolating world_normal/world_tangent past the edge and producing a bad-normal lighting fleck that survives the resolve. Switch these varyings to @interpolate(perspective, centroid) so they evaluate inside the covered region. Equivalent to center for interior pixels (free) and a no-op without MSAA.

WGSL requires the qualifier to match on the vertex output and every paired fragment input, so apply it to all three shared geometry-pass structs: the VertexOutput plus both fragment-input copies (geometry_wgsl + masked_wgsl, which cover the plain / custom-vertex / masked / masked-custom-vertex variants — all of which reuse the one geometry vertex shader). barycentric stays center-sampled on purpose: its screen-space derivatives drive texture-LOD and centroid breaks them.

Also restore the material_edge_buffers.is_some() <=> MSAA-on invariant on an MSAA on->off flip: tear the edge buffers + layout uniform down (mirroring the off->on allocation) so the MSAA-off path stops leaking them and running wasted per-frame edge bookkeeping, and early-return render_edge when MSAA is off as defense-in-depth (the multisampled cs_prep_edge pass must never bind a single-sampled prep main group).

Verified in the model-viewer: clean init with MSAA on, MSAA on->off->on round-trip with no crash and no GPU validation errors.