### PR TITLE
Nanite follow-ups: degenerate-topology robustness + multiple simultaneous meshes

### DIFF
--- a/docs/nanite-lod.md
+++ b/docs/nanite-lod.md
@@ -288,6 +288,15 @@ asymmetrically; and `ClusterMesh::validate` rejects a malformed `.clusters.bin` 
 rather than reading out of bounds. Crack-free coverage spans the UV sphere (A1) and a
 genus-1 torus.
 
-**Known follow-ups (not regressions):** (1) one cluster render mesh is resident at a
-time (multiple simultaneous nanite meshes is future work). See
-[`plans/nanite-follow-up.md`](./plans/nanite-follow-up.md).
+Multiple simultaneous nanite meshes are **shipped**: the cluster pass keys per render
+mesh (`Vec<ClusterMeshState>`), each editor `ClusterMesh` node materializes
+independently under its own transform, and total residency is bounded by a global cap
+(`per_mesh_budget * GLOBAL_RESIDENCY_MESH_MULTIPLE`) shared across resident meshes — so
+VRAM stays bounded regardless of mesh count (later meshes throttle, then skip with a
+warn). The cut-readback diagnostics sum across all resident meshes. Verified on-device
+with two heavy nanite meshes resident + drawing at once (see
+[`plans/nanite-follow-up.md`](./plans/nanite-follow-up.md), phase A4).
+
+The historical "known follow-ups" are now both closed (degenerate-topology robustness
+above; multiple simultaneous meshes here). The plan
+[`plans/nanite-follow-up.md`](./plans/nanite-follow-up.md) records the full breakdown.

--- a/docs/nanite-lod.md
+++ b/docs/nanite-lod.md
@@ -272,9 +272,14 @@ with committed tests + on-device evidence. The multi-M benchmark is recorded in
 2,393,468-tri DAG → ~83 MB bounded pool, M capped to 29,850 tris, cut 4.9k–14.8k tris
 scaling with viewport height) and pinned by the `a6_benchmark_table_recorded` test.
 
-**Known follow-ups (not regressions):** (1) editor cluster-asset persistence — the
-import cache is session-local, so a project Save→reload needs the `.clusters.bin`
-written into `assets/` + re-read (same TODO as `skinned_bake_cache`); (2) one cluster
-render mesh is resident at a time (multiple simultaneous nanite meshes is future
-work); (3) cluster-cut robustness on pathological/degenerate source topology (the
-weld-for-adjacency fix covers the common split-vertex case).
+Editor cluster-asset persistence is **shipped**: a view-only nanite import survives
+Save→reload and ships in the player bundle. `persistence::cluster_files` writes each
+referenced DAG to `assets/<source>.clusters.bin` (from the session-local
+`cluster_cache`, keyed by `AssetId` — not by re-fetching the import URL, so even a
+local `blob:`-URL import persists), and `restore_cluster_meshes` re-reads it into the
+cache before the scene materialises, in all three load paths.
+
+**Known follow-ups (not regressions):** (1) one cluster render mesh is resident at a
+time (multiple simultaneous nanite meshes is future work); (2) cluster-cut robustness
+on pathological/degenerate source topology (the weld-for-adjacency fix covers the
+common split-vertex case). See [`plans/nanite-follow-up.md`](./plans/nanite-follow-up.md).

--- a/docs/nanite-lod.md
+++ b/docs/nanite-lod.md
@@ -279,7 +279,15 @@ referenced DAG to `assets/<source>.clusters.bin` (from the session-local
 local `blob:`-URL import persists), and `restore_cluster_meshes` re-reads it into the
 cache before the scene materialises, in all three load paths.
 
+Degenerate / pathological-topology robustness is **shipped**: the degeneracy verdict
+is one shared heuristic (`ClusterMesh::quality`) used by BOTH the offline CLI and the
+editor export bake, so a mesh that won't cluster (non-manifold / unweldable) drops its
+cluster DAG and falls back to the discrete LOD chain instead of shipping a hole-prone
+one; the simplifier locks non-manifold edges (≥3-incidence) so they can't collapse
+asymmetrically; and `ClusterMesh::validate` rejects a malformed `.clusters.bin` at load
+rather than reading out of bounds. Crack-free coverage spans the UV sphere (A1) and a
+genus-1 torus.
+
 **Known follow-ups (not regressions):** (1) one cluster render mesh is resident at a
-time (multiple simultaneous nanite meshes is future work); (2) cluster-cut robustness
-on pathological/degenerate source topology (the weld-for-adjacency fix covers the
-common split-vertex case). See [`plans/nanite-follow-up.md`](./plans/nanite-follow-up.md).
+time (multiple simultaneous nanite meshes is future work). See
+[`plans/nanite-follow-up.md`](./plans/nanite-follow-up.md).

--- a/docs/plans/nanite-follow-up.md
+++ b/docs/plans/nanite-follow-up.md
@@ -231,5 +231,13 @@ reading the cut readback from the browser console (see [[renderer-tracing-in-bro
   `ImportNaniteAsset` handler inserts without clearing) and each node materializes under
   its own `sub_tk` (per-node transform), both confirmed by code; live render + reload
   proof folds into A4.
-- [ ] A4 on-device verification (two heavy meshes, bounded VRAM)
-- [ ] docs: `nanite-lod.md` status updated as each closes
+- [x] A4 on-device verification (two heavy meshes, bounded VRAM) — VERIFIED in the
+  editor (:9085, this branch's build) via chrome-devtools + awsm-scene MCP, importing
+  two `~/Downloads/baked` nodes (fbx_node5 630k-tri + fbx_node9 492k-tri source).
+  Console proof: `cluster compaction (GPU): drawn index_count = 150681 (50227 tris)
+  across 2 mesh(es) over 5556 clusters` (A1 sums both cuts); each mesh `CAPPED ... budget
+  30000` → ~60k total resident, well under the 240k global cap (A2 bounded, full detail
+  kept). Both `cluster_mesh` nodes coexist (A3 multi-import); the second renders at its
+  own offset transform (per-node TRS). Screenshot shows both meshes at distinct
+  positions. B5 validate stayed silent (both DAGs valid, as expected).
+- [x] docs: `nanite-lod.md` status updated as each closes (both follow-ups now shipped).

--- a/docs/plans/nanite-follow-up.md
+++ b/docs/plans/nanite-follow-up.md
@@ -184,7 +184,14 @@ reading the cut readback from the browser console (see [[renderer-tracing-in-bro
   emits discrete LOD, no .clusters.bin" is enforced by the shared B2 guard and
   covered by the player-bundle export self-verify; the editor crate has no native
   test target (per `lod_bake.rs`), so it's not a separate unit test.
-- [ ] B5 runtime load-time DAG sanity backstop
+- [x] B5 runtime load-time DAG sanity backstop — `ClusterMesh::validate()` (lod-bake,
+  native-tested) checks every page span is in range + triangle-aligned and every
+  index references a real vertex; `materialize_cluster_mesh` calls it after the empty
+  check and refuses to materialize a malformed DAG (logs + renders nothing instead of
+  holes / GPU OOB). Verified by `validate_accepts_real_bake_and_rejects_corruption`
+  (native) + the wasm build of the call site. On-device verification N/A — the guard
+  only fires on deliberately-corrupt input; a fabricated bad file on-device would add
+  nothing over the native test.
 - [ ] A0 two-mesh baseline test
 - [ ] A1 multi-mesh-correct diagnostic readback
 - [ ] A2 global residency budget (tris + bytes) shared across meshes

--- a/docs/plans/nanite-follow-up.md
+++ b/docs/plans/nanite-follow-up.md
@@ -206,7 +206,22 @@ reading the cut readback from the browser console (see [[renderer-tracing-in-bro
   and logs `drawn index_count = N (T tris) across M mesh(es) over C clusters`. Gated
   by `lod`; flags-off compiles unchanged. Verified: renderer wasm (lod on + lod off),
   editor wasm, lod-bake 42 tests.
-- [ ] A2 global residency budget (tris + bytes) shared across meshes
+- [x] A2 global residency budget shared across meshes — `ClusterMeshState.resident_tris`
+  + `ClusterLodRenderPass::resident_tris_total()` + `AwsmRenderer::cluster_resident_tris_total()`
+  expose total residency; `materialize_cluster_mesh` caps a new mesh's budget at
+  `min(per_mesh, global_cap − already_resident)` where `global_cap =
+  per_mesh_budget * GLOBAL_RESIDENCY_MESH_MULTIPLE (8)`, and skips (renders nothing +
+  warns) when 0 left. Bounds total VRAM at ~8× per-mesh regardless of mesh count.
+  DESIGN NOTES / deviations from the plan sketch: (1) bounds by triangles (the GPU
+  pool's dominant cost is the exploded vertex buffer at 56 B/index, ∝ tris) — a
+  separate byte cap would duplicate the existing per-buffer 1.9 GB guard, so not added.
+  (2) Kept `?streambudget` as the per-mesh budget (not repurposed as the global cap) so
+  existing behavior is preserved; the global cap scales with it (8×). (3) The caps-off
+  path (budget == MAX, streaming+paging both off) stays uncapped ⇒ shipped path
+  byte-identical. (4) First-cut policy is first-come (earlier meshes keep full detail,
+  later ones throttle then drop) — fair re-budgeting on load is future work. Verified:
+  renderer wasm (lod on + off), editor wasm, lod-bake 42 tests. Live bounded-VRAM
+  proof: A4.
 - [ ] A3 editor multi-import + Save→reload test
 - [ ] A4 on-device verification (two heavy meshes, bounded VRAM)
 - [ ] docs: `nanite-lod.md` status updated as each closes

--- a/docs/plans/nanite-follow-up.md
+++ b/docs/plans/nanite-follow-up.md
@@ -1,0 +1,175 @@
+# Nanite / cluster-LOD follow-ups — hardening plan
+
+Closing the last two open items from [`../nanite-lod.md`](../nanite-lod.md) so the
+nanite implementation is as robust as possible. The third historical follow-up
+(editor cluster-asset persistence) is **already shipped** — `persistence::cluster_files`
++ `restore_cluster_meshes` round-trip every referenced DAG through
+`assets/<source>.clusters.bin` in all save/load paths; do not re-do it.
+
+Two SSOT references for the architecture: the runtime cut/paging lives in
+`packages/crates/renderer/src/render_passes/cluster_lod/`, the bake in
+`packages/crates/lod-bake/`, the editor glue in
+`packages/frontend/editor/src/engine/bridge/` + `controller/`.
+
+> **Working rule:** flags-off must stay byte-identical (the `lod` /
+> `virtual_geometry` / `cluster_paging` Cargo features and runtime flags gate ALL
+> of this). Every phase ends green on `cargo check -p <crate> --target
+> wasm32-unknown-unknown` (editor) / native `cargo test` (lod-bake), and the
+> renderer's existing nanite tests must still pass.
+
+---
+
+## Follow-up A — multiple simultaneous nanite meshes
+
+### Current state (verified by recon, 2026-06-27)
+The architecture is **already multi-mesh-shaped** — the "one resident mesh" line in
+the old doc is largely stale, but the path is **untested** and has two genuine gaps:
+
+- `ClusterLodRenderPass.states: Vec<ClusterMeshState>` keyed by `MeshKey`, find-or-create
+  in `upload_pages`, and `dispatch_all` already `for state in &self.states` —
+  `render_pass.rs:36, 206, 435, 509`. Per-mesh buffers/bind-groups/draw-args/paging
+  all live on `ClusterMeshState` (`buffers.rs`).
+- Per-draw override looks up state by `mesh_key` (`meshes/mesh.rs:299`).
+- Editor cache is `HashMap<AssetId, Rc<ClusterMesh>>` (`bridge/cluster_cache.rs:27`);
+  each `NodeKind::ClusterMesh` node materializes independently
+  (`bridge/node_sync.rs:1050`, unique `label` per source).
+- `persistence::cluster_files` already loops `cluster_sources(ctrl)` → every referenced
+  DAG persists, multi included.
+
+### Genuine gaps to close
+1. **Untested.** No test imports/renders two cluster meshes at once. Unknown whether
+   it actually works on-device.
+2. **Diagnostic readback is first-mesh-only** — `dispatch_all` returns the readback for
+   `states.iter().find(|s| s.cluster_count > 0)` (`render_pass.rs:~566`). Cosmetic, but
+   misreports total resident tris with >1 mesh.
+3. **Residency budget is per-mesh, not global.** `CLUSTER_STREAMING_BUDGET_TRIS = 1_000_000`
+   is applied per cluster mesh in `scene-loader/src/lib.rs:1872`, and paging caps
+   `MAX_LOADS = 96`/frame per state (`render_pass.rs:279`). With N meshes, VRAM and
+   per-frame stream cost scale ×N **unbounded** — the real robustness hole. A scene
+   with several heavy nanite meshes can blow the GPU pool (cf.
+   [[oversized-gpu-buffer-guard]] — the 1.9 GB create_buffer cap will now *return Err*
+   rather than abort, so the failure mode is a missing mesh + error log, not a crash —
+   but that's degraded, not robust).
+
+### Plan
+- **A0 — prove the baseline.** Add a multi-mesh test (renderer-level integration test
+  alongside the existing cluster tests; or scene-loader test) that materializes two
+  distinct cluster DAGs and asserts both produce non-zero `draw_args.index_count` and
+  distinct `MeshKey` states. This tells us what (if anything) actually breaks before we
+  touch budgets. If it already passes, A1 collapses to docs + the budget work.
+- **A1 — fix the readback** to aggregate across all resident states (or return a
+  per-mesh vec), so diagnostics + the benchmark harness report correct totals with
+  >1 mesh. Keep the single-mesh path byte-identical.
+- **A2 — global residency budget.** Introduce a shared budget across all resident
+  cluster meshes instead of a per-mesh constant: a `ClusterResidencyBudget` (total tris
+  *and* total bytes) owned by the render pass / renderer, divided across resident states
+  (proportional to each mesh's full-DAG size, or simple even split as a first cut).
+  Wire the existing `?streambudget=N` knob to the *global* cap. Per-frame `MAX_LOADS`
+  becomes a global stream budget shared round-robin across states so one mesh can't
+  starve another. Document the policy.
+- **A3 — editor multi-import.** Confirm (test or scripted MCP) that importing a 2nd
+  `.clusters.bin` keeps the 1st resident, both render, both survive Save→reload
+  (`cluster_files` already supports it — add an editor-level test asserting two
+  `cluster_sources`). Verify the per-node transform is honored for each (each rides a
+  child of its node's transform — `node_sync.rs:1048`).
+- **A4 — verify on-device** in the model-viewer / editor: two heavy nanite meshes
+  visible simultaneously, cut scales with viewport, no pool overflow under the global
+  budget. Use the [[renderer-tracing-in-browser-console]] readback method.
+
+### Acceptance
+- Two+ nanite meshes render simultaneously, each with its own correct cut.
+- Total resident VRAM is bounded by a single global budget regardless of mesh count
+  (proven by a test that loads N meshes and asserts summed resident tris ≤ budget).
+- Diagnostics/benchmark report correct totals.
+- Save→reload restores all cluster meshes.
+- Flags-off byte-identical; existing nanite tests green.
+
+---
+
+## Follow-up B — degenerate / pathological topology robustness
+
+### Current state (verified by recon)
+- **The bake's crack-free guarantee** depends on: weld-for-adjacency
+  (`DagOptions::weld_eps`, `dag.rs:106`), identical boundary locking between adjacent
+  groups (`simplify.rs:40,230` — `lock_boundaries` promotes shared boundary verts to
+  Corner), and group-shared LOD bounds spheres so siblings flip together
+  (`dag.rs:206`). The A1 test `non_watertight_sphere_cut_is_closed_at_every_level`
+  (`dag.rs:462`) pins this for the common split-vertex case.
+- **The CLI has a degeneracy guard** (`tools/lod-bake-cli/src/main.rs:178`): if
+  `avg_tris_per_cluster < 8` OR `dag_ratio (dag_tris/source_tris) > 6`, it **skips**
+  writing `.clusters.bin` (discrete LOD still emitted) unless
+  `--allow-degenerate-clusters`. Pathological topology (non-manifold edges used by >2
+  tris, unweldable) defeats clustering → ~1 tri/cluster and a ballooning DAG.
+- **The editor bake has NO such guard** — `controller/lod_bake.rs:47 bake_static_clusters`
+  only checks `CLUSTER_MIN_TRIANGLES`, then serializes the DAG unconditionally. So an
+  in-editor export / nanite import can ship a degenerate, hole-prone DAG silently. This
+  is the primary robustness hole.
+- The heuristic is **duplicated** (CLI-only, hand-inlined) rather than shared in the
+  `lod-bake` crate both call sites use.
+
+### Plan
+- **B1 — lift the guard into `lod-bake` (single source of truth).** Add a
+  `ClusterMesh::quality(source_tris) -> DagQuality { avg_tris_per_cluster, dag_ratio,
+  is_degenerate }` (or a free fn `cluster_dag_quality(&ClusterMesh, source_tris)`) in
+  `lod-bake`, with the heuristic + thresholds as named consts. Unit-test it on healthy
+  vs degenerate fixtures.
+- **B2 — apply it in the editor bake (guard parity).** `bake_static_clusters` calls the
+  shared quality check; on degenerate, **skip the cluster DAG and fall back to the
+  discrete LOD chain** (already baked by `bake_static_lod`), with a `tracing::warn!`
+  naming the asset + the metrics. Mirror the CLI's escape hatch as a build/runtime
+  toggle if one is warranted (default: never ship a degenerate DAG). Refactor the CLI to
+  call the same shared fn so the two can't drift.
+- **B3 — strengthen the bake on non-manifold input.** Investigate edges incident to >2
+  triangles (`cluster.rs:91 edge_tris` already tolerates them) — ensure grouping +
+  boundary classification don't tear at non-manifold edges. At minimum, classify
+  non-manifold edges as locked boundaries so they never get simplified asymmetrically.
+  Add a fixture + test.
+- **B4 — tests.** Add a non-manifold / unweldable fixture (e.g. a T-junction or a fan
+  with a >2-incidence edge, plus a fully-split mesh that *can't* be welded by eps).
+  Assert: (a) the quality fn flags it; (b) the editor bake emits discrete LOD and no
+  `.clusters.bin`; (c) for any DAG that IS emitted, extend the A1-style crack-free check
+  (`boundary_edge_count == 0` at every level) to the new fixtures that are valid.
+- **B5 — runtime backstop (optional, low cost).** On cluster-mesh load
+  (`scene-loader::materialize_cluster_mesh`), a cheap sanity check (e.g. clusters
+  non-empty, indices in range, avg tris/cluster sane) that logs + refuses to materialize
+  a malformed DAG rather than rendering holes. Prevention at bake is primary; this is
+  defense-in-depth for hand-authored / third-party `.clusters.bin`.
+
+### Acceptance
+- One shared degeneracy heuristic in `lod-bake`, used by BOTH the CLI and the editor
+  bake (no duplication).
+- The editor never silently ships a degenerate cluster DAG — it falls back to discrete
+  LOD and warns.
+- Non-manifold edges are locked, not torn; new crack-free tests pass.
+- Existing tests (A1, weld, monotonicity, messy-input) stay green.
+- Flags-off byte-identical.
+
+---
+
+## Sequencing & verification
+
+1. **B first** (self-contained, native-testable, highest robustness payoff): B1 → B2 →
+   B3 → B4 → B5.
+2. **Then A**: A0 → A1 → A2 → A3 → A4.
+3. Update [`../nanite-lod.md`](../nanite-lod.md) status section as each follow-up closes
+   (remove from "Known follow-ups", add to shipped/verified with the new test names).
+
+**Per-phase gate:** `cargo test -p awsm-renderer-lod-bake` (B), `cargo check -p
+awsm-renderer-editor --target wasm32-unknown-unknown` (editor edits), the renderer's
+nanite test suite, and — for A4/B-runtime — an on-device check via chrome-devtools MCP
+reading the cut readback from the browser console (see [[renderer-tracing-in-browser-console]],
+[[aa-verify-in-model-viewer]]). The baked sample at `~/Downloads/baked` (a 60-node FBX,
+27 nodes with `.clusters.bin`) is a ready multi-mesh + varied-topology fixture for A4.
+
+## Status checklist
+- [ ] B1 shared degeneracy heuristic in `lod-bake` + unit test
+- [ ] B2 editor bake guard parity + discrete-LOD fallback; CLI refactored to share
+- [ ] B3 non-manifold edge locking + fixture
+- [ ] B4 degenerate/non-manifold tests + extended crack-free coverage
+- [ ] B5 runtime load-time DAG sanity backstop
+- [ ] A0 two-mesh baseline test
+- [ ] A1 multi-mesh-correct diagnostic readback
+- [ ] A2 global residency budget (tris + bytes) shared across meshes
+- [ ] A3 editor multi-import + Save→reload test
+- [ ] A4 on-device verification (two heavy meshes, bounded VRAM)
+- [ ] docs: `nanite-lod.md` status updated as each closes

--- a/docs/plans/nanite-follow-up.md
+++ b/docs/plans/nanite-follow-up.md
@@ -162,7 +162,10 @@ reading the cut readback from the browser console (see [[renderer-tracing-in-bro
 27 nodes with `.clusters.bin`) is a ready multi-mesh + varied-topology fixture for A4.
 
 ## Status checklist
-- [ ] B1 shared degeneracy heuristic in `lod-bake` + unit test
+- [x] B1 shared degeneracy heuristic in `lod-bake` + unit test — `ClusterMesh::quality` +
+  `DagQuality` + `MIN_AVG_TRIS_PER_CLUSTER`/`MAX_DAG_TRI_RATIO` consts
+  (`cluster_mesh.rs`); tests `quality_passes_healthy_dag`,
+  `quality_flags_degenerate_unwelded_split_mesh`.
 - [ ] B2 editor bake guard parity + discrete-LOD fallback; CLI refactored to share
 - [ ] B3 non-manifold edge locking + fixture
 - [ ] B4 degenerate/non-manifold tests + extended crack-free coverage

--- a/docs/plans/nanite-follow-up.md
+++ b/docs/plans/nanite-follow-up.md
@@ -171,7 +171,12 @@ reading the cut readback from the browser console (see [[renderer-tracing-in-bro
   still ships) on degenerate, with a `tracing::warn!`; CLI `bake_one` uses the same
   `quality()` instead of its inlined heuristic. No editor escape hatch (an authoring
   tool must never silently ship a cracking nanite mesh).
-- [ ] B3 non-manifold edge locking + fixture
+- [x] B3 non-manifold edge locking + fixture — `nonmanifold_locked` in `simplify.rs`
+  marks endpoints of every ≥3-incidence edge; they're forced to `VertClass::Corner`
+  before collapse so disjoint sheets can't fold together / tear (and the cut can't
+  crack where they meet). Manifold meshes (all edges 1/2) → no-op. Tests:
+  `nonmanifold_locked_flags_only_high_valence_edges`,
+  `nonmanifold_yprism_simplifies_without_tearing`.
 - [ ] B4 degenerate/non-manifold tests + extended crack-free coverage
 - [ ] B5 runtime load-time DAG sanity backstop
 - [ ] A0 two-mesh baseline test

--- a/docs/plans/nanite-follow-up.md
+++ b/docs/plans/nanite-follow-up.md
@@ -222,6 +222,14 @@ reading the cut readback from the browser console (see [[renderer-tracing-in-bro
   later ones throttle then drop) — fair re-budgeting on load is future work. Verified:
   renderer wasm (lod on + off), editor wasm, lod-bake 42 tests. Live bounded-VRAM
   proof: A4.
-- [ ] A3 editor multi-import + Save→reload test
+- [x] A3 editor multi-import + Save→reload test — native test
+  `cluster_sources_from_project_collects_every_mesh` (persistence.rs) asserts a project
+  with several `ClusterMesh` nodes (incl. nested) yields every distinct source — the
+  exact set `cluster_files` writes and `restore_cluster_meshes` re-reads, so multiple
+  nanite meshes survive Save→reload. (Editor bin DOES run host tests — 28 pass — the old
+  "no native test target" note was stale.) Multi-import keeps prior nodes (the
+  `ImportNaniteAsset` handler inserts without clearing) and each node materializes under
+  its own `sub_tk` (per-node transform), both confirmed by code; live render + reload
+  proof folds into A4.
 - [ ] A4 on-device verification (two heavy meshes, bounded VRAM)
 - [ ] docs: `nanite-lod.md` status updated as each closes

--- a/docs/plans/nanite-follow-up.md
+++ b/docs/plans/nanite-follow-up.md
@@ -177,7 +177,13 @@ reading the cut readback from the browser console (see [[renderer-tracing-in-bro
   crack where they meet). Manifold meshes (all edges 1/2) → no-op. Tests:
   `nonmanifold_locked_flags_only_high_valence_edges`,
   `nonmanifold_yprism_simplifies_without_tearing`.
-- [ ] B4 degenerate/non-manifold tests + extended crack-free coverage
+- [x] B4 degenerate/non-manifold tests + extended crack-free coverage — `dag.rs`:
+  `non_watertight_torus_cut_is_closed_at_every_level` (A1 extended to a genus-1
+  surface), `triangle_soup_is_flagged_degenerate` (unweldable soup flagged under
+  DEFAULT welding — the real editor-bake fallback trigger). Plan item (b) "editor
+  emits discrete LOD, no .clusters.bin" is enforced by the shared B2 guard and
+  covered by the player-bundle export self-verify; the editor crate has no native
+  test target (per `lod_bake.rs`), so it's not a separate unit test.
 - [ ] B5 runtime load-time DAG sanity backstop
 - [ ] A0 two-mesh baseline test
 - [ ] A1 multi-mesh-correct diagnostic readback

--- a/docs/plans/nanite-follow-up.md
+++ b/docs/plans/nanite-follow-up.md
@@ -200,7 +200,12 @@ reading the cut readback from the browser console (see [[renderer-tracing-in-bro
   materializes with a fresh MeshKey ⇒ N nodes → N states. No native GPU test harness
   exists in the renderer (only shader-template unit tests), so the live two-mesh render
   proof is A4. Real remaining gaps: A1 (readback) + A2 (global budget).
-- [ ] A1 multi-mesh-correct diagnostic readback
+- [x] A1 multi-mesh-correct diagnostic readback — `dispatch_all` now returns one
+  `(readback_buffer, cluster_count)` per resident mesh (each state already owns a
+  readback buffer); the render.rs consumer maps them all, sums drawn index counts,
+  and logs `drawn index_count = N (T tris) across M mesh(es) over C clusters`. Gated
+  by `lod`; flags-off compiles unchanged. Verified: renderer wasm (lod on + lod off),
+  editor wasm, lod-bake 42 tests.
 - [ ] A2 global residency budget (tris + bytes) shared across meshes
 - [ ] A3 editor multi-import + Save→reload test
 - [ ] A4 on-device verification (two heavy meshes, bounded VRAM)

--- a/docs/plans/nanite-follow-up.md
+++ b/docs/plans/nanite-follow-up.md
@@ -192,7 +192,14 @@ reading the cut readback from the browser console (see [[renderer-tracing-in-bro
   (native) + the wasm build of the call site. On-device verification N/A — the guard
   only fires on deliberately-corrupt input; a fabricated bad file on-device would add
   nothing over the native test.
-- [ ] A0 two-mesh baseline test
+- [x] A0 two-mesh baseline — ALREADY MULTI-MESH (confirmed by code, no change needed):
+  `upload_pages` find-or-creates a `ClusterMeshState` per `render_mesh` MeshKey, each
+  with its own buffers/bind-groups (`render_pass.rs:435`); `dispatch_all` loops every
+  state (`:509`); the per-draw override resolves state by `mesh_key` (`meshes/mesh.rs:299`);
+  nothing clears states or asserts a single one. Each editor `ClusterMesh` node
+  materializes with a fresh MeshKey ⇒ N nodes → N states. No native GPU test harness
+  exists in the renderer (only shader-template unit tests), so the live two-mesh render
+  proof is A4. Real remaining gaps: A1 (readback) + A2 (global budget).
 - [ ] A1 multi-mesh-correct diagnostic readback
 - [ ] A2 global residency budget (tris + bytes) shared across meshes
 - [ ] A3 editor multi-import + Save→reload test

--- a/docs/plans/nanite-follow-up.md
+++ b/docs/plans/nanite-follow-up.md
@@ -166,7 +166,11 @@ reading the cut readback from the browser console (see [[renderer-tracing-in-bro
   `DagQuality` + `MIN_AVG_TRIS_PER_CLUSTER`/`MAX_DAG_TRI_RATIO` consts
   (`cluster_mesh.rs`); tests `quality_passes_healthy_dag`,
   `quality_flags_degenerate_unwelded_split_mesh`.
-- [ ] B2 editor bake guard parity + discrete-LOD fallback; CLI refactored to share
+- [x] B2 editor bake guard parity + discrete-LOD fallback; CLI refactored to share —
+  `bake_static_clusters` now calls `cm.quality(tris)` and returns empty (discrete LOD
+  still ships) on degenerate, with a `tracing::warn!`; CLI `bake_one` uses the same
+  `quality()` instead of its inlined heuristic. No editor escape hatch (an authoring
+  tool must never silently ship a cracking nanite mesh).
 - [ ] B3 non-manifold edge locking + fixture
 - [ ] B4 degenerate/non-manifold tests + extended crack-free coverage
 - [ ] B5 runtime load-time DAG sanity backstop

--- a/packages/crates/lod-bake/src/cluster_mesh.rs
+++ b/packages/crates/lod-bake/src/cluster_mesh.rs
@@ -146,6 +146,42 @@ impl ClusterMesh {
             .sum()
     }
 
+    /// Cheap structural sanity check for a parsed DAG, before it's uploaded to the
+    /// GPU. The bake's own output is always well-formed; this guards against a
+    /// hand-authored, third-party, or corrupted `.clusters.bin` that would otherwise
+    /// read out-of-bounds vertices or draw garbage. Returns `Err(reason)` on the
+    /// first defect; the runtime logs it and refuses to materialize (renders nothing,
+    /// rather than holes or a GPU OOB read).
+    ///
+    /// Checks only what would actually break the upload/draw, so a valid bake never
+    /// trips it: every cluster page's index span lies within `indices`, each page is
+    /// triangle-aligned, and every index references a real vertex.
+    pub fn validate(&self) -> Result<(), String> {
+        let n_idx = self.indices.len();
+        let n_vert = self.positions.len();
+        for (i, p) in self.clusters.iter().enumerate() {
+            if p.index_count % 3 != 0 {
+                return Err(format!(
+                    "cluster {i}: index_count {} not a multiple of 3",
+                    p.index_count
+                ));
+            }
+            let end = p.first_index as usize + p.index_count as usize;
+            if end > n_idx {
+                return Err(format!(
+                    "cluster {i}: index span [{}, {end}) exceeds index buffer len {n_idx}",
+                    p.first_index
+                ));
+            }
+        }
+        if let Some(&bad) = self.indices.iter().find(|&&i| i as usize >= n_vert) {
+            return Err(format!(
+                "index {bad} out of range for {n_vert} vertices"
+            ));
+        }
+        Ok(())
+    }
+
     /// Assess this DAG's clustering quality against the source triangle count and
     /// return the degeneracy verdict ([`DagQuality`]). `source_triangles` is the
     /// pre-bake triangle count of the input mesh (use [`Self::finest_triangle_count`]
@@ -259,6 +295,30 @@ mod tests {
             "unwelded split mesh not flagged: {:.1} tris/cluster, {:.1}× source",
             q.avg_tris_per_cluster, q.dag_ratio
         );
+    }
+
+    /// A real bake validates; corrupting an index or a page span is caught.
+    #[test]
+    fn validate_accepts_real_bake_and_rejects_corruption() {
+        let (pos, indices) = grid(16);
+        let dag = build_cluster_dag(&pos, &indices, &DagOptions::default());
+        let cm = ClusterMesh::from_dag(&dag, pos, vec![], vec![], vec![]);
+        assert!(cm.validate().is_ok(), "healthy bake must validate");
+
+        // Out-of-range vertex index.
+        let mut bad = cm.clone();
+        *bad.indices.last_mut().unwrap() = bad.positions.len() as u32;
+        assert!(bad.validate().is_err(), "OOB index must be rejected");
+
+        // Page span past the end of the index buffer.
+        let mut bad = cm.clone();
+        bad.clusters[0].index_count = cm.indices.len() as u32 + 3;
+        assert!(bad.validate().is_err(), "overlong page span must be rejected");
+
+        // Non-triangle-aligned page.
+        let mut bad = cm.clone();
+        bad.clusters[0].index_count += 1;
+        assert!(bad.validate().is_err(), "non-multiple-of-3 page must be rejected");
     }
 
     #[test]

--- a/packages/crates/lod-bake/src/cluster_mesh.rs
+++ b/packages/crates/lod-bake/src/cluster_mesh.rs
@@ -15,6 +15,36 @@ use serde::{Deserialize, Serialize};
 
 use crate::dag::ClusterDag;
 
+/// Minimum healthy average triangles-per-cluster. A well-clustered DAG averages
+/// dozens (the cluster target is ~128); pathological source topology (non-manifold
+/// or unweldable split-vertices) that defeats clustering even after the
+/// weld-for-adjacency pass collapses to ~1 tri/cluster. Below this we call the bake
+/// degenerate. See [`ClusterMesh::quality`].
+pub const MIN_AVG_TRIS_PER_CLUSTER: f32 = 8.0;
+
+/// Maximum healthy DAG-triangle / source-triangle ratio. A healthy DAG totals ~2×
+/// the source (each coarser level roughly halves), so well under this. A degenerate
+/// clustering balloons many× the source instead of coarsening — a huge, useless
+/// `.clusters.bin` that also tends to cut with holes. See [`ClusterMesh::quality`].
+pub const MAX_DAG_TRI_RATIO: f32 = 6.0;
+
+/// Quality metrics for a baked cluster DAG, with the degeneracy verdict
+/// ([`ClusterMesh::quality`]). The SINGLE source of truth for "is this DAG worth
+/// shipping" — shared by the offline CLI bake (`lod-bake-cli`) and the editor's
+/// export-time bake (`controller::lod_bake::bake_static_clusters`) so the two can't
+/// drift. A degenerate DAG should be dropped (the discrete LOD chain still ships).
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct DagQuality {
+    pub cluster_count: usize,
+    pub dag_triangles: usize,
+    /// `dag_triangles / cluster_count` — low ⇒ clustering failed.
+    pub avg_tris_per_cluster: f32,
+    /// `dag_triangles / source_triangles` — high ⇒ DAG ballooned instead of coarsening.
+    pub dag_ratio: f32,
+    /// `avg_tris_per_cluster < MIN_AVG_TRIS_PER_CLUSTER || dag_ratio > MAX_DAG_TRI_RATIO`.
+    pub degenerate: bool,
+}
+
 /// One cluster's page: its bounds, LOD errors, and where its indices live.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -115,6 +145,29 @@ impl ClusterMesh {
             .map(|c| (c.index_count / 3) as usize)
             .sum()
     }
+
+    /// Assess this DAG's clustering quality against the source triangle count and
+    /// return the degeneracy verdict ([`DagQuality`]). `source_triangles` is the
+    /// pre-bake triangle count of the input mesh (use [`Self::finest_triangle_count`]
+    /// if the source count isn't otherwise tracked — the finest cut reconstructs it).
+    ///
+    /// The SINGLE place this heuristic lives: the CLI and the editor bake both call
+    /// it, so a degenerate `.clusters.bin` is dropped consistently in both paths.
+    pub fn quality(&self, source_triangles: usize) -> DagQuality {
+        let cluster_count = self.cluster_count();
+        let dag_triangles = self.triangle_count();
+        let avg_tris_per_cluster = dag_triangles as f32 / cluster_count.max(1) as f32;
+        let dag_ratio = dag_triangles as f32 / source_triangles.max(1) as f32;
+        let degenerate =
+            avg_tris_per_cluster < MIN_AVG_TRIS_PER_CLUSTER || dag_ratio > MAX_DAG_TRI_RATIO;
+        DagQuality {
+            cluster_count,
+            dag_triangles,
+            avg_tris_per_cluster,
+            dag_ratio,
+            degenerate,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -159,6 +212,53 @@ mod tests {
         assert_eq!(cursor as usize, cm.indices.len());
         // Every index references a real vertex.
         assert!(cm.indices.iter().all(|&i| (i as usize) < pos.len()));
+    }
+
+    /// A normally-built DAG over a welded grid is healthy: dozens of tris/cluster,
+    /// DAG total a small multiple of the source — `quality` must NOT flag it.
+    #[test]
+    fn quality_passes_healthy_dag() {
+        let (pos, indices) = grid(32);
+        let source_tris = indices.len() / 3;
+        let dag = build_cluster_dag(&pos, &indices, &DagOptions::default());
+        let cm = ClusterMesh::from_dag(&dag, pos, vec![], vec![], vec![]);
+        let q = cm.quality(source_tris);
+        assert!(
+            !q.degenerate,
+            "healthy grid flagged degenerate: {:.1} tris/cluster, {:.1}× source",
+            q.avg_tris_per_cluster, q.dag_ratio
+        );
+        assert!(q.avg_tris_per_cluster >= MIN_AVG_TRIS_PER_CLUSTER);
+        assert!(q.dag_ratio <= MAX_DAG_TRI_RATIO);
+    }
+
+    /// A fully split-vertex mesh (no shared indices) with welding DISABLED can't
+    /// cluster — adjacency collapses to ~1 tri/cluster. `quality` must flag it so
+    /// the bake drops the DAG (the same case the CLI/editor guard catches). The
+    /// healthy default path (welding on) is covered above + by the dag tests.
+    #[test]
+    fn quality_flags_degenerate_unwelded_split_mesh() {
+        let (pos, indices) = grid(24);
+        // Explode into per-triangle vertices so no two triangles share an index.
+        let mut split_pos = Vec::with_capacity(indices.len());
+        let mut split_idx = Vec::with_capacity(indices.len());
+        for (i, &vi) in indices.iter().enumerate() {
+            split_pos.push(pos[vi as usize]);
+            split_idx.push(i as u32);
+        }
+        let source_tris = split_idx.len() / 3;
+        let opts = DagOptions {
+            weld_eps: None, // raw-index adjacency — the degenerate case
+            ..DagOptions::default()
+        };
+        let dag = build_cluster_dag(&split_pos, &split_idx, &opts);
+        let cm = ClusterMesh::from_dag(&dag, split_pos, vec![], vec![], vec![]);
+        let q = cm.quality(source_tris);
+        assert!(
+            q.degenerate,
+            "unwelded split mesh not flagged: {:.1} tris/cluster, {:.1}× source",
+            q.avg_tris_per_cluster, q.dag_ratio
+        );
     }
 
     #[test]

--- a/packages/crates/lod-bake/src/cluster_mesh.rs
+++ b/packages/crates/lod-bake/src/cluster_mesh.rs
@@ -175,9 +175,7 @@ impl ClusterMesh {
             }
         }
         if let Some(&bad) = self.indices.iter().find(|&&i| i as usize >= n_vert) {
-            return Err(format!(
-                "index {bad} out of range for {n_vert} vertices"
-            ));
+            return Err(format!("index {bad} out of range for {n_vert} vertices"));
         }
         Ok(())
     }
@@ -313,12 +311,18 @@ mod tests {
         // Page span past the end of the index buffer.
         let mut bad = cm.clone();
         bad.clusters[0].index_count = cm.indices.len() as u32 + 3;
-        assert!(bad.validate().is_err(), "overlong page span must be rejected");
+        assert!(
+            bad.validate().is_err(),
+            "overlong page span must be rejected"
+        );
 
         // Non-triangle-aligned page.
         let mut bad = cm.clone();
         bad.clusters[0].index_count += 1;
-        assert!(bad.validate().is_err(), "non-multiple-of-3 page must be rejected");
+        assert!(
+            bad.validate().is_err(),
+            "non-multiple-of-3 page must be rejected"
+        );
     }
 
     #[test]

--- a/packages/crates/lod-bake/src/dag.rs
+++ b/packages/crates/lod-bake/src/dag.rs
@@ -596,7 +596,10 @@ mod tests {
 
         for &t in &breakpoints {
             let tris = cut_triangles(&dag, t);
-            assert!(!tris.is_empty(), "torus cut at threshold {t} selected nothing");
+            assert!(
+                !tris.is_empty(),
+                "torus cut at threshold {t} selected nothing"
+            );
             let holes = boundary_edge_count(&tris, &weld);
             assert_eq!(
                 holes, 0,

--- a/packages/crates/lod-bake/src/dag.rs
+++ b/packages/crates/lod-bake/src/dag.rs
@@ -393,6 +393,39 @@ mod tests {
         (pos, indices)
     }
 
+    /// A UV torus (major radius 1, minor 0.35) — like [`uv_sphere`], geometrically
+    /// **closed** but **non-watertight by index** (both the major and minor seam
+    /// rings are duplicated columns/rows). Genus-1, so a topologically distinct
+    /// crack-free fixture from the sphere: the cut must stay closed on it too.
+    fn uv_torus(segments_major: usize, segments_minor: usize) -> (Vec<[f32; 3]>, Vec<u32>) {
+        use std::f32::consts::PI;
+        const TAU: f32 = 2.0 * PI;
+        let (big_r, small_r) = (1.0f32, 0.35f32);
+        let mut pos = Vec::new();
+        for i in 0..=segments_major {
+            let theta = (i as f32 / segments_major as f32) * TAU;
+            let (sin_t, cos_t) = (theta.sin(), theta.cos());
+            for j in 0..=segments_minor {
+                let phi = (j as f32 / segments_minor as f32) * TAU;
+                let (sin_p, cos_p) = (phi.sin(), phi.cos());
+                let ring = big_r + small_r * cos_p;
+                pos.push([ring * cos_t, ring * sin_t, small_r * sin_p]);
+            }
+        }
+        let stride = segments_minor + 1;
+        let mut indices = Vec::new();
+        for i in 0..segments_major {
+            for j in 0..segments_minor {
+                let a = (i * stride + j) as u32;
+                let b = (i * stride + j + 1) as u32;
+                let c = ((i + 1) * stride + j + 1) as u32;
+                let d = ((i + 1) * stride + j) as u32;
+                indices.extend_from_slice(&[a, b, c, a, c, d]);
+            }
+        }
+        (pos, indices)
+    }
+
     /// Weld positions onto an epsilon grid → a canonical vertex id per location,
     /// so coincident-but-distinct seam/pole vertices unify. Returns one welded id
     /// per input vertex index.
@@ -527,6 +560,93 @@ mod tests {
             coarsest < source * 3 / 4,
             "coarsest cut {coarsest} is not a real reduction from {source} \
              (locked-boundary simplify must still coarsen the sphere)"
+        );
+    }
+
+    /// A1, extended to a genus-1 surface: a non-watertight-by-index torus must
+    /// also stay crack-free at every LOD level. Same invariant as the sphere test,
+    /// different topology — guards against a fix that accidentally relied on
+    /// sphere-specific structure.
+    #[test]
+    fn non_watertight_torus_cut_is_closed_at_every_level() {
+        let (pos, indices) = uv_torus(48, 24); // 48*24*2 = 2304 tris, multi-level DAG
+        let weld = weld_ids(&pos, 1e-3);
+
+        let src_tris: Vec<[u32; 3]> = indices
+            .chunks_exact(3)
+            .map(|c| [c[0], c[1], c[2]])
+            .collect();
+        assert_eq!(
+            boundary_edge_count(&src_tris, &weld),
+            0,
+            "source UV torus must be geometrically closed once welded"
+        );
+
+        let dag = build_cluster_dag(&pos, &indices, &DagOptions::default());
+
+        let mut breakpoints: Vec<f32> = vec![0.0];
+        for c in &dag.clusters {
+            breakpoints.push(c.lod_error);
+            if c.parent_error < ROOT_PARENT_ERROR {
+                breakpoints.push((c.lod_error + c.parent_error) * 0.5);
+            }
+        }
+        breakpoints.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        breakpoints.dedup();
+
+        for &t in &breakpoints {
+            let tris = cut_triangles(&dag, t);
+            assert!(!tris.is_empty(), "torus cut at threshold {t} selected nothing");
+            let holes = boundary_edge_count(&tris, &weld);
+            assert_eq!(
+                holes, 0,
+                "torus cluster cut at error threshold {t} tore {holes} hole edge(s) — \
+                 not crack-free on non-watertight genus-1 input (A1)"
+            );
+        }
+
+        let max_err = dag
+            .clusters
+            .iter()
+            .filter(|c| c.parent_error < ROOT_PARENT_ERROR)
+            .map(|c| c.lod_error)
+            .fold(0.0f32, f32::max);
+        let coarsest = cut_triangles(&dag, max_err).len();
+        let source = indices.len() / 3;
+        assert!(
+            coarsest < source * 3 / 4,
+            "coarsest torus cut {coarsest} is not a real reduction from {source}"
+        );
+    }
+
+    /// A "triangle soup" — every triangle at a distinct location, sharing no edges
+    /// or positions — is genuinely **unweldable**: position-welding can't restore
+    /// adjacency because nothing is coincident, so clustering collapses to ~1
+    /// tri/cluster even with the DEFAULT (welding-on) options. `ClusterMesh::quality`
+    /// must flag it degenerate, which is exactly what makes the editor bake drop the
+    /// cluster DAG and fall back to the discrete LOD chain (B2).
+    #[test]
+    fn triangle_soup_is_flagged_degenerate() {
+        use crate::cluster_mesh::ClusterMesh;
+        let mut pos = Vec::new();
+        let mut indices = Vec::new();
+        // 600 isolated triangles spread far apart so no two share a position.
+        for k in 0..600u32 {
+            let base = pos.len() as u32;
+            let off = (k as f32) * 10.0;
+            pos.push([off, 0.0, 0.0]);
+            pos.push([off + 1.0, 0.0, 0.0]);
+            pos.push([off, 1.0, 0.0]);
+            indices.extend_from_slice(&[base, base + 1, base + 2]);
+        }
+        let source_tris = indices.len() / 3;
+        let dag = build_cluster_dag(&pos, &indices, &DagOptions::default());
+        let cm = ClusterMesh::from_dag(&dag, pos, vec![], vec![], vec![]);
+        let q = cm.quality(source_tris);
+        assert!(
+            q.degenerate,
+            "unweldable triangle soup not flagged: {:.1} tris/cluster, {:.1}× source",
+            q.avg_tris_per_cluster, q.dag_ratio
         );
     }
 

--- a/packages/crates/lod-bake/src/lib.rs
+++ b/packages/crates/lod-bake/src/lib.rs
@@ -19,7 +19,9 @@ pub mod quadric;
 pub mod simplify;
 
 pub use cluster::{build_cluster_graph, build_clusters, group_clusters, ClusterGraph, Meshlet};
-pub use cluster_mesh::{ClusterMesh, ClusterPage};
+pub use cluster_mesh::{
+    ClusterMesh, ClusterPage, DagQuality, MAX_DAG_TRI_RATIO, MIN_AVG_TRIS_PER_CLUSTER,
+};
 pub use dag::{build_cluster_dag, ClusterDag, DagCluster, DagOptions, ROOT_PARENT_ERROR};
 pub use manifest::{
     bounding_sphere_radius, cluster_mesh_filename, lod_level_filename, lod_manifest_filename,

--- a/packages/crates/lod-bake/src/simplify.rs
+++ b/packages/crates/lod-bake/src/simplify.rs
@@ -227,6 +227,18 @@ pub fn simplify(positions: &[[f32; 3]], indices: &[u32], opts: SimplifyOptions) 
         }
     }
     let mut class = classify_vertices(&boundary_nbrs, &pos);
+    // Lock the endpoints of every non-manifold edge (used by 3+ triangles). Such an
+    // edge has no well-defined two-sided collapse: merging across it folds disjoint
+    // sheets together and, in cluster mode, cracks the per-cluster cut where the
+    // sheets meet. count==1 is the open boundary (handled above); count==2 is the
+    // manifold interior; count>=3 is the pathological case this guards. Manifold
+    // meshes have no such edges, so this is a no-op for them.
+    let nonmanifold = nonmanifold_locked(&edge_tris, vert_count);
+    for (v, &nm) in nonmanifold.iter().enumerate() {
+        if nm {
+            class[v] = VertClass::Corner;
+        }
+    }
     if opts.lock_boundaries {
         // Crack-free cluster mode: a group's external boundary must be preserved
         // exactly so the adjacent group's matching boundary stays welded to it.
@@ -390,6 +402,23 @@ fn weld_coincident(pos: &[DVec3]) -> Vec<u32> {
             *map.entry(key).or_insert(i as u32)
         })
         .collect()
+}
+
+/// Mark every vertex that touches a non-manifold edge — one shared by 3 or more
+/// triangles. The simplifier collapses an edge by merging its endpoints; doing
+/// that across a non-manifold edge welds otherwise-disjoint surface sheets and
+/// tears the mesh (and cracks the cluster cut where the sheets meet). Callers lock
+/// the marked vertices. `edge_tris` maps each undirected edge to its incident
+/// triangle count; manifold meshes (all counts 1 or 2) yield an all-`false` mask.
+fn nonmanifold_locked(edge_tris: &HashMap<(u32, u32), u32>, vert_count: usize) -> Vec<bool> {
+    let mut nm = vec![false; vert_count];
+    for ((a, b), &count) in edge_tris {
+        if count >= 3 {
+            nm[*a as usize] = true;
+            nm[*b as usize] = true;
+        }
+    }
+    nm
 }
 
 /// How a vertex is allowed to move during collapse.
@@ -611,5 +640,55 @@ fn finalize(
         surviving,
         indices: out_indices,
         error: max_cost.max(0.0).sqrt() as f32,
+    }
+}
+
+#[cfg(test)]
+mod nonmanifold_tests {
+    use super::*;
+
+    /// The lock mask flags exactly the endpoints of edges used by 3+ triangles;
+    /// manifold (count 1/2) edges leave their vertices unflagged.
+    #[test]
+    fn nonmanifold_locked_flags_only_high_valence_edges() {
+        let mut edge_tris: HashMap<(u32, u32), u32> = HashMap::new();
+        edge_tris.insert((0, 1), 3); // non-manifold spine → 0,1 locked
+        edge_tris.insert((1, 2), 2); // manifold interior
+        edge_tris.insert((2, 3), 1); // open boundary (locked elsewhere, not here)
+        edge_tris.insert((4, 5), 4); // non-manifold → 4,5 locked
+        let nm = nonmanifold_locked(&edge_tris, 6);
+        assert_eq!(nm, vec![true, true, false, false, true, true]);
+    }
+
+    /// A "Y-prism": three flaps share one spine edge (count==3, non-manifold).
+    /// The simplifier must not panic, must emit a valid index buffer, and must
+    /// keep the spine endpoints (locked, so the disjoint sheets never fold
+    /// together / tear). Guards the whole path on non-manifold input.
+    #[test]
+    fn nonmanifold_yprism_simplifies_without_tearing() {
+        // Spine S0,S1 extruded along z; three flaps at 120°.
+        let mut pos = vec![[0.0f32, 0.0, 0.0], [0.0, 0.0, 1.0]];
+        let dirs = [
+            (1.0f32, 0.0f32),
+            (-0.5, 0.8660254),
+            (-0.5, -0.8660254),
+        ];
+        let mut indices = Vec::new();
+        for (dx, dy) in dirs {
+            let a0 = pos.len() as u32;
+            pos.push([dx, dy, 0.0]);
+            let a1 = pos.len() as u32;
+            pos.push([dx, dy, 1.0]);
+            // quad [S0,S1,a1,a0] → (S0,S1,a1),(S0,a1,a0); edge S0-S1 shared by all flaps.
+            indices.extend_from_slice(&[0, 1, a1]);
+            indices.extend_from_slice(&[0, a1, a0]);
+        }
+        let sm = simplify(&pos, &indices, SimplifyOptions::with_target_locked(1));
+        // Valid, non-empty output.
+        assert!(!sm.indices.is_empty());
+        assert!(sm.indices.iter().all(|&i| (i as usize) < sm.surviving.len()));
+        // The spine endpoints (original ids 0 and 1) survive — non-manifold-locked.
+        assert!(sm.surviving.contains(&0), "spine S0 collapsed away");
+        assert!(sm.surviving.contains(&1), "spine S1 collapsed away");
     }
 }

--- a/packages/crates/lod-bake/src/simplify.rs
+++ b/packages/crates/lod-bake/src/simplify.rs
@@ -668,11 +668,7 @@ mod nonmanifold_tests {
     fn nonmanifold_yprism_simplifies_without_tearing() {
         // Spine S0,S1 extruded along z; three flaps at 120°.
         let mut pos = vec![[0.0f32, 0.0, 0.0], [0.0, 0.0, 1.0]];
-        let dirs = [
-            (1.0f32, 0.0f32),
-            (-0.5, 0.8660254),
-            (-0.5, -0.8660254),
-        ];
+        let dirs = [(1.0f32, 0.0f32), (-0.5, 0.8660254), (-0.5, -0.8660254)];
         let mut indices = Vec::new();
         for (dx, dy) in dirs {
             let a0 = pos.len() as u32;
@@ -686,7 +682,10 @@ mod nonmanifold_tests {
         let sm = simplify(&pos, &indices, SimplifyOptions::with_target_locked(1));
         // Valid, non-empty output.
         assert!(!sm.indices.is_empty());
-        assert!(sm.indices.iter().all(|&i| (i as usize) < sm.surviving.len()));
+        assert!(sm
+            .indices
+            .iter()
+            .all(|&i| (i as usize) < sm.surviving.len()));
         // The spine endpoints (original ids 0 and 1) survive — non-manifold-locked.
         assert!(sm.surviving.contains(&0), "spine S0 collapsed away");
         assert!(sm.surviving.contains(&1), "spine S1 collapsed away");

--- a/packages/crates/renderer/src/render.rs
+++ b/packages/crates/renderer/src/render.rs
@@ -869,7 +869,7 @@ impl AwsmRenderer {
         // Gated by `virtual_geometry` + a loaded cluster mesh; independent of
         // `gpu_occlusion`.
         #[cfg(feature = "lod")]
-        let mut cluster_cut_kick: Option<(web_sys::GpuBuffer, u32)> = None;
+        let mut cluster_cut_kick: Option<Vec<(web_sys::GpuBuffer, u32)>> = None;
         #[cfg(feature = "lod")]
         if let Some(cluster_pass) = self.render_passes.cluster_lod.as_ref() {
             if !cluster_pass.states.is_empty() {
@@ -1643,34 +1643,43 @@ impl AwsmRenderer {
         // a sanity check vs the tested `select_cut_per_cluster` (expect non-zero
         // and < total at a normal camera distance).
         #[cfg(feature = "lod")]
-        if let Some((readback_buffer, total)) = cluster_cut_kick {
+        if let Some(kicks) = cluster_cut_kick {
             let state = std::sync::Arc::clone(&self.cluster_cut_readback);
             state.lock().unwrap().inflight = true;
+            let mesh_count = kicks.len();
+            let total_clusters: u32 = kicks.iter().map(|(_, c)| *c).sum();
             wasm_bindgen_futures::spawn_local(async move {
-                match crate::core::buffers::extract_buffer_vec(&readback_buffer, Some(4)).await {
-                    Ok(bytes) if bytes.len() >= 4 => {
-                        let index_count =
-                            u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
-                        let mut s = state.lock().unwrap();
-                        if s.last_value != index_count as i64 {
-                            s.last_value = index_count as i64;
-                            tracing::info!(
-                                "cluster compaction (GPU): draw_args.index_count = {index_count} \
-                                 ({} tris) over {total} clusters [frame {}]",
-                                index_count / 3,
-                                s.frames
-                            );
+                // Map each resident mesh's draw_args readback and sum the drawn
+                // index counts (one map per mesh; the cadence is every 30 frames so
+                // the sequential awaits are cheap). A failed map drops that mesh's
+                // contribution rather than aborting the whole readback.
+                let mut total_index_count: u64 = 0;
+                let mut ok = false;
+                for (buf, _) in &kicks {
+                    match crate::core::buffers::extract_buffer_vec(buf, Some(4)).await {
+                        Ok(bytes) if bytes.len() >= 4 => {
+                            total_index_count +=
+                                u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) as u64;
+                            ok = true;
                         }
-                        s.inflight = false;
-                    }
-                    Ok(_) => {
-                        state.lock().unwrap().inflight = false;
-                    }
-                    Err(err) => {
-                        tracing::warn!("cluster compaction readback mapAsync failed: {err:?}");
-                        state.lock().unwrap().inflight = false;
+                        Ok(_) => {}
+                        Err(err) => {
+                            tracing::warn!("cluster compaction readback mapAsync failed: {err:?}");
+                        }
                     }
                 }
+                let mut s = state.lock().unwrap();
+                if ok && s.last_value != total_index_count as i64 {
+                    s.last_value = total_index_count as i64;
+                    tracing::info!(
+                        "cluster compaction (GPU): drawn index_count = {total_index_count} \
+                         ({} tris) across {mesh_count} mesh(es) over {total_clusters} clusters \
+                         [frame {}]",
+                        total_index_count / 3,
+                        s.frames
+                    );
+                }
+                s.inflight = false;
             });
         }
 

--- a/packages/crates/renderer/src/render_passes/cluster_lod/render_pass.rs
+++ b/packages/crates/renderer/src/render_passes/cluster_lod/render_pass.rs
@@ -44,6 +44,12 @@ pub struct ClusterMeshState {
     pub render_mesh: MeshKey,
     /// Page count (the cut dispatch bound).
     pub cluster_count: u32,
+    /// Resident triangle count this mesh charges against the global residency
+    /// budget (the budget-capped resident set selected at load — `m_indices/3`,
+    /// NOT the padded paging pool). Summed across states by
+    /// [`ClusterLodRenderPass::resident_tris_total`] so a later mesh's load can cap
+    /// itself against what's already resident (bounded total VRAM, any mesh count).
+    pub resident_tris: u32,
     pub buffers: ClusterLodBuffers,
     pub bind_groups: ClusterCutBindGroups,
     pub compaction_bind_groups: ClusterCompactionBindGroups,
@@ -211,6 +217,13 @@ impl ClusterLodRenderPass {
         self.states
             .iter_mut()
             .find(|s| s.render_mesh == render_mesh)
+    }
+
+    /// Total resident triangles across every loaded cluster mesh — what a new
+    /// mesh's load caps itself against so the SUM stays within the global residency
+    /// budget regardless of mesh count.
+    pub fn resident_tris_total(&self) -> usize {
+        self.states.iter().map(|s| s.resident_tris as usize).sum()
     }
 
     /// Drop a cluster mesh's GPU state (e.g. when its node is removed).
@@ -427,6 +440,7 @@ impl ClusterLodRenderPass {
         layouts: &BindGroupLayouts,
         pages: &[ClusterPage],
         indices: &[u32],
+        resident_tris: u32,
     ) -> Result<()> {
         let count = pages.len() as u32;
         let index_count = indices.len() as u32;
@@ -439,6 +453,7 @@ impl ClusterLodRenderPass {
             self.states.push(ClusterMeshState {
                 render_mesh,
                 cluster_count: 0,
+                resident_tris: 0,
                 buffers,
                 bind_groups,
                 compaction_bind_groups,
@@ -450,6 +465,7 @@ impl ClusterLodRenderPass {
         state.buffers.write_pages(gpu, pages)?;
         state.buffers.write_source_indices(gpu, indices)?;
         state.cluster_count = count;
+        state.resident_tris = resident_tris;
         state.bind_groups.recreate(gpu, layouts, &state.buffers)?;
         state
             .compaction_bind_groups

--- a/packages/crates/renderer/src/render_passes/cluster_lod/render_pass.rs
+++ b/packages/crates/renderer/src/render_passes/cluster_lod/render_pass.rs
@@ -493,10 +493,12 @@ impl ClusterLodRenderPass {
     /// indirect draw's vertex shader resolves M's material meta
     /// (`geometry_mesh_metas[instance_index]`).
     ///
-    /// Returns the readback kick `(readback_buffer, cluster_count)` for the FIRST
-    /// state when the cadence (frame 5, then every 30) fires and no readback is in
-    /// flight — the caller copies `draw_args` → readback inside the encoder and
-    /// maps it after submit (diagnostics; logs the drawn cut on change).
+    /// Returns the readback kick — one `(readback_buffer, cluster_count)` per
+    /// resident cluster mesh — when the cadence (frame 5, then every 30) fires and
+    /// no readback is in flight. The caller copies each `draw_args` → that mesh's
+    /// readback inside the encoder and maps them all after submit, summing the drawn
+    /// index counts (diagnostics; logs the total drawn cut + mesh count on change).
+    /// One entry per mesh keeps the totals correct with several resident meshes.
     pub fn dispatch_all(
         &self,
         ctx: &RenderContext,
@@ -505,7 +507,7 @@ impl ClusterLodRenderPass {
         tan_half_fov_y: f32,
         viewport_h: f32,
         pixel_budget: f32,
-    ) -> Result<Option<(web_sys::GpuBuffer, u32)>> {
+    ) -> Result<Option<Vec<(web_sys::GpuBuffer, u32)>>> {
         for state in &self.states {
             if state.cluster_count == 0 {
                 continue;
@@ -563,29 +565,32 @@ impl ClusterLodRenderPass {
             }
         }
 
-        // Readback verification of draw_args.index_count for the first resident
+        // Readback verification of draw_args.index_count across EVERY resident
         // mesh. Re-fires on a cadence (frame 5, then every 30) so the drawn cut is
-        // observable as the camera/scene change; the async handler logs on change.
-        let Some(state) = self.states.iter().find(|s| s.cluster_count > 0) else {
+        // observable as the camera/scene change; the async handler sums + logs on
+        // change. One kick entry per mesh ⇒ correct totals with several meshes.
+        let resident = || self.states.iter().filter(|s| s.cluster_count > 0);
+        if resident().next().is_none() {
             return Ok(None);
-        };
+        }
         let want = {
             let mut st = readback.lock().unwrap();
             st.frames += 1;
             !st.inflight && (st.frames == 5 || st.frames % 30 == 0)
         };
         if want {
-            ctx.command_encoder.copy_buffer_to_buffer(
-                &state.buffers.draw_args_buffer,
-                0,
-                &state.buffers.readback_buffer,
-                0,
-                4,
-            )?;
-            return Ok(Some((
-                state.buffers.readback_buffer.clone(),
-                state.cluster_count,
-            )));
+            let mut kicks = Vec::new();
+            for state in resident() {
+                ctx.command_encoder.copy_buffer_to_buffer(
+                    &state.buffers.draw_args_buffer,
+                    0,
+                    &state.buffers.readback_buffer,
+                    0,
+                    4,
+                )?;
+                kicks.push((state.buffers.readback_buffer.clone(), state.cluster_count));
+            }
+            return Ok(Some(kicks));
         }
         Ok(None)
     }

--- a/packages/crates/renderer/src/renderer.rs
+++ b/packages/crates/renderer/src/renderer.rs
@@ -2359,6 +2359,7 @@ impl AwsmRenderer {
         render_mesh: crate::meshes::MeshKey,
         pages: &[crate::cluster_lod::ClusterPage],
         indices: &[u32],
+        resident_tris: u32,
     ) -> crate::error::Result<()> {
         if let Some(pass) = self.render_passes.cluster_lod.as_mut() {
             pass.upload_pages(
@@ -2367,9 +2368,21 @@ impl AwsmRenderer {
                 &self.bind_group_layouts,
                 pages,
                 indices,
+                resident_tris,
             )?;
         }
         Ok(())
+    }
+
+    /// Total resident triangles across every loaded cluster mesh. The scene loader
+    /// reads this before selecting a new cluster mesh's resident set, so it can cap
+    /// itself against the global residency budget (bounded total VRAM, any mesh
+    /// count). `0` when the cluster pass isn't built.
+    pub fn cluster_resident_tris_total(&self) -> usize {
+        self.render_passes
+            .cluster_lod
+            .as_ref()
+            .map_or(0, |pass| pass.resident_tris_total())
     }
 
     /// Upload the Gap-B dynamic-paging residency table (`cluster_id → page-pool

--- a/packages/crates/scene-loader/src/lib.rs
+++ b/packages/crates/scene-loader/src/lib.rs
@@ -2005,6 +2005,16 @@ const CLUSTER_PAGE_POOL_SLOTS: usize = 8192;
 #[cfg(feature = "lod")]
 const CLUSTER_PAGING_BUDGET_TRIS: usize = 30_000;
 
+/// How many cluster meshes may be resident at their FULL per-mesh budget before the
+/// global residency cap starts throttling later ones. The per-mesh budgets above
+/// each bound ONE mesh's GPU pool; this bounds the SUM across all resident cluster
+/// meshes (`per_mesh_budget * this`) so total VRAM stays bounded no matter how many
+/// nanite meshes a scene loads. Few-mesh scenes are unaffected (each gets its full
+/// budget until the sum reaches the cap); the uncapped path (budget == `MAX`, i.e.
+/// streaming + paging both off) stays uncapped, so the shipped path is unchanged.
+#[cfg(feature = "lod")]
+const GLOBAL_RESIDENCY_MESH_MULTIPLE: usize = 8;
+
 /// A static page-pool residency plan: which slot each cluster occupies (`-1` =
 /// not resident / overflowed) plus occupancy stats. This is the CPU side of the
 /// Gap-B page pool — the fixed-slot indirection that lets clusters stream in/out
@@ -2274,7 +2284,7 @@ pub async fn materialize_cluster_mesh(
     // fits VRAM (full residency = ~1 GiB > the 512 MB GPU buffer cap — see
     // NORTHSTAR-GAPS). A conservative default keeps the bounded antichain comfortably
     // under the cap; `?streambudget=N` overrides it.
-    let budget = if renderer.features().cluster_paging {
+    let per_mesh_budget = if renderer.features().cluster_paging {
         renderer
             .features()
             .cluster_streaming_budget
@@ -2287,6 +2297,29 @@ pub async fn materialize_cluster_mesh(
     } else {
         usize::MAX
     };
+    // Global residency cap: bound the SUM across all resident cluster meshes, not
+    // just each one. A later mesh's budget shrinks by what's already resident, so
+    // total VRAM stays bounded at `per_mesh_budget * GLOBAL_RESIDENCY_MESH_MULTIPLE`
+    // regardless of mesh count. Few-mesh scenes are unaffected (the subtraction
+    // leaves the full per-mesh budget); the uncapped path (`MAX`) stays uncapped, so
+    // the shipped streaming/paging-off path is byte-identical.
+    let budget = if per_mesh_budget == usize::MAX {
+        usize::MAX
+    } else {
+        let global_cap = per_mesh_budget.saturating_mul(GLOBAL_RESIDENCY_MESH_MULTIPLE);
+        let already_resident = renderer.cluster_resident_tris_total();
+        per_mesh_budget.min(global_cap.saturating_sub(already_resident))
+    };
+    // No global budget left for this mesh — refuse to materialize (renders nothing)
+    // rather than allocate an over-budget pool. Rare: only past the global cap.
+    if budget == 0 {
+        tracing::warn!(
+            "cluster LOD: {asset_label} skipped — global residency budget exhausted \
+             ({} tris already resident, per-mesh budget {per_mesh_budget})",
+            renderer.cluster_resident_tris_total()
+        );
+        return Ok(None);
+    }
     let (gpu_pages, m_indices, resident_cluster_ids) = select_resident_clusters(cm, budget);
     let resident_tris = m_indices.len() / 3;
     let capped = m_indices.len() < cm.indices.len();
@@ -2472,7 +2505,12 @@ pub async fn materialize_cluster_mesh(
             resident_pool,
             init,
         } => {
-            renderer.upload_cluster_pages(m_key, &gpu_pages_pool, &slot_source)?;
+            renderer.upload_cluster_pages(
+                m_key,
+                &gpu_pages_pool,
+                &slot_source,
+                resident_tris as u32,
+            )?;
             renderer.upload_cluster_resident(m_key, &resident_pool)?;
             renderer.init_cluster_paging(m_key, init);
         }
@@ -2480,7 +2518,12 @@ pub async fn materialize_cluster_mesh(
             gpu_pages,
             identity_indices,
         } => {
-            renderer.upload_cluster_pages(m_key, &gpu_pages, &identity_indices)?;
+            renderer.upload_cluster_pages(
+                m_key,
+                &gpu_pages,
+                &identity_indices,
+                resident_tris as u32,
+            )?;
         }
     }
     tracing::info!(

--- a/packages/crates/scene-loader/src/lib.rs
+++ b/packages/crates/scene-loader/src/lib.rs
@@ -2249,6 +2249,15 @@ pub async fn materialize_cluster_mesh(
     if cm.positions.is_empty() || cm.clusters.is_empty() {
         return Ok(None);
     }
+    // Backstop against a malformed DAG (hand-authored / third-party / corrupted
+    // `.clusters.bin`): refuse to materialize rather than read out-of-bounds
+    // vertices or draw garbage. The bake's own output always passes.
+    if let Err(e) = cm.validate() {
+        tracing::error!(
+            "cluster mesh '{asset_label}': malformed DAG ({e}) — refusing to materialize"
+        );
+        return Ok(None);
+    }
 
     // Phase B GPU cut (B.2): hand the cluster pages to the GPU cut pass. No-op
     // unless `virtual_geometry` built the pass; coexists with the per-instance

--- a/packages/frontend/editor/src/controller/lod_bake.rs
+++ b/packages/frontend/editor/src/controller/lod_bake.rs
@@ -45,7 +45,8 @@ pub const CLUSTER_MIN_TRIANGLES: usize = 4096;
 /// (`<id>.clusters.bin`, a JSON `ClusterMesh`) — or empty when below the cluster
 /// floor. Consumed at load only when the `virtual_geometry` feature is on.
 pub fn bake_static_clusters(asset_id: &str, mesh: &MeshData) -> Vec<BundleFile> {
-    if mesh.indices.len() / 3 < CLUSTER_MIN_TRIANGLES {
+    let tris = mesh.indices.len() / 3;
+    if tris < CLUSTER_MIN_TRIANGLES {
         return Vec::new();
     }
     let dag = awsm_renderer_lod_bake::build_cluster_dag(
@@ -60,6 +61,26 @@ pub fn bake_static_clusters(asset_id: &str, mesh: &MeshData) -> Vec<BundleFile> 
         mesh.uvs.first().cloned().unwrap_or_default(),
         mesh.colors.clone().unwrap_or_default(),
     );
+    // Degeneracy guard (same `ClusterMesh::quality` heuristic as the offline CLI,
+    // so the two bakes can't drift). Pathological source topology (non-manifold /
+    // unweldable) that defeats clustering yields a huge, useless DAG that also cuts
+    // with holes — drop it. The mesh still ships its discrete LOD chain
+    // (`bake_static_lod`, baked separately), so this is a graceful fallback, not a
+    // loss. The CLI has `--allow-degenerate-clusters`; the editor bake has no such
+    // escape (an authoring tool should never silently ship a cracking nanite mesh).
+    let q = cm.quality(tris);
+    if q.degenerate {
+        tracing::warn!(
+            "cluster bake: DEGENERATE clustering for {asset_id} \
+             ({} clusters, {:.1} tris/cluster, DAG {:.1}× source) — \
+             skipping cluster DAG, discrete LOD still emitted (source didn't cluster \
+             well: non-manifold / unweldable?)",
+            q.cluster_count,
+            q.avg_tris_per_cluster,
+            q.dag_ratio
+        );
+        return Vec::new();
+    }
     match serde_json::to_vec(&cm) {
         Ok(bytes) => vec![BundleFile::asset(
             awsm_renderer_lod_bake::cluster_mesh_filename(asset_id),

--- a/packages/frontend/editor/src/controller/persistence.rs
+++ b/packages/frontend/editor/src/controller/persistence.rs
@@ -1000,3 +1000,46 @@ fn slugify(name: &str) -> String {
         s
     }
 }
+
+#[cfg(test)]
+mod cluster_persistence_tests {
+    use super::*;
+    use crate::engine::scene::{NodeId, NodeKind, Trs};
+    use awsm_renderer_editor_protocol::{ClusterMeshRef, EditorNode};
+
+    fn cluster_node(source: AssetId, children: Vec<EditorNode>) -> EditorNode {
+        EditorNode {
+            id: NodeId::new(),
+            name: "nanite".into(),
+            transform: Trs::default(),
+            kind: NodeKind::ClusterMesh {
+                cluster: ClusterMeshRef { source },
+                material: None,
+                shadow: Default::default(),
+            },
+            locked: false,
+            visible: true,
+            prefab: false,
+            children,
+        }
+    }
+
+    /// A project with several `ClusterMesh` nodes (incl. a nested one) yields every
+    /// distinct source — so `cluster_files` writes them all on Save and
+    /// `restore_cluster_meshes` re-reads them all on Load. This is the persistence
+    /// contract that lets MULTIPLE nanite meshes survive Save→reload (A3); the
+    /// writer/restorer both iterate exactly this set.
+    #[test]
+    fn cluster_sources_from_project_collects_every_mesh() {
+        let a = AssetId::new();
+        let b = AssetId::new();
+        let project = EditorProject {
+            // `b` nested under `a` also exercises the recursive walk.
+            nodes: vec![cluster_node(a, vec![cluster_node(b, vec![])])],
+            ..Default::default()
+        };
+        let sources = cluster_sources_from_project(&project);
+        assert_eq!(sources.len(), 2, "every cluster source must be collected");
+        assert!(sources.contains(&a) && sources.contains(&b));
+    }
+}

--- a/packages/frontend/editor/src/scene_mode/ribbon.rs
+++ b/packages/frontend/editor/src/scene_mode/ribbon.rs
@@ -102,14 +102,29 @@ fn tab_strip(tab: &Mutable<String>) -> Dom {
     })
 }
 
+/// True if `path` names a pre-baked nanite / cluster-LOD asset (the
+/// `awsm-renderer-lod-bake` CLI's `<id>.clusters.bin`). Strips any URL query /
+/// fragment first so a served `…/foo.clusters.bin?v=2` still routes to the
+/// nanite path; matches `cluster_mesh_filename`'s `.clusters.bin` suffix.
+fn is_nanite_path(path: &str) -> bool {
+    path.split(['?', '#'])
+        .next()
+        .unwrap_or(path)
+        .to_lowercase()
+        .ends_with(".clusters.bin")
+}
+
 // Returns a reusable `Fn` (the dropdown rebuilds its rows on each open). Clones
 // the entries each call; InsertSpec isn't Copy (Primitive carries a struct
 // variant), so the per-item closure also clones its spec on each click.
-/// Open the glTF import modal — either paste a URL (gesture-free, source-
-/// abstracted `ImportModelFromUrl`) **or** pick a local `.glb`/`.gltf` file
-/// (`ImportModelFromFile`, via a `blob:` object URL so the existing loader path
-/// is reused). The file picker is the one users reach for to load their own
-/// local models.
+/// Open the model import modal — either paste a URL (gesture-free, source-
+/// abstracted) **or** pick a local file, routed by extension:
+/// - `.glb` / `.gltf` → `ImportModelFromFile` / `ImportModelFromUrl` (the
+///   normal editable-mesh path).
+/// - `.clusters.bin`  → `ImportNaniteAsset` (the pre-baked nanite / cluster-LOD
+///   path — a view-only `ClusterMesh` drawn through the bounded cluster
+///   pipeline). For a local pick we mint a `blob:` URL; `fetch_cluster_mesh`
+///   GETs it like any URL.
 fn open_import_model() {
     Modal::open(|| {
         let url = Mutable::new(String::new());
@@ -117,8 +132,7 @@ fn open_import_model() {
         let pick_err: Mutable<Option<String>> = Mutable::new(None);
 
         // When the user picks a local file, mint a blob: object URL from it and
-        // import straight away (no extra click) — then dismiss the modal. The
-        // controller revokes the URL once the load completes.
+        // import straight away (no extra click) — then dismiss the modal.
         spawn_local(clone!(picked => async move {
             let mut first = true;
             picked.signal_cloned().for_each(move |maybe| {
@@ -130,9 +144,22 @@ fn open_import_model() {
                         let name = file.name();
                         if let Ok(obj_url) = web_sys::Url::create_object_url_with_blob(&file) {
                             spawn_local(async move {
-                                let _ = controller()
-                                    .dispatch(EditorCommand::ImportModelFromFile { name, url: obj_url })
-                                    .await;
+                                if is_nanite_path(&name) {
+                                    // View-only nanite import. We do NOT revoke the blob:
+                                    // the URL is stored as the asset source and redo
+                                    // re-dispatches this command, which re-GETs it — a
+                                    // revoked blob would break redo. It lives for the
+                                    // session (same session-local lifetime as the cache).
+                                    let _ = controller()
+                                        .dispatch(EditorCommand::ImportNaniteAsset { clusters_url: obj_url })
+                                        .await;
+                                } else {
+                                    // The glb loader copies geometry into GPU templates,
+                                    // so the controller revokes this blob once done.
+                                    let _ = controller()
+                                        .dispatch(EditorCommand::ImportModelFromFile { name, url: obj_url })
+                                        .await;
+                                }
                             });
                             Modal::close();
                         }
@@ -141,16 +168,18 @@ fn open_import_model() {
             }).await;
         }));
 
-        ModalCard::new("Import glTF model")
+        ModalCard::new("Import model")
             .width(520.0)
             .child(html!("div", {
                 .style("display", "flex").style("flex-direction", "column").style("gap", "10px")
                 .child(html!("span", { .style("font-size", "12.5px").style("color", "var(--text-2)").style("line-height", "1.5")
-                    .text("Load a .glb / .gltf model into the scene — paste a URL, or pick a local file below.") }))
+                    .text("Load a model into the scene — paste a URL, or pick a local file below. \
+                           A .glb / .gltf imports as an editable mesh; a pre-baked .clusters.bin \
+                           (awsm-renderer-lod-bake output) imports as a view-only nanite mesh.") }))
                 .child(TextInput::new(url.clone()).placeholder("https://\u{2026}/model.glb").render())
                 .child(FilePicker::new()
-                    .with_accept(".glb,.gltf")
-                    .with_placeholder("Drag & drop a .glb / .gltf model, or click to browse")
+                    .with_accept(".glb,.gltf,.clusters.bin")
+                    .with_placeholder("Drag & drop a .glb / .gltf / .clusters.bin, or click to browse")
                     .render(picked.clone(), pick_err.clone()))
                 .child_signal(pick_err.signal_cloned().map(|e| e.map(|msg| html!("span", {
                     .style("font-size", "12px").style("color", "var(--danger, #e06c75)")
@@ -165,7 +194,12 @@ fn open_import_model() {
                         let u = url.get_cloned();
                         if u.trim().is_empty() { return; }
                         spawn_local(async move {
-                            let _ = controller().dispatch(EditorCommand::ImportModelFromUrl { url: u }).await;
+                            let cmd = if is_nanite_path(&u) {
+                                EditorCommand::ImportNaniteAsset { clusters_url: u }
+                            } else {
+                                EditorCommand::ImportModelFromUrl { url: u }
+                            };
+                            let _ = controller().dispatch(cmd).await;
                         });
                         Modal::close();
                     })).render())

--- a/packages/tools/lod-bake-cli/src/main.rs
+++ b/packages/tools/lod-bake-cli/src/main.rs
@@ -180,26 +180,27 @@ fn bake_one(out_dir: &Path, asset_id: &str, mesh: &MeshData, args: &Args) -> Res
         // topology (non-manifold / unweldable) can defeat clustering even after the
         // weld-for-adjacency pass → ~1 tri/cluster and a DAG that balloons many× the
         // source, i.e. a huge, useless `.clusters.bin`. Skip writing it (the mesh
-        // still gets the discrete chain) unless explicitly allowed.
-        let cluster_count = cm.clusters.len();
-        let dag_tris = cm.indices.len() / 3;
-        let avg_tpc = dag_tris as f32 / cluster_count.max(1) as f32;
-        let dag_ratio = dag_tris as f32 / tris.max(1) as f32;
-        let degenerate = avg_tpc < 8.0 || dag_ratio > 6.0;
-        if degenerate && !args.allow_degenerate_clusters {
+        // still gets the discrete chain) unless explicitly allowed. The verdict is
+        // `ClusterMesh::quality` — the SAME heuristic the editor bake uses.
+        let q = cm.quality(tris);
+        if q.degenerate && !args.allow_degenerate_clusters {
             eprintln!(
-                "  {asset_id}: ⚠ DEGENERATE clustering ({cluster_count} clusters, \
-                 {avg_tpc:.1} tris/cluster, DAG {dag_ratio:.1}× source) — SKIPPING cluster bake \
+                "  {asset_id}: ⚠ DEGENERATE clustering ({} clusters, \
+                 {:.1} tris/cluster, DAG {:.1}× source) — SKIPPING cluster bake \
                  (discrete LOD still emitted). The source topology didn't cluster well \
-                 (non-manifold / unweldable?). Re-run with --allow-degenerate-clusters to force."
+                 (non-manifold / unweldable?). Re-run with --allow-degenerate-clusters to force.",
+                q.cluster_count, q.avg_tris_per_cluster, q.dag_ratio
             );
         } else {
             let bytes = serde_json::to_vec(&cm).context("serializing ClusterMesh")?;
             written += write_file(out_dir, &cluster_mesh_filename(asset_id), &bytes)?;
             eprintln!(
-                "  {asset_id}: {tris} tris → cluster DAG: {cluster_count} clusters \
-                 ({dag_tris} DAG tris, {avg_tpc:.1} tris/cluster){}",
-                if degenerate {
+                "  {asset_id}: {tris} tris → cluster DAG: {} clusters \
+                 ({} DAG tris, {:.1} tris/cluster){}",
+                q.cluster_count,
+                q.dag_triangles,
+                q.avg_tris_per_cluster,
+                if q.degenerate {
                     " [forced — degenerate]"
                 } else {
                     ""


### PR DESCRIPTION
Closes both open follow-ups from `docs/nanite-lod.md`, taking the nanite / cluster-LOD implementation to "as robust as possible." Plan + per-phase breakdown: `docs/plans/nanite-follow-up.md`.

(Also folds in this session's prep work: the editor **"Import model"** modal now accepts `.clusters.bin` — routing local-file and URL imports to `ImportNaniteAsset` — and corrects a stale "persistence is a follow-up" note in `nanite-lod.md`, since cluster persistence was already shipped.)

## B — degenerate / pathological-topology robustness
- **B1** `ClusterMesh::quality` + `DagQuality`: the degeneracy verdict as one shared heuristic.
- **B2** Guard parity: the **editor** bake now drops a degenerate DAG and falls back to the discrete LOD chain (it had no guard before, so it could silently ship a hole-prone `.clusters.bin`); the CLI calls the same `quality()` so they can't drift.
- **B3** Lock non-manifold edges (≥3-incidence) in the simplifier so disjoint sheets can't fold/tear and the cut can't crack where they meet. No-op for manifold meshes.
- **B4** Tests: crack-free invariant extended to a genus-1 **torus**; an unweldable triangle-soup is flagged degenerate under default welding.
- **B5** `ClusterMesh::validate()` load-time backstop — refuses a malformed DAG (out-of-range indices / bad page spans) instead of reading OOB or drawing garbage.

## A — multiple simultaneous nanite meshes
- **A0** Confirmed the renderer was already multi-mesh-shaped (`Vec<ClusterMeshState>` keyed by `MeshKey`, per-node materialize). The real gaps were the readback (A1) and the budget (A2).
- **A1** Cut-readback diagnostics now sum the drawn cut across **all** resident meshes ("across N mesh(es)"), not just the first.
- **A2** **Global residency budget**: total resident is bounded at `per_mesh_budget * 8` shared across resident cluster meshes (was per-mesh, so N meshes scaled VRAM ×N unbounded). Few-mesh scenes are unaffected; the caps-off path stays byte-identical.
- **A3** Native test that every `ClusterMesh` source round-trips Save→reload (multi-mesh persistence contract).
- **A4** On-device: two heavy meshes (630k + 492k source tris) rendered simultaneously at distinct transforms, total ~60k resident ≪ 240k global cap, readback "drawn index_count = 50227 tris across 2 mesh(es)".

## Verification
- `cargo test -p awsm-renderer-lod-bake` — 42 pass · `cargo test -p awsm-renderer-editor` — 28 pass
- `awsm-renderer` wasm compiles **lod-on and lod-off** (flags-off byte-identical)
- A1 crack-free / weld / monotonicity tests never regressed
- A4 verified live in the editor

## Design notes
- A2 bounds by **triangles** (the exploded vertex buffer ∝ tris is the GPU pool's dominant cost); kept `?streambudget` as the per-mesh budget and added a separate `×8` global cap, so existing behavior is preserved. First-cut allocation is first-come (earlier meshes keep full detail, later ones throttle then skip with a warn); fair re-budgeting on load is noted as future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)