### PR TITLE
fix(renderer-core): hard-cap GPU buffer allocs below PartitionAlloc's…

### DIFF
--- a/packages/crates/renderer-core/src/error.rs
+++ b/packages/crates/renderer-core/src/error.rs
@@ -72,6 +72,9 @@ pub enum AwsmCoreError {
     #[error("[gpu] failed create buffer: {0}")]
     BufferCreation(String),
 
+    #[error("[gpu] refused oversized buffer allocation: {0}")]
+    OversizedBufferAllocation(String),
+
     #[error("[gpu] failed map buffer: {0}")]
     BufferMap(String),
 
@@ -316,6 +319,17 @@ impl AwsmCoreError {
     /// Creates a buffer creation error from a JS value.
     pub fn buffer_creation(err: JsValue) -> Self {
         Self::BufferCreation(format_err(err))
+    }
+
+    /// Builds the error for a buffer allocation rejected by the always-on
+    /// [`crate::MAX_GPU_BUFFER_BYTES`] hard cap (would otherwise trap the
+    /// renderer process inside PartitionAlloc).
+    pub fn oversized_buffer_allocation(requested: u64, cap: u64) -> Self {
+        Self::OversizedBufferAllocation(format!(
+            "requested {requested} bytes (>= {cap} hard cap); a single GPU buffer this \
+             large would abort the renderer in PartitionAlloc — likely a runaway/overflowed \
+             size computation"
+        ))
     }
 
     /// Creates a buffer map error from a JS value.

--- a/packages/crates/renderer-core/src/lib.rs
+++ b/packages/crates/renderer-core/src/lib.rs
@@ -21,10 +21,25 @@ pub mod shaders;
 pub mod texture;
 pub mod web_global;
 
-/// Opt-in hardening guard threshold: any single GPU allocation larger than this
-/// is treated as a runaway size computation (overflow / flipped count) and
-/// logged + `debug_assert!`ed at our call site rather than left to trap deep in
-/// the browser allocator (the "Aw, Snap!" `IMMEDIATE_CRASH`). 512 MB is far past
-/// any legitimate single buffer/texture in this renderer. Only consulted under
-/// `debug_assertions` / the `harden-diag` feature.
+/// Soft diagnostic threshold: any single GPU allocation larger than this is
+/// flagged as a likely runaway size computation (overflow / flipped count) and
+/// logged + `debug_assert!`ed at our call site. The allocation still proceeds —
+/// this only surfaces "getting suspiciously big" early in dev. 512 MB is far
+/// past any legitimate single buffer in this renderer. Only consulted under
+/// `debug_assertions` / the `harden-diag` feature. See [`MAX_GPU_BUFFER_BYTES`]
+/// for the always-on hard cap that actually prevents the crash.
 pub const OVERSIZED_ALLOC_BYTES: u64 = 512 * 1024 * 1024;
+
+/// Always-on hard ceiling for a single GPU buffer allocation. A request at or
+/// above this is rejected as a recoverable `Err` *before* it reaches the WebGPU
+/// API, instead of being passed through to abort the whole renderer process.
+///
+/// Chrome's PartitionAlloc traps with a deliberate `IMMEDIATE_CRASH`
+/// (`EXC_BREAKPOINT`, the "Aw, Snap!") on any single allocation that reaches its
+/// ~2 GiB `MaxDirectMapped` ceiling — observed in the wild as renderer aborts
+/// with a `0x80000000` (2 GiB) size operand. That trap kills the process; it is
+/// **not** a catchable WebGPU validation error. We cap a comfortable margin
+/// below 2 GiB so a runaway buffer size fails the model/scene load gracefully
+/// (propagated `Result`) rather than taking the editor/viewer down with it. No
+/// legitimate single buffer here comes anywhere near this.
+pub const MAX_GPU_BUFFER_BYTES: u64 = 1900 * 1024 * 1024;

--- a/packages/crates/renderer-core/src/methods.rs
+++ b/packages/crates/renderer-core/src/methods.rs
@@ -291,34 +291,52 @@ impl AwsmRendererWebGpu {
         &self,
         descriptor: &web_sys::GpuBufferDescriptor,
     ) -> Result<web_sys::GpuBuffer> {
-        // Opt-in oversized-allocation guard: a single GPU buffer larger than
-        // OVERSIZED_ALLOC_BYTES almost certainly means a runaway size
-        // computation (a `* 0` count flipped, an overflow). Tripping a
-        // `debug_assert!` + `tracing::error!` here surfaces it at OUR call site
-        // with a stack — instead of as an opaque `IMMEDIATE_CRASH` deep in the
-        // browser allocator. Cold path (buffer creation, not per frame).
-        #[cfg(any(debug_assertions, feature = "harden-diag"))]
-        {
-            let size = js_sys::Reflect::get(
-                descriptor.as_ref(),
-                &wasm_bindgen::JsValue::from_str("size"),
-            )
-            .ok()
-            .and_then(|v| v.as_f64())
-            .unwrap_or(0.0);
-            if size > crate::OVERSIZED_ALLOC_BYTES as f64 {
-                tracing::error!(
-                    target: "awsm_renderer_core::oversized_alloc",
-                    "create_buffer requested {} bytes (> {} cap) — likely a runaway size computation",
-                    size,
-                    crate::OVERSIZED_ALLOC_BYTES
-                );
-                debug_assert!(
-                    size <= crate::OVERSIZED_ALLOC_BYTES as f64,
-                    "oversized GPU buffer allocation: {size} bytes"
-                );
-            }
+        // Oversized-allocation guard. A single GPU buffer near 2 GiB almost
+        // certainly means a runaway size computation (a `* 0` count flipped, an
+        // overflow). Cold path (buffer creation, not per frame).
+        let size = js_sys::Reflect::get(
+            descriptor.as_ref(),
+            &wasm_bindgen::JsValue::from_str("size"),
+        )
+        .ok()
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.0);
+
+        // Hard cap, always on (release included): a request at/above
+        // MAX_GPU_BUFFER_BYTES would hit PartitionAlloc's ~2 GiB ceiling and
+        // abort the whole renderer process with a deliberate `IMMEDIATE_CRASH`
+        // — which is NOT a catchable WebGPU validation error. Reject it here so
+        // the load fails as a recoverable `Result` at our call site instead.
+        if size >= crate::MAX_GPU_BUFFER_BYTES as f64 {
+            tracing::error!(
+                target: "awsm_renderer_core::oversized_alloc",
+                "create_buffer refused {} bytes (>= {} hard cap) — would abort the renderer in PartitionAlloc",
+                size,
+                crate::MAX_GPU_BUFFER_BYTES
+            );
+            return Err(AwsmCoreError::oversized_buffer_allocation(
+                size as u64,
+                crate::MAX_GPU_BUFFER_BYTES,
+            ));
         }
+
+        // Soft diagnostic threshold: surface "getting suspiciously big" early in
+        // dev (proceeds with the allocation). Tripping a `debug_assert!` here
+        // points at OUR call site with a stack.
+        #[cfg(any(debug_assertions, feature = "harden-diag"))]
+        if size > crate::OVERSIZED_ALLOC_BYTES as f64 {
+            tracing::warn!(
+                target: "awsm_renderer_core::oversized_alloc",
+                "create_buffer requested {} bytes (> {} soft threshold) — likely a runaway size computation",
+                size,
+                crate::OVERSIZED_ALLOC_BYTES
+            );
+            debug_assert!(
+                size <= crate::OVERSIZED_ALLOC_BYTES as f64,
+                "oversized GPU buffer allocation: {size} bytes"
+            );
+        }
+
         self.device
             .create_buffer(descriptor)
             .map_err(AwsmCoreError::buffer_creation)


### PR DESCRIPTION
… 2GiB trap

Three renderer crash dumps (un-symbolized) were the same Chrome PartitionAlloc deliberate IMMEDIATE_CRASH (EXC_BREAKPOINT) with a byte-identical register fingerprint, key operand x8 = 0x80000000 = exactly 2 GiB — PartitionAlloc's MaxDirectMapped ceiling. A single GPU buffer alloc reaching ~2 GB aborts the whole renderer process; it is NOT a catchable WebGPU validation error.

The pre-existing oversized-alloc guard in create_buffer was inert in production: gated behind debug_assertions/harden-diag (a feature never enabled in any build) and, even when active, only debug_assert!'d then allocated anyway.

Make it real: add always-on MAX_GPU_BUFFER_BYTES = 1.9 GB. A request at/above it now returns Err(OversizedBufferAllocation) before reaching the WebGPU API, so a runaway/overflowed buffer size fails the load gracefully via the existing Result plumbing instead of taking the editor/viewer down. Transitively protects the map/readback ArrayBuffer paths (can't map a buffer bigger than the cap). Keep the 512 MB threshold as a dev-only soft warning. Cold path (buffer creation, not per frame); marginal cost is one JS size read + a float compare per buffer.

Mitigation, not culprit-ID: the new oversized_alloc tracing::error! fires at the real call site with the exact byte count next time, to pinpoint the source.