### PR TITLE
fix(editor): free nanite cluster_cache on node deletion (renderer OOM)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,7 +187,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "askama",
@@ -214,7 +214,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-core"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "binpack2d",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-curves"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "glam 0.32.1",
  "serde",
@@ -248,7 +248,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-debugging"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-editor"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-editor-protocol"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "awsm-renderer-meshgen",
  "awsm-renderer-scene",
@@ -323,7 +323,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-geometry"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "glam 0.32.1",
  "serde",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-glb-export"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "awsm-renderer-meshgen",
  "awsm-renderer-tangents",
@@ -346,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-gltf"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-gltf-convert"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "awsm-renderer-glb-export",
  "awsm-renderer-meshgen",
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-lod-bake"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "glam 0.32.1",
  "serde",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-lod-bake-cli"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "awsm-renderer-glb-export",
@@ -410,7 +410,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-materials"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "awsm-renderer-core",
  "thiserror 2.0.18",
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-meshgen"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "awsm-renderer-curves",
  "awsm-renderer-geometry",
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-model-tests"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-multithreaded-example"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "awsm-renderer",
  "awsm-renderer-core",
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-particles"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "awsm-renderer-curves",
  "awsm-renderer-geometry",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-render-worker-example"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-scene"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "bitcode",
  "glam 0.32.1",
@@ -535,7 +535,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-scene-loader"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-scene-mcp"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "awsm-renderer-editor-protocol",
@@ -578,14 +578,14 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-tangents"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "bevy_mikktspace",
 ]
 
 [[package]]
 name = "awsm-renderer-web-shared"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ resolver = "2"
 [workspace.package]
 description = "awsm renderer"
 edition = "2021"
-version = "0.4.3"
+version = "0.5.0"
 license = "MIT OR Apache-2.0"
 authors = ["David Komer"]
 # 1.85 floor: rmcp 1.x (the MCP server SDK) is edition-2024, which requires
@@ -118,23 +118,23 @@ opt-level = 1
 # `workspace.package.version` so the published crates carry concrete
 # version requirements on each other (crates.io rejects path-only deps).
 # Bump this block together with the version above on every release.
-awsm-renderer-curves = { path = "packages/crates/curves", version = "0.4.3" }
-awsm-renderer-geometry = { path = "packages/crates/geometry", version = "0.4.3" }
-awsm-renderer-scene = { path = "packages/crates/scene", version = "0.4.3" }
-awsm-renderer-scene-loader = { path = "packages/crates/scene-loader", version = "0.4.3" }
-awsm-renderer-editor-protocol = { path = "packages/mcp/editor-protocol", version = "0.4.3" }
-awsm-renderer-core = { path = "packages/crates/renderer-core", version = "0.4.3" }
-awsm-renderer-meshgen = { path = "packages/crates/meshgen", version = "0.4.3" }
-awsm-renderer-glb-export = { path = "packages/crates/glb-export", version = "0.4.3" }
-awsm-renderer-gltf-convert = { path = "packages/crates/gltf-convert", version = "0.4.3" }
-awsm-renderer-tangents = { path = "packages/crates/tangents", version = "0.4.3" }
-awsm-renderer-lod-bake = { path = "packages/crates/lod-bake", version = "0.4.3" }
-awsm-renderer-particles = { path = "packages/crates/particles", version = "0.4.3" }
-awsm-renderer-materials = { path = "packages/crates/materials", version = "0.4.3" }
-awsm-renderer = { path = "packages/crates/renderer", version = "0.4.3" }
-awsm-renderer-gltf = { path = "packages/crates/renderer-gltf", version = "0.4.3" }
+awsm-renderer-curves = { path = "packages/crates/curves", version = "0.5.0" }
+awsm-renderer-geometry = { path = "packages/crates/geometry", version = "0.5.0" }
+awsm-renderer-scene = { path = "packages/crates/scene", version = "0.5.0" }
+awsm-renderer-scene-loader = { path = "packages/crates/scene-loader", version = "0.5.0" }
+awsm-renderer-editor-protocol = { path = "packages/mcp/editor-protocol", version = "0.5.0" }
+awsm-renderer-core = { path = "packages/crates/renderer-core", version = "0.5.0" }
+awsm-renderer-meshgen = { path = "packages/crates/meshgen", version = "0.5.0" }
+awsm-renderer-glb-export = { path = "packages/crates/glb-export", version = "0.5.0" }
+awsm-renderer-gltf-convert = { path = "packages/crates/gltf-convert", version = "0.5.0" }
+awsm-renderer-tangents = { path = "packages/crates/tangents", version = "0.5.0" }
+awsm-renderer-lod-bake = { path = "packages/crates/lod-bake", version = "0.5.0" }
+awsm-renderer-particles = { path = "packages/crates/particles", version = "0.5.0" }
+awsm-renderer-materials = { path = "packages/crates/materials", version = "0.5.0" }
+awsm-renderer = { path = "packages/crates/renderer", version = "0.5.0" }
+awsm-renderer-gltf = { path = "packages/crates/renderer-gltf", version = "0.5.0" }
 # Frontend-only (not published); workspace dep keeps consumers path-agnostic.
-awsm-renderer-web-shared = { path = "packages/frontend/web-shared", version = "0.4.3" }
+awsm-renderer-web-shared = { path = "packages/frontend/web-shared", version = "0.5.0" }
 
 # Misc
 cfg-if = "1.0.4"

--- a/packages/frontend/editor/src/engine/bridge/cluster_cache.rs
+++ b/packages/frontend/editor/src/engine/bridge/cluster_cache.rs
@@ -38,8 +38,9 @@ pub fn get(source: AssetId) -> Option<Rc<ClusterMesh>> {
     CLUSTER_MESHES.with(|c| c.borrow().get(&source).cloned())
 }
 
-/// Drop a cached cluster mesh (e.g. when its node + asset are removed).
-#[allow(dead_code)] // teardown hook — wired when ClusterMesh node removal lands
+/// Drop a cached cluster mesh — called from `node_sync::remove_node` when the last
+/// `ClusterMesh` node referencing this source is deleted, so a view-only nanite
+/// import doesn't leak its parsed DAG (tens of MB) for the rest of the session.
 pub fn remove(source: AssetId) {
     CLUSTER_MESHES.with(|c| {
         c.borrow_mut().remove(&source);
@@ -51,4 +52,26 @@ pub fn remove(source: AssetId) {
 /// the persisted `assets/<source>.clusters.bin` via `restore_cluster_meshes`).
 pub fn clear() {
     CLUSTER_MESHES.with(|c| c.borrow_mut().clear());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `remove` drops only the targeted source; others stay cached. Guards the
+    /// teardown leak fix (a deleted ClusterMesh node frees its DAG, siblings keep
+    /// theirs).
+    #[test]
+    fn remove_drops_only_the_targeted_source() {
+        let a = AssetId::new();
+        let b = AssetId::new();
+        insert(a, ClusterMesh::default());
+        insert(b, ClusterMesh::default());
+        assert!(get(a).is_some() && get(b).is_some());
+        remove(a);
+        assert!(get(a).is_none(), "removed source must be gone");
+        assert!(get(b).is_some(), "other source must remain");
+        remove(b);
+        assert!(get(b).is_none());
+    }
 }

--- a/packages/frontend/editor/src/engine/bridge/node_sync.rs
+++ b/packages/frontend/editor/src/engine/bridge/node_sync.rs
@@ -395,6 +395,10 @@ async fn remove_node(node_id: NodeId) {
         // gone. Candidate templates: this node's tracked import id, and (for a
         // skinned node) the template it renders from.
         reclaim_templates_for_removed(&entry, node_id).await;
+        // Free the view-only nanite DAG cache for a deleted ClusterMesh node (last
+        // reference only) — closes the editor-side session leak that otherwise grows
+        // the wasm heap toward an OOM abort on re-import-heavy sessions.
+        reclaim_cluster_cache_for_removed(&entry);
         // Dropping the entry (and its loaders) cancels the observers.
     }
 }
@@ -423,6 +427,50 @@ fn scene_has_skinned_from(aid: AssetId) -> bool {
         .lock_ref()
         .iter()
         .any(|n| walk(n, aid))
+}
+
+/// Whether the AUTHORED scene still has a `ClusterMesh` referencing `source`.
+/// Mirror of [`scene_has_skinned_from`] for view-only nanite meshes: keeps the
+/// `cluster_cache` free reload-safe (on `apply_project` the new nodes with the same
+/// source are already in `controller().scene`) and duplicate-safe (a duplicated
+/// `ClusterMesh` shares the source, so deleting one must not free the DAG the other
+/// still renders from).
+fn scene_has_cluster_from(source: AssetId) -> bool {
+    fn walk(node: &Arc<crate::engine::scene::node::Node>, source: AssetId) -> bool {
+        if let NodeKind::ClusterMesh { cluster, .. } = node.kind.get_cloned() {
+            if cluster.source == source {
+                return true;
+            }
+        }
+        node.children.lock_ref().iter().any(|c| walk(c, source))
+    }
+    controller()
+        .scene
+        .nodes
+        .lock_ref()
+        .iter()
+        .any(|n| walk(n, source))
+}
+
+/// Free the parsed cluster-LOD DAG ([`super::cluster_cache`]) of a deleted
+/// `ClusterMesh` node once **nothing** still references its source. Without this the
+/// ~tens-of-MB parsed DAG leaks for the whole session — and since each import mints
+/// a fresh `AssetId`, re-importing the same `.clusters.bin` accumulates a new entry
+/// every time, growing the wasm heap until `memory.grow` fails the V8 backing-store
+/// allocation and the renderer aborts (FatalProcessOutOfMemory). The renderer-side
+/// GPU state is already freed by `remove_mesh` → `drop_cluster_lod_for_mesh`; this
+/// closes the editor-side half. Reload-safe + duplicate-safe via the authored-scene
+/// check (see [`scene_has_cluster_from`]).
+fn reclaim_cluster_cache_for_removed(entry: &Arc<RendererNode>) {
+    if let NodeKind::ClusterMesh { cluster, .. } = entry.node.kind.get_cloned() {
+        if !scene_has_cluster_from(cluster.source) {
+            super::cluster_cache::remove(cluster.source);
+            tracing::debug!(
+                "freed cluster cache for {:?} (last ClusterMesh node deleted)",
+                cluster.source
+            );
+        }
+    }
 }
 
 async fn reclaim_templates_for_removed(entry: &Arc<RendererNode>, node_id: NodeId) {


### PR DESCRIPTION
## Crash

Analyzed the dump in `~/Downloads/temp-crashes` (`6c080ebe-…`). A **renderer process** aborted with `EXC_BREAKPOINT` (`brk`) on `CrRendererMain`, reached **through our WASM** calling a **V8 runtime helper** (wasm frames → trampolines → ~15 deep Chrome-framework runtime frames → trap), with a poison register and all other threads idle. That shape is **`V8::FatalProcessOutOfMemory`** (same class as our prior PartitionAlloc 2 GiB-buffer crash): our wasm heap needed to grow, `memory.grow` asked V8 for a bigger backing store, the allocation failed, and V8 aborted the process. The page is our editor (`localhost:9085`) under a 70-minute `chrome-devtools-mcp` automation session.

(No public Chrome 149 symbols, so the exact `CHECK` line can't be named — but the our-side trigger is excessive memory, and there's a clear unbounded-growth bug.)

## Root cause

The editor's `cluster_cache` (parsed nanite DAGs, ~24 MB each) leaked:
- `cluster_cache::remove` was `#[allow(dead_code)]` — never wired into node teardown, so deleting a `ClusterMesh` node never freed its DAG.
- Every import mints a fresh `AssetId`, so re-importing the same `.clusters.bin` accumulated a new ~24 MB entry each time.

Over an import-heavy session this grows the wasm heap unbounded → OOM abort. (The renderer-side GPU buffers were already freed on delete via `remove_mesh` → `drop_cluster_lod_for_mesh`; only this editor-side cache leaked.)

## Fix

- `remove_node` now frees the source's `cluster_cache` entry once the **last** referencing node is gone, mirroring `reclaim_templates_for_removed`. A `scene_has_cluster_from` authored-scene check keeps it **reload-safe** (`apply_project` swaps nodes synchronously) and **duplicate-safe** (a duplicated node shares the source).
- Un-dead-coded `cluster_cache::remove`; added a unit test (`remove_drops_only_the_targeted_source`).

## No performance regression
The new code runs **only** in `remove_node` (the scene-removal teardown observer — node delete / re-materialize), never the render loop, and is gated on the node being a `ClusterMesh`. It adds **zero** per-frame work and no per-frame allocations; `scene_has_cluster_from` walks the tree only when a `ClusterMesh` node is deleted (cold, user-driven).

## Verification
- `cargo fmt` clean · `task lint` clean
- 29 editor host tests pass (incl. the new cache test); editor wasm compiles

## Residual (not fixed here)
Many *simultaneously-live* nanite imports still hold each ~24 MB parsed DAG in CPU memory (A2's global budget bounds GPU VRAM, not the CPU-side cache). A content-hash dedup of `cluster_cache` would be the next step — out of scope for this crash fix.

Includes the `bump` commit (Cargo version bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)