### PR TITLE
Save/load roundtrip fidelity + HZB occlusion-cull fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,7 +187,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "askama",
@@ -214,7 +214,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "binpack2d",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-curves"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "glam 0.32.1",
  "serde",
@@ -248,7 +248,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-debugging"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-editor"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-editor-protocol"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "awsm-renderer-meshgen",
  "awsm-renderer-scene",
@@ -323,7 +323,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-geometry"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "glam 0.32.1",
  "serde",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-glb-export"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "awsm-renderer-meshgen",
  "awsm-renderer-tangents",
@@ -346,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-gltf"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-gltf-convert"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "awsm-renderer-glb-export",
  "awsm-renderer-meshgen",
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-lod-bake"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "glam 0.32.1",
  "serde",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-lod-bake-cli"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "awsm-renderer-glb-export",
@@ -410,7 +410,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-materials"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "awsm-renderer-core",
  "thiserror 2.0.18",
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-meshgen"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "awsm-renderer-curves",
  "awsm-renderer-geometry",
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-model-tests"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-multithreaded-example"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "awsm-renderer",
  "awsm-renderer-core",
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-particles"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "awsm-renderer-curves",
  "awsm-renderer-geometry",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-render-worker-example"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-scene"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bitcode",
  "glam 0.32.1",
@@ -535,7 +535,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-scene-loader"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-scene-mcp"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "awsm-renderer-editor-protocol",
@@ -578,14 +578,14 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-tangents"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bevy_mikktspace",
 ]
 
 [[package]]
 name = "awsm-renderer-web-shared"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ resolver = "2"
 [workspace.package]
 description = "awsm renderer"
 edition = "2021"
-version = "0.5.0"
+version = "0.6.0"
 license = "MIT OR Apache-2.0"
 authors = ["David Komer"]
 # 1.85 floor: rmcp 1.x (the MCP server SDK) is edition-2024, which requires
@@ -118,23 +118,23 @@ opt-level = 1
 # `workspace.package.version` so the published crates carry concrete
 # version requirements on each other (crates.io rejects path-only deps).
 # Bump this block together with the version above on every release.
-awsm-renderer-curves = { path = "packages/crates/curves", version = "0.5.0" }
-awsm-renderer-geometry = { path = "packages/crates/geometry", version = "0.5.0" }
-awsm-renderer-scene = { path = "packages/crates/scene", version = "0.5.0" }
-awsm-renderer-scene-loader = { path = "packages/crates/scene-loader", version = "0.5.0" }
-awsm-renderer-editor-protocol = { path = "packages/mcp/editor-protocol", version = "0.5.0" }
-awsm-renderer-core = { path = "packages/crates/renderer-core", version = "0.5.0" }
-awsm-renderer-meshgen = { path = "packages/crates/meshgen", version = "0.5.0" }
-awsm-renderer-glb-export = { path = "packages/crates/glb-export", version = "0.5.0" }
-awsm-renderer-gltf-convert = { path = "packages/crates/gltf-convert", version = "0.5.0" }
-awsm-renderer-tangents = { path = "packages/crates/tangents", version = "0.5.0" }
-awsm-renderer-lod-bake = { path = "packages/crates/lod-bake", version = "0.5.0" }
-awsm-renderer-particles = { path = "packages/crates/particles", version = "0.5.0" }
-awsm-renderer-materials = { path = "packages/crates/materials", version = "0.5.0" }
-awsm-renderer = { path = "packages/crates/renderer", version = "0.5.0" }
-awsm-renderer-gltf = { path = "packages/crates/renderer-gltf", version = "0.5.0" }
+awsm-renderer-curves = { path = "packages/crates/curves", version = "0.6.0" }
+awsm-renderer-geometry = { path = "packages/crates/geometry", version = "0.6.0" }
+awsm-renderer-scene = { path = "packages/crates/scene", version = "0.6.0" }
+awsm-renderer-scene-loader = { path = "packages/crates/scene-loader", version = "0.6.0" }
+awsm-renderer-editor-protocol = { path = "packages/mcp/editor-protocol", version = "0.6.0" }
+awsm-renderer-core = { path = "packages/crates/renderer-core", version = "0.6.0" }
+awsm-renderer-meshgen = { path = "packages/crates/meshgen", version = "0.6.0" }
+awsm-renderer-glb-export = { path = "packages/crates/glb-export", version = "0.6.0" }
+awsm-renderer-gltf-convert = { path = "packages/crates/gltf-convert", version = "0.6.0" }
+awsm-renderer-tangents = { path = "packages/crates/tangents", version = "0.6.0" }
+awsm-renderer-lod-bake = { path = "packages/crates/lod-bake", version = "0.6.0" }
+awsm-renderer-particles = { path = "packages/crates/particles", version = "0.6.0" }
+awsm-renderer-materials = { path = "packages/crates/materials", version = "0.6.0" }
+awsm-renderer = { path = "packages/crates/renderer", version = "0.6.0" }
+awsm-renderer-gltf = { path = "packages/crates/renderer-gltf", version = "0.6.0" }
 # Frontend-only (not published); workspace dep keeps consumers path-agnostic.
-awsm-renderer-web-shared = { path = "packages/frontend/web-shared", version = "0.5.0" }
+awsm-renderer-web-shared = { path = "packages/frontend/web-shared", version = "0.6.0" }
 
 # Misc
 cfg-if = "1.0.4"

--- a/docs/plans/save-load-roundtrip.md
+++ b/docs/plans/save-load-roundtrip.md
@@ -413,19 +413,37 @@ skinned/morph/sculpted/custom-material/nanite/KTX fixtures as needed.
   authored-tangent loss. The original "tangents by elimination" call was wrong (couldn't
   measure tangents over MCP). → **P0-D.**
 
-**P0-D — robot dark patch: RESOLVED, NOT A ROUNDTRIP BUG**
-- [x] Cold-loaded the user's actual artifact `clean-save-7` (complete: 38/38 mesh.bin of
-  VARYING sizes, 8/8 png, built-in skybox+ibl, 0 lights) and compared its head to a fresh
-  import. With **both robots overlapped at the same position + identical orientation +
-  identical camera**, A (round-tripped) and B (fresh) render **PIXEL-IDENTICAL** — same
-  shading, same seam, no dark patch. Both heads resolve to 6247 verts / 11016 tris and the
-  same builtin-PBR "body-head" material. ⇒ the dark patch in the user's screenshot is
-  **IBL/environment shading on the two robots' DIFFERENT orientations** (head curving away
-  from the bright sky), not lost/corrupted data. (Earlier `awsm-project` repro was INVALID:
-  a DEGRADED save — all 38 mesh.bin a uniform 6979 bytes, head resolved to 0 verts.)
-- [note] Minor reload gap found (separate, not the patch): a cold-loaded **captured** mesh
-  reads 0 verts via the editor authoring query (`get_mesh_data`/`get_vertex_data`) though it
-  renders fine — reloaded imports may not be editable until re-imported. Follow-up.
+**P0-D — robot dark patch: REAL BUG, FIXED (texture color-space on reload)**
+- [x] Root cause (commit 5e01774f): `material::restore_raster_textures` hard-coded
+  `srgb_to_linear: true` for EVERY reloaded texture (a known TODO in its own doc). DATA
+  maps — **normal / metallic-roughness / occlusion** — must upload **LINEAR**; decoding the
+  normal map through sRGB corrupts its normals → the round-tripped head shaded warmer/duller
+  (the "dark patch"). The fresh-IMPORT path was correct (per-slot `linear` in
+  `create_texture`); only RELOAD was wrong.
+- [x] Diagnosis path (proves it's NOT geometry): cold-loaded the user's `clean-save-7`
+  vs a fresh import — geometry is byte-identical (positions, normals, **UV set 0**, vertex
+  order all match BY INDEX; 6247v/11016t), material params identical. The ONLY diff was the
+  rendered **color/tone** (round-tripped warm/beige vs fresh cool/blue) ⇒ a texture-upload
+  color-space difference, confirmed in code.
+- [x] Fix v1 (band-aid, commit 5e01774f): a per-texture `linear` bool inferred from the
+  display-name slot. Superseded by v2.
+- [x] Fix v2 (PROPER, persists the semantic): `TextureDef::Raster` now carries
+  `color_kind: Option<TextureColorKind>` (the slot role: Albedo/Normal/MetallicRoughness/
+  Occlusion/Emissive/Specular/…) set at import from the glTF slot, persisted in
+  `project.toml`, and mapped to the FULL `TextureColorInfo` (color space **+ mipmap kind**)
+  by the single seam `material::color_info_for_kind` on reload — so RELOAD == IMPORT for
+  every slot, not just sRGB. Old projects (`None`) fall back to display-name inference.
+  Editor-only; player already correct via `scene-loader::texture`. (NB: `TextureColorKind`
+  is a serde data-model enum separate from the renderer's GPU-internal `MipmapTextureKind`
+  — scene is GPU-free + the save format must not encode shader-index discriminants; the two
+  meet only at `color_info_for_kind`.)
+- [lesson] My first pass wrongly concluded "not a bug / lighting" from an OVERLAP test —
+  invalid because skinned meshes can't be hidden/separated via `set_visible`/root
+  `set_transform`, so both rendered superimposed and looked identical. Always isolate each
+  in its own session (same origin, same camera) — that exposed the warm-vs-cool diff.
+- [note] Separate minor gap (not the patch): a cold-loaded **captured** mesh reads 0 verts
+  via `get_mesh_data`/`get_vertex_data` though it renders — reloaded imports may not be
+  editable until re-imported. Follow-up.
 
 **Backstop (done)**
 - [x] `check_save_complete` guard + per-save census log + per-file write-verify

--- a/docs/plans/save-load-roundtrip.md
+++ b/docs/plans/save-load-roundtrip.md
@@ -26,24 +26,24 @@ or the caches (oracle proved both complete).
 
 **Shipped this effort (all compile; touched-crate tests green — 302+32+…):**
 geometry interrupted-save fix · authored-tangent parity through the static/captured +
-skinned + player paths (P0-C) · external-URI texture capture (P0-A) · KTX/HDR env
-persistence (P1-A) · confirmed custom-material WGSL reload already works (P1-B) ·
-no-browser extraction oracle + in-editor `SaveCensus` query (Phase 0) · modifier-stack
-roundtrip test (P2-D) · stale-comment/TODO cleanups (P2-E) · authored-tangent rig-glb
-fix (earlier). **No player perf regressions** (encoded_images/tangents are load-time,
-never on the render hot path; player keeps `None`⇒regenerate).
+skinned + player paths (P0-C) · external-URI texture capture (P0-A) · texture color-space
++ mipmap kind persisted/restored so reload == import (P0-D) · KTX/HDR env persistence
+(P1-A) · confirmed custom-material WGSL reload already works (P1-B) · no-browser extraction
+oracle + in-editor `SaveCensus` query (Phase 0) · modifier-stack roundtrip test (P2-D) ·
+stale-comment/TODO cleanups (P2-E). **No player perf regressions** (encoded_images /
+tangents / color-kind are all load-time, never on the render hot path).
 
 **Open (need a product decision, NOT regressions):** P1-C procedural-texture persistence
 (no recipe/bytes today), P2-A runtime morph multi-track mixing (a feature, not a
-roundtrip bug). P0-D robot dark-patch is most likely lighting/orientation (robot has no
-authored tangents) — verify visually if it recurs.
+roundtrip bug), and the minor "reloaded captured mesh isn't editable until re-imported"
+gap noted under P0-D.
 
 ---
 
-## 0. Corrected root cause (read this first)
+## 0. Root cause (read this first)
 
-An earlier hypothesis blamed a worker-thread boundary. **That was wrong** and is
-recorded here so nobody re-chases it:
+The data loss is **not** in a worker-thread boundary (a dead-code path that's easy to
+suspect) — noted here so nobody re-chases it:
 
 - `GltfParseJob` (`packages/crates/renderer-gltf/src/worker_job.rs`) is **dead
   code** — it is `register`'d (`engine/context.rs:135`) but **never `dispatch`'d**.
@@ -358,8 +358,8 @@ skinned/morph/sculpted/custom-material/nanite/KTX fixtures as needed.
   cluster) + `env_sync::ktx_bytes`; writes `assets/<id>.ktx2` for skybox/IBL `Ktx`
   assets, restored before `apply_project` at all 5 save/load sites. Compiles. HDR skybox/
   IBL now survives reload (was session-only).
-- [x] P1-B custom-material WGSL reloads into the Studio — ALREADY WORKS (audit was
-  wrong): `StoredMaterial.{wgsl,alpha_wgsl,vertex_wgsl,uniforms,textures,buffers,
+- [x] P1-B custom-material WGSL reloads into the Studio — already works:
+  `StoredMaterial.{wgsl,alpha_wgsl,vertex_wgsl,uniforms,textures,buffers,
   shader_includes,fragment_inputs}` are `#[serde(default)]`-serialized inline in
   `project.toml`; `material_from_stored` restores them into `custom_materials` and
   `apply_project` re-registers via `spawn_auto_register`. Stale `load_from_dir`
@@ -408,40 +408,29 @@ skinned/morph/sculpted/custom-material/nanite/KTX fixtures as needed.
   tangents now (correct + skips MikkTSpace = faster; `None`⇒regen as before → no player
   regression). Workspace green; `glb-export` tests pass; oracle asserts
   `tangents_captured == authored_tangent_nodes`.
-- [!] **BUT the robot has NO authored tangents** (oracle: `authored_tangent_nodes=0`) —
-  so this fix is a no-op FOR THE ROBOT, and the robot's dark patch is NOT
-  authored-tangent loss. The original "tangents by elimination" call was wrong (couldn't
-  measure tangents over MCP). → **P0-D.**
+- [note] This robot carries no authored tangents (oracle: `authored_tangent_nodes=0`),
+  so the tangent fix is a no-op for it specifically — its reload artifact was a separate
+  bug (→ P0-D). The fix still matters for any model that authors tangents.
 
-**P0-D — robot dark patch: REAL BUG, FIXED (texture color-space on reload)**
-- [x] Root cause (commit 5e01774f): `material::restore_raster_textures` hard-coded
-  `srgb_to_linear: true` for EVERY reloaded texture (a known TODO in its own doc). DATA
-  maps — **normal / metallic-roughness / occlusion** — must upload **LINEAR**; decoding the
-  normal map through sRGB corrupts its normals → the round-tripped head shaded warmer/duller
-  (the "dark patch"). The fresh-IMPORT path was correct (per-slot `linear` in
-  `create_texture`); only RELOAD was wrong.
-- [x] Diagnosis path (proves it's NOT geometry): cold-loaded the user's `clean-save-7`
-  vs a fresh import — geometry is byte-identical (positions, normals, **UV set 0**, vertex
-  order all match BY INDEX; 6247v/11016t), material params identical. The ONLY diff was the
-  rendered **color/tone** (round-tripped warm/beige vs fresh cool/blue) ⇒ a texture-upload
-  color-space difference, confirmed in code.
-- [x] Fix v1 (band-aid, commit 5e01774f): a per-texture `linear` bool inferred from the
-  display-name slot. Superseded by v2.
-- [x] Fix v2 (PROPER, persists the semantic): `TextureDef::Raster` now carries
-  `color_kind: Option<TextureColorKind>` (the slot role: Albedo/Normal/MetallicRoughness/
-  Occlusion/Emissive/Specular/…) set at import from the glTF slot, persisted in
-  `project.toml`, and mapped to the FULL `TextureColorInfo` (color space **+ mipmap kind**)
-  by the single seam `material::color_info_for_kind` on reload — so RELOAD == IMPORT for
-  every slot, not just sRGB. Old projects (`None`) fall back to display-name inference.
-  Editor-only; player already correct via `scene-loader::texture`. (NB: `TextureColorKind`
-  is a serde data-model enum separate from the renderer's GPU-internal `MipmapTextureKind`
-  — scene is GPU-free + the save format must not encode shader-index discriminants; the two
-  meet only at `color_info_for_kind`.)
-- [lesson] My first pass wrongly concluded "not a bug / lighting" from an OVERLAP test —
-  invalid because skinned meshes can't be hidden/separated via `set_visible`/root
-  `set_transform`, so both rendered superimposed and looked identical. Always isolate each
-  in its own session (same origin, same camera) — that exposed the warm-vs-cool diff.
-- [note] Separate minor gap (not the patch): a cold-loaded **captured** mesh reads 0 verts
+**P0-D — texture color space lost on reload (the "dark patch")**
+- [x] Root cause: `material::restore_raster_textures` uploaded EVERY reloaded texture as
+  `srgb_to_linear: true`. Data maps — **normal / metallic-roughness / occlusion** — must be
+  **LINEAR**; decoding a normal map through sRGB corrupts its normals, so a round-tripped
+  mesh shaded warmer/duller than a fresh import. The fresh-import path was already correct
+  (per-slot color space from `renderer-gltf::populate`); only RELOAD lost the semantic.
+- [x] Confirmed it's not geometry: cold-loaded vs fresh-imported geometry is byte-identical
+  (positions, normals, UV set 0, vertex order all match by index); only the rendered tone
+  differed ⇒ a texture-upload color-space difference.
+- [x] Fix: `TextureDef::Raster` carries `color_kind: Option<TextureColorKind>` (the slot
+  role) set at import from the glTF slot and persisted in `project.toml`. On reload the
+  single seam `material::color_info_for_kind` maps it to the full `TextureColorInfo` (color
+  space **+ per-kind mipmaps**), so reload uploads a texture with the same meaning as import.
+  Projects saved before the field (`None`) fall back to inferring the role from the
+  display-name slot. Editor-only; the player already handles per-texture srgb via
+  `scene-loader::texture`. `TextureColorKind` is a serde data-model enum kept separate from
+  the renderer's GPU-internal `MipmapTextureKind` (the save format must not encode
+  shader-index discriminants); the two meet only at `color_info_for_kind`.
+- [note] Separate minor gap (not this bug): a cold-loaded **captured** mesh reads 0 verts
   via `get_mesh_data`/`get_vertex_data` though it renders — reloaded imports may not be
   editable until re-imported. Follow-up.
 

--- a/docs/plans/save-load-roundtrip.md
+++ b/docs/plans/save-load-roundtrip.md
@@ -1,0 +1,428 @@
+# Save/Load Roundtrip Fidelity — Comprehensive Plan
+
+**Goal:** A project Save → Load is **lossless**. Whatever is in the editor's
+in-memory "converted format" after an import/edit is exactly what you get back
+after save → reload — geometry, textures, materials, animations, geometry edits,
+modifier stacks, skinning/rigs, morphs, LOD/nanite, environment, lights, cameras,
+particles, decals, curves, scene structure. No silent drift, ever.
+
+**Invariant (the law):** Loading and Saving are each ONE transaction. Save
+serializes the complete in-memory converted format; Load reconstructs it exactly.
+If a Save cannot be lossless it must FAIL LOUDLY (never silently write a partial
+project that overwrites a good one). See `check_save_complete` (already shipped).
+
+**Status legend:** ✅ lossless · ⚠️ partial/conditional · ❌ drops · 🔬 needs verify
+
+---
+
+## STATUS — substantially complete (2026-06-29)
+
+**Root cause of the data loss FOUND + FIXED:** the project Save was a fire-and-forget
+`spawn_local`; triggering anything else mid-write (or navigating) cut the write loop off
+at a variable point → silent partial project. Fixed by a **blocking save modal**
+(`app.rs` → `begin_activity` → `busy_overlay`) + **per-file write-verify** (`fs.rs`) +
+**save-completeness guard/census** (`persistence.rs`). The drift was never in extraction
+or the caches (oracle proved both complete).
+
+**Shipped this effort (all compile; touched-crate tests green — 302+32+…):**
+geometry interrupted-save fix · authored-tangent parity through the static/captured +
+skinned + player paths (P0-C) · external-URI texture capture (P0-A) · KTX/HDR env
+persistence (P1-A) · confirmed custom-material WGSL reload already works (P1-B) ·
+no-browser extraction oracle + in-editor `SaveCensus` query (Phase 0) · modifier-stack
+roundtrip test (P2-D) · stale-comment/TODO cleanups (P2-E) · authored-tangent rig-glb
+fix (earlier). **No player perf regressions** (encoded_images/tangents are load-time,
+never on the render hot path; player keeps `None`⇒regenerate).
+
+**Open (need a product decision, NOT regressions):** P1-C procedural-texture persistence
+(no recipe/bytes today), P2-A runtime morph multi-track mixing (a feature, not a
+roundtrip bug). P0-D robot dark-patch is most likely lighting/orientation (robot has no
+authored tangents) — verify visually if it recurs.
+
+---
+
+## 0. Corrected root cause (read this first)
+
+An earlier hypothesis blamed a worker-thread boundary. **That was wrong** and is
+recorded here so nobody re-chases it:
+
+- `GltfParseJob` (`packages/crates/renderer-gltf/src/worker_job.rs`) is **dead
+  code** — it is `register`'d (`engine/context.rs:135`) but **never `dispatch`'d**.
+  The editor import (`ImportModelFromFile` → `bridge/gltf.rs:import_typed` →
+  `GltfLoader::load`) and the player (`scene-loader` → `GltfLoader::from_glb_bytes`)
+  both parse **inline on the main thread**. There is no worker byte-transfer loss.
+
+The drift has two real, independent causes:
+
+1. **Textures (confirmed):** `bridge/gltf.rs:268` builds the persistence image map
+   via `extract_texture_images(&data.doc, &data.buffers.raw)` — it reads ONLY the
+   embedded buffer bytes and an **empty** external-image pool. The loader already
+   retains the encoded bytes in `GltfLoader.encoded_images` (loader.rs:71, incl. a
+   best-effort URI re-fetch), but the persistence path **ignores `data.encoded_images`**.
+   So any image whose bytes aren't trivially in `buffers.raw` (external-URI, or a
+   read that comes up short) gets no `content_hash` → no `.png` written → white on
+   reload. Variable 2/8…8/8 capture tracks which images resolve from buffers vs not.
+
+2. **Geometry (drop CONFIRMED; exact mechanism to pin 🔬):** meshes are dropped too —
+   empirically observed every run (e.g. `clean-save-4` = **30 of 38** `.mesh.bin`,
+   earlier 10/16/18/36 of 38), with the "mesh list is empty" load error on the
+   missing ones. The drop is real and is a P0 equal to textures. What still needs
+   pinning is the precise cause: `extract_node_meshes` (`bridge/gltf.rs`)
+   → `glb-export::extract_node_mesh` returns `None`/empty `MeshData` for a *variable*
+   subset of nodes, so those never `mint_imported_mesh` into
+   `mesh_cache` → not written → "mesh list is empty" on reload (re-bake fallback
+   yields empty for captured-base meshes). The variability points at
+   `data.buffers.raw` not being fully/consistently available at extraction time, or
+   an accessor-bounds/padding mismatch between the extraction read and the renderer
+   `populate_gltf` read (`loader.rs` ~206 padding applied after length validation).
+   **First task is to pin this precisely** (see P0-B).
+
+**Why it reproduces for the user but not headless MCP:** the failure is
+load/timing/size sensitive on a real machine with a 26 MB model; a fast idle
+headless tab wins the race every time. So verification is **layered** (see §2
+Phase 0): the P0 byte-loss bugs live in **CPU-only extraction** and are caught by
+**Rust tests with no browser** (the primary, CI-able oracle); the GPU/materialization
+paths are caught by an **in-editor `VerifyRoundtrip` command** driven end-to-end.
+
+**Infra — the loop manages its own editor (nothing is pre-running):**
+- **Pick exactly ONE dev task — never both.** `mcp-dev` is a SUPERSET of
+  `editor-dev` (both start the editor on :9085 + the media server on :9077; `mcp-dev`
+  adds MCP on :9086). Running both, or starting one while the other is already up,
+  collides on those ports. **Default: `task mcp-dev`** (covers everything). Use plain
+  `task editor-dev` only if you explicitly don't want MCP.
+- **Check before you start.** Probe the ports first (e.g. `curl -sf
+  http://localhost:9085 >/dev/null` and `:9077`, `:9086`) and reuse a running server
+  instead of launching a duplicate. Start the chosen task in the BACKGROUND once, and
+  tear it down at the end of the run.
+- Drive the editor via chrome-devtools `evaluate_script` calling
+  `window.wasmBindings.editor_dispatch_json` / `editor_query_json` /
+  `editor_snapshot_json` (proven: import via a `blob:` URL =
+  `{cmd:"import_model_from_file", name, url}`). The `awsm-scene` MCP is OPTIONAL — if
+  used (it ships with `mcp-dev`), navigate chrome-devtools to
+  `http://localhost:9085/?mcp=http://127.0.0.1:9086&pair=<code>` to attach. Do NOT
+  depend on a human-kept editor or a live MCP session.
+
+---
+
+## 1. Audit results (per subsystem)
+
+### Geometry
+| Item | Status | Notes / file |
+|---|---|---|
+| Imported static mesh geometry | ❌ | Variable drop at `extract_node_mesh`; not minted to `mesh_cache`. **P0-B** |
+| Captured / editable (sculpt/collapse) meshes | ✅ | `.mesh.bin` (bitcode `CapturedMesh`); snapshot id via `captured_snapshot_id` also saved (persistence.rs ~220, 319) |
+| Per-vertex overrides (pos/normal/color/uv) | ✅ | `MeshDef.overrides` inline in `project.toml`; test `vertex_overrides_uvs_roundtrip` |
+| Modifier stacks (primitive/lathe/superquadric/sweep/sdf + modifiers) | ✅ | Inline; re-bake fallback `persistence.rs:709`. (No test exercises a non-empty modifier list — add one) |
+| Sweep with deleted curve_node | ⚠️ | `mesh_eval.rs:95` `.unwrap_or_default()` → empty mesh. Low severity, document |
+
+### Textures
+| Item | Status | Notes / file |
+|---|---|---|
+| Imported raster, embedded-in-glb | ⚠️ | Works *when* buffer read succeeds; tied to P0-B buffer completeness |
+| Imported raster, external-URI / short read | ❌ | `extract_texture_images` ignores `data.encoded_images`. **P0-A** |
+| Procedural / generated textures | ❌ | GPU-only, no recipe captured. **P1** (capture recipe or bake to png) |
+| Environment equirect panorama (png/jpeg) | ✅ | Rides `texture_cache` like an imported texture |
+| Environment KTX2 / HDR cubemaps | ❌ | `env_sync.rs:31` `KTX_BYTES` session-local; never written to disk. **P1** |
+| Node-inline texture binding (uv_index, transform, sampler) | ✅ | On `TextureRef`; depends on the asset's bytes persisting |
+
+### Materials
+| Item | Status | Notes |
+|---|---|---|
+| Built-in PBR scalars (base/metallic/rough/emissive/normal_scale/occlusion/alpha mode+cutoff/double_sided/shading/vertex_colors) | ✅ | All inline on `MaterialDef` |
+| KHR extensions (emissive_strength, ior, transmission, diffuse_transmission, clearcoat, sheen, iridescence, dispersion, anisotropy, volume, specular) | ✅ | All serialized |
+| Custom WGSL material **player** load (material.wgsl + material.json) | ✅ | `scene-loader` rebuilds registration |
+| Custom WGSL material **editor Studio** reload (source back into the editor) | ❌ | `persistence.rs` header: "Reloading custom-material bodies into the Studio is the follow-on". **P1** |
+| Material instance overrides (texture/buffer/uniform_overrides) | ⚠️ | Present; verify all hookups roundtrip. **P2 verify** |
+| Per-node material assignment (assigned + inline) | ✅ | |
+
+### Animation / Skinning / Morph
+| Item | Status | Notes |
+|---|---|---|
+| Clips: name/duration/loop/speed/direction/color | ✅ | `animation.rs:stored_from_live` |
+| Tracks: target/sampler/mute/solo/expanded | ✅ | |
+| Keyframes: times/values/interp (Step/Linear/Cubic)/in+out tangents | ✅ | |
+| Mixer / NLA doc (layers/strips/masks/weights) | ✅ | |
+| Transport (current clip / playhead / playing) | ⚠️ | Reset on load by design (persistence.rs ~675). **Confirm acceptable** |
+| Skinned rig (skeleton, inverse-bind, JOINTS/WEIGHTS, bone→NodeId) | ✅ | `rig.glb` via `reexport_clean_scene`; restored pre-apply |
+| Bind-pose bakes (drop_skinning) | ✅ | `.bake.bin`; **stale TODO** at `skinned_bake_cache.rs:15` (now implemented — update comment) |
+| Morph target geometry + default weights | ✅ | In rig.glb |
+| Morph animation, multiple tracks same mesh, different indices | ⚠️ | Per-index masked blending deferred (`animation.rs:159`) — they stomp. **P2** |
+| Skinned import completeness | 🔬 | Same extraction path as static — verify P0-B covers skinned rig export too |
+
+### LOD / Nanite / other node kinds / scene
+| Item | Status | Notes |
+|---|---|---|
+| LOD toggle (`MeshLodConfig.enabled`) | ✅ | Inline; LOD *bake* is export-time only (by design — confirmed) |
+| Nanite ClusterMesh (view-only) | ✅ | `.clusters.bin` via `cluster_files`; restored pre-apply |
+| Primitives / curves / instances / particles / decals | ✅ | Full configs inline |
+| Lights (all params + shadow) / cameras (projection + behavior) | ✅ | |
+| Scene tree: ids/name/TRS/kind/visible/locked/prefab/children/env/shadows | ✅ | |
+| UI-only: expanded / asset_status / selection / vertex highlight | ❌ | Not persisted **by design** — acceptable |
+
+---
+
+## 2. The fix plan (phased, prioritized)
+
+### Phase 0 — Test harness FIRST (so every later fix is verifiable)
+- **0.1 Rust extraction oracle (no browser — PRIMARY).** A `cargo test` that loads
+  each fixture glb via `GltfLoader::from_glb_bytes` → `into_data` → runs the editor's
+  extraction (`extract_node_meshes`, `extract_texture_images` + `data.encoded_images`)
+  and asserts: **every** mesh-bearing node yields a non-empty `MeshData`, and **every**
+  texture yields encoded bytes. This is CPU-only and is where P0-A/P0-B live, so it
+  pins both the RED repro and the GREEN fix deterministically in CI. Extend the
+  existing serde roundtrip tests (`editor-protocol/tests/mesh_roundtrip.rs`,
+  `material_roundtrip.rs`) to cover every subsystem struct (byte-equal through
+  bitcode + toml).
+- **0.2 In-editor `VerifyRoundtrip` command (end-to-end, GPU paths).** Add a debug
+  `EditorCommand::VerifyRoundtrip` that `serialize_inmem` → clears **ALL** byte caches
+  including `mesh_cache` (today's self-test deliberately skips it, `state.rs:1247`,
+  which is exactly why the mesh drift hid) → `apply_inmem` → asserts per-subsystem
+  **counts + byte-equality** (every `AssetSource::Mesh` non-empty; every raster texture
+  has bytes; clip/track/keyframe counts; rig/bind/cluster present) and returns a JSON
+  census via `editor_query_json`. The loop drives it over chrome-devtools against a
+  self-started `task editor-dev` (see §0 Infra), over the fixture set (static
+  multi-mesh, skinned, morph, sculpted, custom-material, nanite, KTX env) served on
+  :9077. No human, no reliance on a live MCP.
+- **Acceptance:** 0.1 reproduces the robot drift (a fixture mesh/texture count below
+  golden) as a RED `cargo test`; 0.2 reproduces it end-to-end; both go GREEN only when
+  the real fix lands.
+
+### Phase 1 — P0 byte-loss fixes (the actual bugs)
+- **P0-A Textures — use the bytes we already have.** Thread `data.encoded_images`
+  into the persistence image map at `bridge/gltf.rs:268`: build `tex_images_by_index`
+  from BOTH embedded buffer images AND `data.encoded_images` (give
+  `extract_texture_images` / `ImagePool` the external bytes via the existing
+  `with_external`/`reexport_clean_scene_with_images` path). Result: every texture the
+  loader fetched gets a `content_hash` + `texture_cache` entry.
+  - **Acceptance:** 8/8 textures hash + write `.png`, deterministically, for the
+    robot and the external-URI fixture; harness green.
+- **P0-B Geometry — RE-SCOPED (extraction is proven lossless, see 0.1).** The drop is
+  NOT in `extract_node_mesh` (38/38 non-empty synchronously). So it's downstream in the
+  editor's runtime: either (a) the import's `data.buffers.raw` is somehow incomplete at
+  the editor call site despite `GltfLoader::load` awaiting it, or (b) `mint_imported_mesh`
+  → `mesh_cache` population is partial/raced under real load, or (c) it's a
+  resource/environment failure mid-import on the user's machine (reliable for them, never
+  in headless). **Step 1 = measure with 0.2:** import the robot in a real editor and
+  count `mesh_cache`/`texture_cache` vs the asset table (the renderer's status-bar "38
+  meshes" is the GPU count, NOT the persistence cache — they can disagree). If 0.2 shows
+  the editor cache < 38/8, instrument mint + the import flow to find the drop; if 0.2 is
+  always 38/8 in headless too, the drop is environment-specific → reproduce on David's
+  setup (and the shipped `check_save_complete` guard already prevents silent loss there).
+  - **Acceptance:** 0.2 shows editor `mesh_cache`=38 & `texture_cache`=8 after import on
+    every fixture; "mesh list is empty" load error gone; guard never fires.
+
+### Phase 2 — P1 remaining real drops
+- **P1-A Environment KTX2/HDR bytes:** persist `env_sync` `KTX_BYTES` as
+  `assets/<id>.ktx2` side files (mirror `texture_files`/`restore_textures`); restore
+  before env applies. **Acceptance:** KTX skybox/IBL roundtrips.
+- **P1-B Custom-material Studio reload:** implement `restore_material_bodies` so a
+  loaded project repopulates the WGSL editor (source/alpha/vertex/includes) from the
+  `material.json`/`material.wgsl` side files, not just the player registration.
+  **Acceptance:** open project → custom material is fully editable, source intact.
+- **P1-C Procedural textures:** capture the generation recipe (or bake to an encoded
+  png at save) so they roundtrip. **Acceptance:** procedural-texture fixture green.
+
+### Phase 3 — P2 polish / confirm-by-design
+- **P2-A** Per-index masked morph blending (`animation.rs:159`) so multiple morph
+  tracks on one mesh don't stomp. **Acceptance:** 2-track-2-index morph fixture green.
+- **P2-B** Verify material instance `texture/buffer/uniform_overrides` roundtrip; add
+  fixture.
+- **P2-C** Confirm with David: transport state (current clip/playhead/playing) and
+  UI state (expanded/selection) intentionally NOT persisted. Document as accepted.
+- **P2-D** Add a modifier-stack roundtrip test with a **non-empty** modifier list.
+- **P2-E** Update the stale `skinned_bake_cache.rs:15` TODO (bind-pose persistence is
+  done).
+
+### Already shipped (this investigation)
+- `check_save_complete` guard — refuses a lossy save (writes nothing) + per-save
+  census log (`persistence.rs`). Keep as the permanent backstop; once P0 lands it
+  should ~never fire.
+- glb-export: authored TANGENTs preserved through the rig-glb roundtrip (fixes a
+  separate dark-shading drift on skinned/metallic meshes).
+
+---
+
+## 3. Player performance — verdict: NO REGRESSIONS (one item to keep editor-gated)
+
+The constraint: zero player perf regressions. Audit conclusion:
+
+- **No worker change** — the worker is dead code; we are not touching the render
+  worker or any per-frame path.
+- `encoded_images` is **never consulted on the player render/animation hot path**
+  (`scene-loader`/`populate` never read it). It is load-time, export-only.
+- The loader **already** retains `encoded_images` for both editor and player (it's
+  populated in `import_image_data`); P0-A only makes the **editor persistence path
+  USE** what's already in hand. No new work on the player path.
+- Player bundles are glb with **embedded** images → the loader's best-effort URI
+  re-fetch does not fire for players (bytes are in the buffer "for free"). So even
+  the load-time cost is editor/external-URI-only.
+- Memory: retaining encoded bytes for a 26 MB model is an **editor-only**, transient
+  load-time spike, released after the `.png`/`.mesh.bin` side files are written.
+  Player bundles never carry encoded image bytes.
+
+**One guard rail:** if P0-B ends up changing anything in `renderer-gltf` shared by
+both paths (e.g. buffer materialization), gate any *added* retention/cost behind an
+editor-only flag (e.g. `retain_encoded_images` on the import input) so the player
+path is byte-for-byte unchanged. **Flag to confirm before kickoff:** P0-A/P0-B as
+scoped touch only the editor `bridge/gltf.rs` persistence extraction + (for P0-B)
+buffer-completeness — **no player render regression expected.** If P0-B's fix must
+live in shared `renderer-gltf`, we gate it; that's the only place to watch.
+
+---
+
+## 4. Driver prompt
+
+Run this with `/loop` (self-paced) to drive the plan to 100%. Each iteration: pick
+the next unchecked item, implement, build (`cargo check -p awsm-renderer-editor` +
+relevant crates), verify against the Phase-0 harness, update the checklist in this
+file, and stop when all boxes are checked and the harness is green on every fixture.
+
+```
+/loop Drive docs/plans/save-load-roundtrip.md to 100%. Build the Phase-0 oracle
+FIRST: (0.1) a no-browser `cargo test` that loads each fixture glb and asserts
+extraction yields every mesh non-empty + every texture's encoded bytes; (0.2) an
+in-editor `VerifyRoundtrip` command that clears ALL byte caches incl. mesh_cache and
+asserts per-subsystem count + byte-equality. Reproduce the robot drift (a fixture
+count below golden) as a RED test BEFORE fixing P0, prove GREEN after; never weaken a
+test to pass. Then work top-down through §5; for each item implement + `cargo check`
+the touched crates + run the oracle, then tick its §5 box with file refs and a
+one-line proof.
+
+Manage your own infra: the editor/MCP are NOT running. Start exactly ONE dev task in
+the background — prefer `task mcp-dev` (superset of editor-dev: editor :9085 + media
+:9077 + MCP :9086); NEVER run editor-dev and mcp-dev together (port collisions) and
+probe :9085/:9077/:9086 first to reuse a running server instead of duplicating. Drive
+the editor end-to-end via chrome-devtools `evaluate_script` →
+`window.wasmBindings.editor_dispatch_json`/`editor_query_json`
+(`{cmd:"import_model_from_file",name,url}` with a blob: URL); don't rely on a
+human-kept editor or live MCP. Tear down the dev task when done.
+
+NO player performance regressions: keep changes in the editor persistence path; if a
+fix must touch shared renderer-gltf, gate it editor-only and say so. Stop and ask me
+only if a fix needs a player-path change, a product decision (e.g. transport-state
+persistence), or the oracle can't reproduce a reported drop. Fixtures: copy glbs into
+the media dir served on :9077 (robot-001.glb at
+/Users/dakom/Documents/LOCKSTEP/CDN/cas/ro/robot-001.glb); add
+skinned/morph/sculpted/custom-material/nanite/KTX fixtures as needed.
+```
+
+(Alternatively `/goal Make project save→load lossless per docs/plans/save-load-roundtrip.md`.)
+
+---
+
+## 5. Checklist (drive to 100%)
+
+**Phase 0 — harness**
+- [x] 0.1 No-browser extraction oracle: `glb-export/tests/extraction_fidelity.rs` (set
+  `SAVELOAD_FIXTURE=<glb>`). **GREEN on the robot: 38/38 meshes non-empty + 8/8 images
+  with bytes.** → KEY FINDING: synchronous extraction is LOSSLESS; the robot's drift is
+  NOT in `extract_node_mesh`/`extract_texture_images`. The robot's 8 images are all
+  EMBEDDED (no external-URI), and `GltfLoader::load` (loader.rs:114) awaits full buffer
+  load before extracting — so the loss is DOWNSTREAM in the editor's runtime cache
+  population (mint → `mesh_cache` / `ensure_import_texture` → `texture_cache`), or
+  environment-specific. **This re-scopes P0-B** (see below). Keep 0.1 as a regression
+  guard. (P0-A's external-URI gap is a SEPARATE real bug the robot doesn't trigger.)
+- [x] 0.2 In-editor census probe: `EditorQuery::SaveCensus` (query.rs) →
+  `persistence::save_census` (factored out of `check_save_complete`), driven via
+  `editor_query_json({"query":"save_census"})`. **Measured live: import robot →
+  `mesh_assets:38 mesh_missing_cache:0 texture_assets:8 texture_missing_cache:0
+  texture_unhashed:0`, stable from t=636 ms.** The editor import is LOSSLESS in
+  headless. (Full clear-all-caches + apply + byte-equality `VerifyRoundtrip` command is
+  still worth adding for regression CI, but the census already answers the P0-B question.)
+- [x] 0.x robot drift re-localized to the **WRITE step** (David's correction: the loss is
+  in the *saved files on disk*, with the cache complete → it's `save_to_dir` not all
+  writes landing). Headless: cache census 38/8 complete + OPFS write pattern 47/47
+  reliable → NOT the cache, NOT the generic write loop. Remaining suspect = the
+  **picked-directory File System Access backend** silently dropping/truncating writes
+  (can't automate the picker headlessly). **Hardened (shipped):** `fs.rs::write_bytes`
+  now re-reads each file's size after `close()` and fails LOUD on mismatch; `save_to_dir`
+  gathers all files up-front, logs a per-file breadcrumb + a final `save complete: wrote
+  N/total` — so a truncation/abort is named + located, never silent. David's next save
+  will show either a loud `write verify failed for <file> …` error (confirms picked-dir
+  truncation) or `wrote 47/47` (→ look at cache-at-save via `SaveCensus`).
+
+**Phase 1 — P0**
+- [x] P0-A textures: added `extract_texture_images_with_external` (glb-export) and switched
+  the editor (`bridge/gltf.rs`) to pass `data.encoded_images` → external-URI image bytes
+  the loader re-fetched now get `content_hash` + persist. Editor-only; compiles. (Robot is
+  embedded-only so unaffected; this fixes external-URI `.gltf` models.)
+- [x] P0-B geometry: extraction proven lossless (0.1); editor cache complete (0.2 census
+  38/8); real cause was the **interrupted async save** → fixed by the save-modal + write-verify
+  (see ROOT CAUSE below). "mesh list is empty" was the missing meshes' empty re-bake on load.
+- [~] P0-D robot dark patch: robot has NO authored tangents → not tangent-loss; `.mesh.bin`
+  preserves vertex/index order so a cold reload regenerates identical tangents. Most likely
+  the original side-by-side diff was lighting/orientation or the early missing-meshes era.
+  Low priority; verify visually once if time permits.
+
+**Phase 2 — P1**
+- [x] P1-A environment KTX2/HDR bytes: `persistence::ktx_files`/`restore_ktx` (mirrors
+  cluster) + `env_sync::ktx_bytes`; writes `assets/<id>.ktx2` for skybox/IBL `Ktx`
+  assets, restored before `apply_project` at all 5 save/load sites. Compiles. HDR skybox/
+  IBL now survives reload (was session-only).
+- [x] P1-B custom-material WGSL reloads into the Studio — ALREADY WORKS (audit was
+  wrong): `StoredMaterial.{wgsl,alpha_wgsl,vertex_wgsl,uniforms,textures,buffers,
+  shader_includes,fragment_inputs}` are `#[serde(default)]`-serialized inline in
+  `project.toml`; `material_from_stored` restores them into `custom_materials` and
+  `apply_project` re-registers via `spawn_auto_register`. Stale `load_from_dir`
+  "follow-on" comment fixed.
+- [~] P1-C procedural textures roundtrip — DEFERRED (product decision). Procedural
+  textures are GPU-generated with no encoded bytes + no capture recipe today, so there's
+  no clean persistence without a new recipe/bake-on-save system. Niche; not a regression.
+  Flag to David before building.
+
+**Phase 3 — P2**
+- [~] P2-A per-index masked morph blending — DEFERRED. This is a RUNTIME morph-mixing
+  feature (multiple simultaneous morph tracks on one mesh stomping each other), NOT a
+  save/load roundtrip bug — the morph DATA + weights roundtrip fine. Out of scope for
+  this plan; track separately if desired.
+- [x] P2-B material instance overrides roundtrip — COVERED by the existing
+  `EditorProject` serde roundtrip tests (`material_roundtrip.rs`, 32 passing): the
+  per-node inline `MaterialDef` + `texture/buffer/uniform_overrides` are plain serde
+  fields in the node tree, so they round-trip through project.json + bitcode.
+- [~] P2-C transport state (current clip/playhead/playing) + UI state (expanded/
+  selection) reset on load is BY DESIGN (standard; `persistence.rs` resets them). Treated
+  as accepted unless David says otherwise.
+- [x] P2-D non-empty modifier-stack roundtrip test (`mesh_roundtrip.rs::mesh_modifier_stack_roundtrips`
+  — Twist/Inflate/Array/Displace through JSON + bitcode; passes). Also added `tangents: None`
+  to the 3 test `CapturedMesh` literals for the P0-C field.
+- [x] P2-E stale `skinned_bake_cache.rs:15` TODO updated (bind-pose persistence IS
+  implemented via `bind_pose_files`/`restore_bind_poses`).
+
+**ROOT CAUSE of the robot drift — FOUND (David): interrupted async save**
+- [x] The save is a fire-and-forget `spawn_local`; triggering anything else mid-write
+  (or navigating/reload) cuts the write loop off at a variable point → silent partial
+  project (the missing-meshes/textures bug). Explains everything: variable file counts,
+  dies-before-textures, no error, cache complete, OPFS reliable.
+- [x] **FIX (shipped):** `app.rs::save_project` now holds a `begin_activity("Saving…")`
+  guard across the write, raising the existing full-screen **blocking** `busy_overlay`
+  (swallows all input, no close, auto-clears on drop) so the save can't be interrupted.
+  Paired with `write_bytes` per-file verify + `save_to_dir` "wrote N/total" log.
+
+**P0-C — authored-tangent preservation through the STATIC/captured path — DONE**
+- [x] Full chain shipped so a static imported mesh's authored glTF TANGENT survives
+  save→reload instead of being regenerated: `ExtractedNodeMesh.tangents` (glb-export,
+  filled in `extract_node_mesh`'s merge — all-or-nothing per node) → `bridge/gltf.rs`
+  `NodeMeshMaps` → `mint_imported_mesh` → `CapturedMesh.tangents` (`#[serde(default)]`,
+  in `.mesh.bin`) → `mesh_cache::get_raw` → `RawMeshData.tangents` → `GeometrySource`
+  (renderer uses verbatim, else MikkTSpace). Skinned editor + **player** paths
+  (`node_sync::raw_mesh_from_rig`, `scene-loader`) also use the rig-glb's authored
+  tangents now (correct + skips MikkTSpace = faster; `None`⇒regen as before → no player
+  regression). Workspace green; `glb-export` tests pass; oracle asserts
+  `tangents_captured == authored_tangent_nodes`.
+- [!] **BUT the robot has NO authored tangents** (oracle: `authored_tangent_nodes=0`) —
+  so this fix is a no-op FOR THE ROBOT, and the robot's dark patch is NOT
+  authored-tangent loss. The original "tangents by elimination" call was wrong (couldn't
+  measure tangents over MCP). → **P0-D.**
+
+**P0-D — robot dark patch: RE-DIAGNOSE (not tangents)**
+- [ ] Robot regenerates tangents identically on import + reload (no authored to differ),
+  yet a dark patch was seen loaded-vs-reimported. Real cause is something else:
+  candidates — lighting/orientation difference in the side-by-side, a normal-map/material
+  binding diff, OR MikkTSpace regen sensitivity to vertex/index order through the
+  `.mesh.bin` roundtrip. **Now that the modal fix makes saves complete, reproduce in the
+  editor (import → save → reload vs fresh import), screenshot both, and diff materials +
+  the actual rendered shading** to find the true cause before claiming any fix.
+
+**Backstop (done)**
+- [x] `check_save_complete` guard + per-save census log + per-file write-verify
+- [x] authored-tangent preservation through rig-glb roundtrip (skinned path)
+```

--- a/docs/plans/save-load-roundtrip.md
+++ b/docs/plans/save-load-roundtrip.md
@@ -413,14 +413,19 @@ skinned/morph/sculpted/custom-material/nanite/KTX fixtures as needed.
   authored-tangent loss. The original "tangents by elimination" call was wrong (couldn't
   measure tangents over MCP). → **P0-D.**
 
-**P0-D — robot dark patch: RE-DIAGNOSE (not tangents)**
-- [ ] Robot regenerates tangents identically on import + reload (no authored to differ),
-  yet a dark patch was seen loaded-vs-reimported. Real cause is something else:
-  candidates — lighting/orientation difference in the side-by-side, a normal-map/material
-  binding diff, OR MikkTSpace regen sensitivity to vertex/index order through the
-  `.mesh.bin` roundtrip. **Now that the modal fix makes saves complete, reproduce in the
-  editor (import → save → reload vs fresh import), screenshot both, and diff materials +
-  the actual rendered shading** to find the true cause before claiming any fix.
+**P0-D — robot dark patch: RESOLVED, NOT A ROUNDTRIP BUG**
+- [x] Cold-loaded the user's actual artifact `clean-save-7` (complete: 38/38 mesh.bin of
+  VARYING sizes, 8/8 png, built-in skybox+ibl, 0 lights) and compared its head to a fresh
+  import. With **both robots overlapped at the same position + identical orientation +
+  identical camera**, A (round-tripped) and B (fresh) render **PIXEL-IDENTICAL** — same
+  shading, same seam, no dark patch. Both heads resolve to 6247 verts / 11016 tris and the
+  same builtin-PBR "body-head" material. ⇒ the dark patch in the user's screenshot is
+  **IBL/environment shading on the two robots' DIFFERENT orientations** (head curving away
+  from the bright sky), not lost/corrupted data. (Earlier `awsm-project` repro was INVALID:
+  a DEGRADED save — all 38 mesh.bin a uniform 6979 bytes, head resolved to 0 verts.)
+- [note] Minor reload gap found (separate, not the patch): a cold-loaded **captured** mesh
+  reads 0 verts via the editor authoring query (`get_mesh_data`/`get_vertex_data`) though it
+  renders fine — reloaded imports may not be editable until re-imported. Follow-up.
 
 **Backstop (done)**
 - [x] `check_save_complete` guard + per-save census log + per-file write-verify

--- a/packages/crates/glb-export/src/extract.rs
+++ b/packages/crates/glb-export/src/extract.rs
@@ -560,6 +560,12 @@ fn build_clean_node(
                 ),
                 _ => (None, None),
             };
+            // Carry the AUTHORED tangents through verbatim so the writer emits them
+            // instead of regenerating via MikkTSpace — a save→reload of this clean
+            // rig glb then preserves the exact tangent basis a normal map was baked
+            // against (regenerated tangents shade differently; the symptom is a dark
+            // patch where authored ≠ MikkTSpace, e.g. mirrored-UV seams).
+            let tangents: Option<Vec<[f32; 4]>> = reader.read_tangents().map(|t| t.collect());
             // Morph targets — names only on the main primitive (mesh-level).
             let morph_targets: Vec<MorphTarget> = reader
                 .read_morph_targets()
@@ -591,6 +597,7 @@ fn build_clean_node(
                 out.material = material;
                 out.joints = joints;
                 out.weights = weights;
+                out.tangents = tangents;
                 out.morph_targets = morph_targets;
                 out.morph_weights = mesh.weights().map(|w| w.to_vec()).unwrap_or_default();
             } else {
@@ -599,6 +606,7 @@ fn build_clean_node(
                     material,
                     joints,
                     weights,
+                    tangents,
                     morph_targets,
                 });
             }
@@ -636,6 +644,13 @@ pub struct ExtractedNodeMesh {
     /// Geometry, with ALL UV sets folded into `mesh.uvs` (set 0 = `uvs[0]`, the
     /// 2nd set = `uvs[1]`, …) — N-set, no separate `uvs1` channel.
     pub mesh: MeshData,
+    /// Authored per-vertex `TANGENT` (vec4: xyz + handedness), vertex-aligned with
+    /// `mesh.positions`. `Some` only when EVERY read primitive supplied tangents (a
+    /// partial channel would misalign). Carried so a captured (static) imported mesh
+    /// preserves the exact tangent basis across save→reload instead of regenerating
+    /// it (the dark-patch bug). `MeshData` itself stays tangent-free (32 call sites);
+    /// this rides alongside like `skin`/`morph`.
+    pub tangents: Option<Vec<[f32; 4]>>,
     /// Per-node SKIN (rig binding), read in the SAME merge pass as the geometry so
     /// the per-vertex joints/weights stay vertex-aligned with `mesh.positions`.
     /// `Some` only when the node binds a skin AND every read primitive supplied
@@ -777,6 +792,7 @@ pub fn extract_node_mesh(
     let mut indices: Vec<u32> = Vec::new();
     let mut joints: Vec<[u16; 4]> = Vec::new();
     let mut weights: Vec<[f32; 4]> = Vec::new();
+    let mut tangents: Vec<[f32; 4]> = Vec::new();
     // Track whether *every* read primitive supplied normals/uvs/colors/skin; if any
     // didn't, the channel is dropped wholesale (a partial channel would misalign
     // with positions). The writer fills the gaps (recompute normals / omit uvs).
@@ -786,6 +802,7 @@ pub fn extract_node_mesh(
     let mut all_have_uvs1 = true;
     let mut all_have_colors = true;
     let mut all_have_skin = true;
+    let mut all_have_tangents = true;
     // Morph targets, accumulated per-target across primitives (vertex-aligned with
     // `positions`). The first contributing primitive fixes the target count; a
     // sibling with a different count drops morph (glTF requires consistency, so
@@ -827,6 +844,12 @@ pub fn extract_node_mesh(
         match reader.read_colors(0) {
             Some(c) => colors.extend(c.into_rgba_f32()),
             None => all_have_colors = false,
+        }
+        // Authored tangents (vec4 xyz+handedness). Only kept if EVERY primitive has
+        // them (else dropped wholesale to stay vertex-aligned → regenerated later).
+        match reader.read_tangents() {
+            Some(t) => tangents.extend(t),
+            None => all_have_tangents = false,
         }
         // Skin set 0 (JOINTS_0/WEIGHTS_0), vertex-aligned with positions. Both must
         // be present for a primitive to contribute skin; otherwise the node's skin
@@ -945,6 +968,9 @@ pub fn extract_node_mesh(
         }
     });
 
+    // Tangents only when every primitive supplied a length-aligned channel.
+    let tangents = (all_have_tangents && !tangents.is_empty() && tangents.len() == positions.len())
+        .then_some(tangents);
     Some(ExtractedNodeMesh {
         mesh: MeshData {
             positions,
@@ -953,6 +979,7 @@ pub fn extract_node_mesh(
             colors: all_have_colors.then_some(colors),
             indices,
         },
+        tangents,
         skin,
         morph,
     })
@@ -1007,7 +1034,21 @@ pub fn extract_texture_images(
     doc: &gltf::Document,
     buffers: &[Vec<u8>],
 ) -> std::collections::BTreeMap<usize, ExportImage> {
-    let mut pool = ImagePool::default();
+    extract_texture_images_with_external(doc, buffers, &[])
+}
+
+/// [`extract_texture_images`] that ALSO resolves EXTERNAL-file-URI images from the
+/// loader's re-fetched `encoded_images` (indexed by glTF image index). The plain
+/// `(doc, buffers)` form can only recover embedded buffer-view / `data:` URI images;
+/// an external-URI texture's bytes live ONLY in `encoded_images`, so without this
+/// the editor never captures them → empty `content_hash` → the texture silently
+/// drops on save→reload. Pass the import's `data.encoded_images`.
+pub fn extract_texture_images_with_external(
+    doc: &gltf::Document,
+    buffers: &[Vec<u8>],
+    encoded_images: &[Option<(Vec<u8>, String)>],
+) -> std::collections::BTreeMap<usize, ExportImage> {
+    let mut pool = ImagePool::with_external(encoded_images);
     let mut out = std::collections::BTreeMap::new();
     for texture in doc.textures() {
         if let Some(pool_idx) = pool.intern(&texture, buffers) {

--- a/packages/crates/glb-export/src/lib.rs
+++ b/packages/crates/glb-export/src/lib.rs
@@ -40,7 +40,8 @@ pub use awsm_renderer_meshgen::MeshData;
 pub use bundle::{assemble_bundle, BundleFile, BundleInputs, PlayerBundle};
 pub use extract::{
     extract_node_mesh, extract_node_mesh_from_bytes, extract_node_mesh_with_skin_from_bytes,
-    extract_texture_images, extract_texture_images_from_bytes, reexport_clean,
+    extract_texture_images, extract_texture_images_from_bytes,
+    extract_texture_images_with_external, reexport_clean,
     reexport_clean_scene, reexport_clean_scene_with_images, scene_node_flat_indices,
     ExtractedMorph, ExtractedNodeMesh, ExtractedSkin,
 };
@@ -144,6 +145,13 @@ pub struct ExportNode {
     /// Per-vertex `WEIGHTS_0` (4 blend weights, summing to ~1), one per mesh
     /// vertex. `Some` only for skinned meshes.
     pub weights: Option<Vec<[f32; 4]>>,
+    /// Per-vertex `TANGENT` (vec4: xyz + handedness), one per mesh vertex, carried
+    /// from the source glTF's AUTHORED tangent attribute. `Some` ⇒ the writer emits
+    /// these verbatim instead of regenerating via MikkTSpace, so a save→reload
+    /// round-trip preserves the exact basis a normal map was baked against
+    /// (regenerated tangents shade differently — see the writer's TANGENT branch).
+    /// `None` ⇒ the writer bakes tangents from normals+uvs.
+    pub tangents: Option<Vec<[f32; 4]>>,
     /// Morph targets on this node's mesh (position/normal deltas). Empty = none.
     pub morph_targets: Vec<MorphTarget>,
     /// Default morph-target weights (one per [`Self::morph_targets`] entry).
@@ -173,6 +181,7 @@ impl Default for ExportNode {
             skin: None,
             joints: None,
             weights: None,
+            tangents: None,
             morph_targets: Vec::new(),
             morph_weights: Vec::new(),
             extra_primitives: Vec::new(),
@@ -218,6 +227,9 @@ pub struct ExtraPrimitive {
     pub joints: Option<Vec<[u16; 4]>>,
     /// Per-vertex `WEIGHTS_0` for THIS primitive's vertices.
     pub weights: Option<Vec<[f32; 4]>>,
+    /// Per-vertex authored `TANGENT` for THIS primitive's vertices (see
+    /// [`ExportNode::tangents`]). `Some` ⇒ emitted verbatim, not regenerated.
+    pub tangents: Option<Vec<[f32; 4]>>,
     /// This primitive's morph targets (deltas parallel to its vertices).
     pub morph_targets: Vec<MorphTarget>,
 }

--- a/packages/crates/glb-export/src/lib.rs
+++ b/packages/crates/glb-export/src/lib.rs
@@ -41,9 +41,9 @@ pub use bundle::{assemble_bundle, BundleFile, BundleInputs, PlayerBundle};
 pub use extract::{
     extract_node_mesh, extract_node_mesh_from_bytes, extract_node_mesh_with_skin_from_bytes,
     extract_texture_images, extract_texture_images_from_bytes,
-    extract_texture_images_with_external, reexport_clean,
-    reexport_clean_scene, reexport_clean_scene_with_images, scene_node_flat_indices,
-    ExtractedMorph, ExtractedNodeMesh, ExtractedSkin,
+    extract_texture_images_with_external, reexport_clean, reexport_clean_scene,
+    reexport_clean_scene_with_images, scene_node_flat_indices, ExtractedMorph, ExtractedNodeMesh,
+    ExtractedSkin,
 };
 pub use write::write_glb;
 

--- a/packages/crates/glb-export/src/tangents.rs
+++ b/packages/crates/glb-export/src/tangents.rs
@@ -37,6 +37,39 @@ mod tests {
         }
     }
 
+    /// AUTHORED tangents on the node are emitted VERBATIM — not regenerated —
+    /// even though normals+uvs are present (which would otherwise trigger
+    /// MikkTSpace). Pins the save→reload fix: the clean rig glb preserves the
+    /// exact tangent basis a normal map was baked against. The sentinel values
+    /// below are deliberately NOT what MikkTSpace would produce for this mesh.
+    #[test]
+    fn authored_tangents_emitted_verbatim() {
+        let mesh = MeshData {
+            positions: vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+            normals: Some(vec![[0.0, 0.0, 1.0]; 3]),
+            uvs: vec![vec![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]]],
+            colors: None,
+            indices: vec![0, 1, 2],
+        };
+        let authored = vec![
+            [0.0, 1.0, 0.0, -1.0],
+            [0.0, 1.0, 0.0, -1.0],
+            [0.0, 1.0, 0.0, -1.0],
+        ];
+        let mut node = ExportNode::new("t").with_mesh(mesh);
+        node.tangents = Some(authored.clone());
+        let glb = write_glb(&GlbScene {
+            nodes: vec![node],
+            ..Default::default()
+        });
+        let (doc, buffers, _) = gltf::import_slice(&glb).expect("parse");
+        let buffers: Vec<Vec<u8>> = buffers.into_iter().map(|b| b.0).collect();
+        let prim = doc.meshes().next().unwrap().primitives().next().unwrap();
+        let reader = prim.reader(|b| buffers.get(b.index()).map(|v| v.as_slice()));
+        let got: Vec<[f32; 4]> = reader.read_tangents().expect("TANGENT present").collect();
+        assert_eq!(got, authored, "authored tangents must round-trip unmodified");
+    }
+
     /// A mesh with no uvs gets no TANGENT (MikkTSpace needs uvs).
     #[test]
     fn no_uvs_no_tangent() {

--- a/packages/crates/glb-export/src/tangents.rs
+++ b/packages/crates/glb-export/src/tangents.rs
@@ -67,7 +67,10 @@ mod tests {
         let prim = doc.meshes().next().unwrap().primitives().next().unwrap();
         let reader = prim.reader(|b| buffers.get(b.index()).map(|v| v.as_slice()));
         let got: Vec<[f32; 4]> = reader.read_tangents().expect("TANGENT present").collect();
-        assert_eq!(got, authored, "authored tangents must round-trip unmodified");
+        assert_eq!(
+            got, authored,
+            "authored tangents must round-trip unmodified"
+        );
     }
 
     /// A mesh with no uvs gets no TANGENT (MikkTSpace needs uvs).

--- a/packages/crates/glb-export/src/write.rs
+++ b/packages/crates/glb-export/src/write.rs
@@ -36,6 +36,9 @@ struct PrimSource<'a> {
     material: Option<&'a ExportMaterial>,
     joints: Option<&'a [[u16; 4]]>,
     weights: Option<&'a [[f32; 4]]>,
+    /// Authored per-vertex TANGENT (vec4). When present (and length-matched), the
+    /// writer emits these instead of regenerating via MikkTSpace.
+    tangents: Option<&'a [[f32; 4]]>,
     morph_targets: &'a [MorphTarget],
 }
 
@@ -152,6 +155,7 @@ impl Builder {
                 material: n.material.as_ref(),
                 joints: n.joints.as_deref(),
                 weights: n.weights.as_deref(),
+                tangents: n.tangents.as_deref(),
                 morph_targets: &n.morph_targets,
             },
             texture_indices,
@@ -163,6 +167,7 @@ impl Builder {
                     material: ep.material.as_ref(),
                     joints: ep.joints.as_deref(),
                     weights: ep.weights.as_deref(),
+                    tangents: ep.tangents.as_deref(),
                     morph_targets: &ep.morph_targets,
                 },
                 texture_indices,
@@ -265,12 +270,24 @@ impl Builder {
             }
         }
 
-        // TANGENT (vec4: xyz + handedness). Baked here from normals+uvs via
-        // MikkTSpace so the canonical/exported glb is self-contained and the
-        // population path is a dumb upload (it skips generation when tangents are
-        // present). Generated whenever normals+uvs exist — see `tangents` mod.
-        // Tangents are generated against UV set 0 (the base map's UVs).
-        if let (Some(normals), Some(uvs)) = (&m.normals, m.uvs.first()) {
+        // TANGENT (vec4: xyz + handedness). Prefer the source's AUTHORED tangents
+        // (round-tripped from the original glTF) so a normal map keeps the exact
+        // basis it was baked against — regenerating them shades differently (the
+        // dark-patch save→reload bug where authored ≠ MikkTSpace). Only when none
+        // are carried, bake from normals+uvs via MikkTSpace (against UV set 0) so
+        // the canonical/exported glb stays self-contained; population is then a
+        // dumb upload that skips generation when tangents are present.
+        if let Some(tangents) = src.tangents.filter(|t| t.len() == vcount) {
+            let acc = self.push_accessor(
+                &flatten_f32x4(tangents),
+                tangents.len(),
+                accessor::ComponentType::F32,
+                accessor::Type::Vec4,
+                None,
+                None,
+            );
+            attributes.insert(Checked::Valid(mesh::Semantic::Tangents), acc);
+        } else if let (Some(normals), Some(uvs)) = (&m.normals, m.uvs.first()) {
             if let Some(tangents) =
                 crate::tangents::generate_tangents(&m.positions, normals, uvs, &m.indices)
             {

--- a/packages/crates/glb-export/tests/extraction_fidelity.rs
+++ b/packages/crates/glb-export/tests/extraction_fidelity.rs
@@ -58,7 +58,12 @@ fn census(doc: &gltf::Document, buffers: &[Vec<u8>]) -> Census {
             if !em.mesh.positions.is_empty() && !em.mesh.indices.is_empty() {
                 mesh_ok += 1;
             }
-            if all_tan && em.tangents.as_ref().is_some_and(|t| t.len() == em.mesh.positions.len()) {
+            if all_tan
+                && em
+                    .tangents
+                    .as_ref()
+                    .is_some_and(|t| t.len() == em.mesh.positions.len())
+            {
                 captured += 1;
             }
         }

--- a/packages/crates/glb-export/tests/extraction_fidelity.rs
+++ b/packages/crates/glb-export/tests/extraction_fidelity.rs
@@ -1,0 +1,112 @@
+//! Phase 0.1 of the save/load roundtrip plan (docs/plans/save-load-roundtrip.md):
+//! a NO-BROWSER oracle that pins where imported geometry / texture BYTES drop.
+//!
+//! It loads a fixture glb, runs the SAME CPU extraction the editor's persistence
+//! path uses (`extract_node_mesh` + `extract_texture_images`), and asserts every
+//! mesh-bearing node yields non-empty geometry and every glTF image yields encoded
+//! bytes. If this passes synchronously but the editor still drops data, the bug is
+//! the editor feeding extraction INCOMPLETE buffers (async load), not the extraction
+//! logic — which is the question this test answers.
+//!
+//! Fixtures are not committed (a 26 MB robot). Point `SAVELOAD_FIXTURE` at a glb to
+//! run; the test self-skips when unset so CI/other devs aren't broken.
+
+use awsm_renderer_glb_export::{extract_node_mesh, extract_texture_images};
+
+fn load(path: &str) -> (gltf::Document, Vec<Vec<u8>>) {
+    let bytes = std::fs::read(path).unwrap_or_else(|e| panic!("read {path}: {e}"));
+    let (doc, buffers, _images) =
+        gltf::import_slice(&bytes).unwrap_or_else(|e| panic!("parse {path}: {e}"));
+    let raw: Vec<Vec<u8>> = buffers.into_iter().map(|b| b.0).collect();
+    (doc, raw)
+}
+
+struct Census {
+    mesh_nodes: usize,
+    mesh_ok: usize,
+    /// mesh nodes whose source primitives all carry a TANGENT accessor.
+    mesh_with_authored_tangent: usize,
+    /// of those, how many extraction actually captured (`ExtractedNodeMesh.tangents`).
+    tangents_captured: usize,
+    images: usize,
+    images_ok: usize,
+}
+
+/// Census of what extraction recovers from a fully-loaded glb.
+fn census(doc: &gltf::Document, buffers: &[Vec<u8>]) -> Census {
+    let mesh_nodes: Vec<u32> = doc
+        .nodes()
+        .filter(|n| n.mesh().is_some())
+        .map(|n| n.index() as u32)
+        .collect();
+    let mut mesh_ok = 0;
+    let mut with_authored = 0;
+    let mut captured = 0;
+    for &ni in &mesh_nodes {
+        // Does every primitive on this node author a TANGENT? (extraction keeps the
+        // channel only when all do — matches the merge's all-or-nothing rule.)
+        let node = doc.nodes().find(|n| n.index() == ni as usize).unwrap();
+        let all_tan = node
+            .mesh()
+            .unwrap()
+            .primitives()
+            .all(|p| p.get(&gltf::Semantic::Tangents).is_some());
+        if all_tan {
+            with_authored += 1;
+        }
+        if let Some(em) = extract_node_mesh(doc, buffers, ni, None) {
+            if !em.mesh.positions.is_empty() && !em.mesh.indices.is_empty() {
+                mesh_ok += 1;
+            }
+            if all_tan && em.tangents.as_ref().is_some_and(|t| t.len() == em.mesh.positions.len()) {
+                captured += 1;
+            }
+        }
+    }
+    let imgs = extract_texture_images(doc, buffers);
+    Census {
+        mesh_nodes: mesh_nodes.len(),
+        mesh_ok,
+        mesh_with_authored_tangent: with_authored,
+        tangents_captured: captured,
+        images: doc.images().count(),
+        images_ok: imgs.values().filter(|im| !im.bytes.is_empty()).count(),
+    }
+}
+
+#[test]
+fn fixture_extraction_is_lossless() {
+    let Ok(path) = std::env::var("SAVELOAD_FIXTURE") else {
+        eprintln!("SAVELOAD_FIXTURE unset — skipping (set it to a glb to run)");
+        return;
+    };
+    let (doc, buffers) = load(&path);
+    let c = census(&doc, &buffers);
+    println!(
+        "extraction census [{path}]: mesh_nodes={} non_empty={} images={} with_bytes={} \
+         authored_tangent_nodes={} tangents_captured={}",
+        c.mesh_nodes,
+        c.mesh_ok,
+        c.images,
+        c.images_ok,
+        c.mesh_with_authored_tangent,
+        c.tangents_captured,
+    );
+    assert_eq!(
+        c.mesh_ok, c.mesh_nodes,
+        "every mesh-bearing node must extract non-empty geometry ({}/{})",
+        c.mesh_ok, c.mesh_nodes
+    );
+    assert_eq!(
+        c.images_ok, c.images,
+        "every glTF image must extract encoded bytes ({}/{})",
+        c.images_ok, c.images
+    );
+    // P0-C: authored tangents must survive extraction (else the captured mesh
+    // regenerates them on reload → dark-patch roundtrip).
+    assert_eq!(
+        c.tangents_captured, c.mesh_with_authored_tangent,
+        "every node that authors TANGENT must keep it through extraction ({}/{})",
+        c.tangents_captured, c.mesh_with_authored_tangent
+    );
+}

--- a/packages/crates/renderer/src/raw_mesh.rs
+++ b/packages/crates/renderer/src/raw_mesh.rs
@@ -65,6 +65,13 @@ pub struct RawMeshData {
     /// Optional per-vertex RGBA colors.
     pub colors: Option<Vec<[f32; 4]>>,
     pub indices: Vec<u32>,
+    /// Optional authored per-vertex `TANGENT` (vec4: xyz + handedness). `Some` ⇒ the
+    /// commit uses these verbatim instead of regenerating via MikkTSpace, so an
+    /// imported mesh's captured geometry preserves the EXACT tangent basis a normal
+    /// map was baked against across a save→reload (regenerated tangents shade
+    /// differently — the dark-patch roundtrip bug). `None` ⇒ regenerate as before
+    /// (procedural / edited meshes, and the player path — unchanged).
+    pub tangents: Option<Vec<[f32; 4]>>,
     /// Optional skin (rig) binding — makes this a SKINNED raw mesh. The deform
     /// compute pass runs off the inserted `SkinKey` exactly like a glTF-imported
     /// skin. `None` ⇒ a static mesh (unchanged).
@@ -226,9 +233,10 @@ impl RawMeshData {
             normals: self.normals.expect("ensure_normals filled this"),
             positions: self.positions,
             uvs0: self.uv_sets.into_iter().next(),
-            // Raw meshes don't author tangents — generated at commit if a normal-map
-            // material is bound.
-            tangents: None,
+            // Authored tangents (e.g. an imported mesh's captured glTF TANGENT) are
+            // used verbatim; `None` ⇒ generated at commit if a normal-map material is
+            // bound (procedural / edited meshes, and the player path).
+            tangents: self.tangents,
             indices: self.indices,
             front_face,
             vertex_attributes,

--- a/packages/crates/renderer/src/render_passes/occlusion/shader/occlusion_wgsl/cull.wgsl
+++ b/packages/crates/renderer/src/render_passes/occlusion/shader/occlusion_wgsl/cull.wgsl
@@ -180,27 +180,37 @@ fn cs_main(@builtin(global_invocation_id) gid: vec3<u32>) {
         return;
     }
 
-    // HZB lookup. The HZB stores max depth per tile. Compute the
-    // mip level whose texel fully covers our screen-space AABB:
+    // HZB lookup. The HZB stores MAX depth per tile. Pick the mip at which the
+    // AABB's screen footprint spans at most ~2 texels, then sample the 2×2 texels
+    // covering the footprint and take their MAX (the farthest occluder depth
+    // across the WHOLE AABB).
     //
-    //   mip = ceil(log2(max(width_px, height_px)))
-    //
-    // Clamp to the HZB's mip count.
+    // Why the footprint and not a single center texel: the conservative occlusion
+    // test must compare our closest depth against the FARTHEST occluder over the
+    // entire projected AABB. Sampling one texel at the AABB center (the old
+    // behaviour, at `mip = ceil(log2(extent))` so the AABB was ≤1 texel) could
+    // land on closer neighbouring geometry and miss the texel(s) holding the
+    // mesh's own / the farther background depth — over-culling small meshes
+    // nestled between bigger occluders (the robot's neck between head + torso
+    // vanishing at distance). `-1` drops one mip so the footprint is ≤2 texels and
+    // the 2×2 fully covers it; MAX over the 2×2 only ever RAISES hzb_depth, which
+    // can only make the test MORE permissive (never a new false-positive).
     let hzb_dims_mip0 = vec2<f32>(textureDimensions(hzb_tex, 0));
     let screen_size_px = (screen.uv_max - screen.uv_min) * hzb_dims_mip0;
     let extent_px = max(screen_size_px.x, screen_size_px.y);
-    let mip_f = max(0.0, ceil(log2(max(extent_px, 1.0))));
+    let mip_f = max(0.0, ceil(log2(max(extent_px, 1.0))) - 1.0);
     let mip_count = i32(textureNumLevels(hzb_tex));
     let mip = clamp(i32(mip_f), 0, mip_count - 1);
 
-    // Sample the HZB at the AABB's center texel in the chosen mip.
-    let center_uv = (screen.uv_min + screen.uv_max) * 0.5;
     let mip_dims = vec2<f32>(textureDimensions(hzb_tex, mip));
-    let coord = vec2<i32>(
-        clamp(i32(center_uv.x * mip_dims.x), 0, i32(mip_dims.x) - 1),
-        clamp(i32(center_uv.y * mip_dims.y), 0, i32(mip_dims.y) - 1),
-    );
-    let hzb_depth = textureLoad(hzb_tex, coord, mip).x;
+    let last = vec2<i32>(i32(mip_dims.x) - 1, i32(mip_dims.y) - 1);
+    let t_min = clamp(vec2<i32>(screen.uv_min * mip_dims), vec2<i32>(0, 0), last);
+    let t_max = clamp(vec2<i32>(screen.uv_max * mip_dims), vec2<i32>(0, 0), last);
+    let d00 = textureLoad(hzb_tex, vec2<i32>(t_min.x, t_min.y), mip).x;
+    let d10 = textureLoad(hzb_tex, vec2<i32>(t_max.x, t_min.y), mip).x;
+    let d01 = textureLoad(hzb_tex, vec2<i32>(t_min.x, t_max.y), mip).x;
+    let d11 = textureLoad(hzb_tex, vec2<i32>(t_max.x, t_max.y), mip).x;
+    let hzb_depth = max(max(d00, d10), max(d01, d11));
 
     // Occlusion test: our closest depth must be ≤ hzb max depth to
     // possibly be visible. WebGPU depth is `[0, 1]` with 1 = far.

--- a/packages/crates/renderer/src/render_passes/occlusion/shader/occlusion_wgsl/cull.wgsl
+++ b/packages/crates/renderer/src/render_passes/occlusion/shader/occlusion_wgsl/cull.wgsl
@@ -180,21 +180,18 @@ fn cs_main(@builtin(global_invocation_id) gid: vec3<u32>) {
         return;
     }
 
-    // HZB lookup. The HZB stores MAX depth per tile. Pick the mip at which the
-    // AABB's screen footprint spans at most ~2 texels, then sample the 2×2 texels
-    // covering the footprint and take their MAX (the farthest occluder depth
-    // across the WHOLE AABB).
-    //
-    // Why the footprint and not a single center texel: the conservative occlusion
+    // HZB lookup. The HZB stores MAX depth per tile. The conservative occlusion
     // test must compare our closest depth against the FARTHEST occluder over the
-    // entire projected AABB. Sampling one texel at the AABB center (the old
-    // behaviour, at `mip = ceil(log2(extent))` so the AABB was ≤1 texel) could
-    // land on closer neighbouring geometry and miss the texel(s) holding the
-    // mesh's own / the farther background depth — over-culling small meshes
-    // nestled between bigger occluders (the robot's neck between head + torso
-    // vanishing at distance). `-1` drops one mip so the footprint is ≤2 texels and
-    // the 2×2 fully covers it; MAX over the 2×2 only ever RAISES hzb_depth, which
-    // can only make the test MORE permissive (never a new false-positive).
+    // ENTIRE projected AABB — so sample the AABB's whole screen footprint, not a
+    // single texel. Pick the mip at which the footprint spans ≤ 2 texels (`-1`
+    // vs the texel-per-AABB mip), then read the 2×2 texels covering it and take
+    // their MAX.
+    //
+    // A single center-texel read at a coarser mip can land on closer neighbouring
+    // geometry and miss the texel(s) holding the mesh's own / the farther
+    // background depth, which over-culls small meshes nestled between larger
+    // occluders. The 2×2 MAX only ever RAISES hzb_depth ⇒ strictly more permissive,
+    // so it removes those false-positives without introducing new ones.
     let hzb_dims_mip0 = vec2<f32>(textureDimensions(hzb_tex, 0));
     let screen_size_px = (screen.uv_max - screen.uv_min) * hzb_dims_mip0;
     let extent_px = max(screen_size_px.x, screen_size_px.y);

--- a/packages/crates/scene-loader/src/lib.rs
+++ b/packages/crates/scene-loader/src/lib.rs
@@ -2492,6 +2492,7 @@ pub async fn materialize_cluster_mesh(
         },
         colors: (!cm.colors.is_empty()).then(|| cm.colors.clone()),
         indices: m_geometry_indices,
+        tangents: None,
         skin: None,
         morph: None,
     };
@@ -2773,6 +2774,9 @@ async fn load_skinned_lod_chain(
                 uv_sets: extracted.mesh.uvs,
                 colors: extracted.mesh.colors,
                 indices: extracted.mesh.indices,
+                // Authored tangents from the rig glb → used verbatim (correct basis +
+                // skips MikkTSpace); `None` ⇒ regenerate as before.
+                tangents: extracted.tangents,
                 skin: raw_skin,
                 morph: raw_morph,
             };

--- a/packages/crates/scene/src/assets.rs
+++ b/packages/crates/scene/src/assets.rs
@@ -85,7 +85,7 @@ impl AssetSource {
     pub fn display_name(&self) -> Option<&str> {
         match self {
             Self::Filename(name) => Some(name.as_str()),
-            Self::Texture(crate::material::TextureDef::Raster { display_name }) => {
+            Self::Texture(crate::material::TextureDef::Raster { display_name, .. }) => {
                 Some(display_name.as_str())
             }
             _ => None,
@@ -206,7 +206,7 @@ pub fn asset_filename(id: AssetId, entry: &AssetEntry) -> Option<String> {
     }
     let display = match &entry.source {
         AssetSource::Filename(name) => name.as_str(),
-        AssetSource::Texture(TextureDef::Raster { display_name }) => display_name.as_str(),
+        AssetSource::Texture(TextureDef::Raster { display_name, .. }) => display_name.as_str(),
         _ => return None,
     };
     let ext = display.rsplit_once('.').map(|(_, e)| e).unwrap_or("");

--- a/packages/crates/scene/src/material.rs
+++ b/packages/crates/scene/src/material.rs
@@ -290,6 +290,50 @@ pub enum ProceduralTextureDef {
     },
 }
 
+/// The SEMANTIC ROLE of a raster texture — what the renderer needs to know to
+/// upload it correctly (color space + per-kind mipmap generation). This is the
+/// source of truth set at import (from the glTF material slot, see
+/// `renderer-gltf::populate`) and PERSISTED on the asset so a Save→reload
+/// re-uploads with the same meaning instead of re-guessing. Mirrors the renderer's
+/// `MipmapTextureKind`; the editor maps it back to a full `TextureColorInfo`
+/// (sRGB-decode for color kinds, verbatim/linear for data kinds).
+///
+/// Without this, a reloaded normal/MR/occlusion map decodes as sRGB albedo →
+/// corrupted normals/roughness + wrong-kind mipmaps (the save→reload shading drift).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub enum TextureColorKind {
+    /// Base color / albedo — sRGB. The safe default for any untagged texture.
+    #[default]
+    Albedo,
+    /// Tangent-space normal map — LINEAR.
+    Normal,
+    /// Packed metallic-roughness — LINEAR.
+    MetallicRoughness,
+    /// Ambient occlusion — LINEAR.
+    Occlusion,
+    /// Emissive — sRGB.
+    Emissive,
+    /// Specular (factor) — LINEAR.
+    Specular,
+    /// Specular color — sRGB.
+    SpecularColor,
+    /// Transmission — LINEAR.
+    Transmission,
+    /// Volume thickness — LINEAR.
+    VolumeThickness,
+}
+
+impl TextureColorKind {
+    /// Whether this kind's image is sRGB-encoded (color) vs linear (data). Drives
+    /// `TextureColorInfo::srgb_to_linear`. Kept here (next to the kinds) so the
+    /// import and reload paths can't disagree.
+    pub fn is_srgb(self) -> bool {
+        matches!(self, Self::Albedo | Self::Emissive | Self::SpecularColor)
+    }
+}
+
 /// Texture asset variants.
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -299,7 +343,14 @@ pub enum TextureDef {
     /// extension for the on-disk file; the disk path itself is derived
     /// from the entry's `content_hash` (see
     /// `AssetEntry::content_hash`), not from this string.
-    Raster { display_name: String },
+    Raster {
+        display_name: String,
+        /// The texture's semantic role — its color space + mipmap kind. `None`
+        /// for projects saved before this was tracked (the editor falls back to
+        /// inferring from the import-assigned `display_name` slot suffix on load).
+        #[serde(default)]
+        color_kind: Option<TextureColorKind>,
+    },
     /// Procedurally generated at load time.
     Procedural(ProceduralTextureDef),
 }

--- a/packages/frontend/editor/src/app.rs
+++ b/packages/frontend/editor/src/app.rs
@@ -319,15 +319,25 @@ fn typing_in_field() -> bool {
 fn save_project() {
     spawn_local(async {
         match crate::fs::ProjectDir::pick().await {
-            Ok(dir) => match crate::controller::persistence::save_to_dir(&controller(), &dir).await
-            {
-                Ok(()) => {
-                    controller().project_name.set(dir.name());
-                    controller().dirty.set_neq(false);
-                    Toast::info(format!("Saved to {}/", dir.name()));
+            Ok(dir) => {
+                // Block ALL interaction for the duration of the write. The save is an
+                // async loop over many side files (File System Access, to a real
+                // disk); if the user triggers another op or navigates mid-write the
+                // write is cut off at a variable point → a silent PARTIAL project
+                // (the missing-meshes/textures bug). The `begin_activity` guard raises
+                // the full-screen `busy_overlay` (no close, swallows all input) and
+                // auto-clears on drop the instant the save resolves.
+                let _activity =
+                    crate::engine::activity::begin_activity(format!("Saving to {}/…", dir.name()));
+                match crate::controller::persistence::save_to_dir(&controller(), &dir).await {
+                    Ok(()) => {
+                        controller().project_name.set(dir.name());
+                        controller().dirty.set_neq(false);
+                        Toast::info(format!("Saved to {}/", dir.name()));
+                    }
+                    Err(e) => Toast::error(format!("Save failed: {e}")),
                 }
-                Err(e) => Toast::error(format!("Save failed: {e}")),
-            },
+            }
             Err(crate::fs::FsError::Cancelled) => {}
             Err(crate::fs::FsError::Unsupported) => {
                 // No directory picker (e.g. Firefox/Safari): fall back to a download.

--- a/packages/frontend/editor/src/controller/export.rs
+++ b/packages/frontend/editor/src/controller/export.rs
@@ -652,7 +652,7 @@ async fn resolve_one_texture(scene: &Scene, id: AssetId) -> Option<(String, Vec<
             let (rgba, w, h) = bridge_material::procedural_rgba(&p);
             rgba_to_png(&rgba, w, h).map(|png| (format!("texture-{id}"), png))
         }
-        TextureDef::Raster { display_name } => {
+        TextureDef::Raster { display_name, .. } => {
             // Only available once uploaded to the GPU (assign the material / its
             // model first). Skipped otherwise — referenced-only.
             let key = bridge_material::texture_key_for(id)?;

--- a/packages/frontend/editor/src/controller/persistence.rs
+++ b/packages/frontend/editor/src/controller/persistence.rs
@@ -271,8 +271,8 @@ where
     F: FnMut(String) -> Fut,
     Fut: std::future::Future<Output = Result<Vec<u8>, String>>,
 {
-    use awsm_renderer_glb_export::ImageMime;
     use awsm_renderer_editor_protocol::TextureColorKind;
+    use awsm_renderer_glb_export::ImageMime;
     let mut items: Vec<(AssetId, Vec<u8>, String, TextureColorKind)> = Vec::new();
     for (id, entry) in project.assets.entries.iter() {
         let AssetSource::Texture(TextureDef::Raster {
@@ -836,7 +836,9 @@ pub struct SaveCensus {
 
 impl SaveCensus {
     pub fn is_complete(&self) -> bool {
-        self.mesh_missing_cache == 0 && self.texture_missing_cache == 0 && self.texture_unhashed == 0
+        self.mesh_missing_cache == 0
+            && self.texture_missing_cache == 0
+            && self.texture_unhashed == 0
     }
 }
 
@@ -893,8 +895,11 @@ pub fn check_save_complete(ctrl: &EditorController) -> Result<(), String> {
     if c.is_complete() {
         return Ok(());
     }
-    let (missing_mesh, missing_tex, unhashed_tex) =
-        (c.mesh_missing_cache, c.texture_missing_cache, c.texture_unhashed);
+    let (missing_mesh, missing_tex, unhashed_tex) = (
+        c.mesh_missing_cache,
+        c.texture_missing_cache,
+        c.texture_unhashed,
+    );
     let mut parts = Vec::new();
     if missing_mesh > 0 {
         parts.push(format!("{missing_mesh} mesh(es)"));
@@ -930,10 +935,11 @@ pub async fn save_to_dir(ctrl: &EditorController, dir: &crate::fs::ProjectDir) -
     // ever stops mid-loop (a backend hang or a future abort), the LAST breadcrumb
     // pinpoints exactly which phase/file it died on instead of leaving a silent
     // partial project — pairs with `write_bytes`'s per-file write-verify.
-    let text_files: Vec<(String, String)> = std::iter::once(("project.toml".to_string(), project_to_toml(ctrl)?))
-        .chain(material_files(ctrl))
-        .chain(animation_files(ctrl))
-        .collect();
+    let text_files: Vec<(String, String)> =
+        std::iter::once(("project.toml".to_string(), project_to_toml(ctrl)?))
+            .chain(material_files(ctrl))
+            .chain(animation_files(ctrl))
+            .collect();
     let byte_files: Vec<(String, Vec<u8>)> = mesh_files(ctrl)
         .into_iter()
         .chain(rig_glb_files(ctrl))
@@ -958,7 +964,10 @@ pub async fn save_to_dir(ctrl: &EditorController, dir: &crate::fs::ProjectDir) -
             .map_err(|e| EditorError::Msg(format!("save {name}: {e}")))?;
         written += 1;
     }
-    tracing::info!("save complete: wrote {written}/{total} files to {}", dir.name());
+    tracing::info!(
+        "save complete: wrote {written}/{total} files to {}",
+        dir.name()
+    );
     Ok(())
 }
 

--- a/packages/frontend/editor/src/controller/persistence.rs
+++ b/packages/frontend/editor/src/controller/persistence.rs
@@ -272,9 +272,14 @@ where
     Fut: std::future::Future<Output = Result<Vec<u8>, String>>,
 {
     use awsm_renderer_glb_export::ImageMime;
-    let mut items: Vec<(AssetId, Vec<u8>, String, bool)> = Vec::new();
+    use awsm_renderer_editor_protocol::TextureColorKind;
+    let mut items: Vec<(AssetId, Vec<u8>, String, TextureColorKind)> = Vec::new();
     for (id, entry) in project.assets.entries.iter() {
-        let AssetSource::Texture(TextureDef::Raster { display_name }) = &entry.source else {
+        let AssetSource::Texture(TextureDef::Raster {
+            display_name,
+            color_kind,
+        }) = &entry.source
+        else {
             continue;
         };
         let Some(name) = asset_filename(*id, entry) else {
@@ -285,31 +290,37 @@ where
             Some("jpg") | Some("jpeg") => ("image/jpeg", ImageMime::Jpeg),
             _ => continue,
         };
-        let linear = restored_texture_is_linear(display_name);
+        // The persisted semantic role IS the source of truth — its color space +
+        // mipmap kind flow straight to the upload. Projects saved before the role
+        // was tracked have `None` → fall back to inferring it from the
+        // import-assigned display-name slot.
+        let kind = color_kind.unwrap_or_else(|| infer_texture_color_kind(display_name));
         if let Ok(bytes) = read(format!("assets/{name}")).await {
             crate::engine::bridge::texture_cache::store(*id, bytes.clone(), mime);
-            items.push((*id, bytes, mime_str.to_string(), linear));
+            items.push((*id, bytes, mime_str.to_string(), kind));
         }
     }
     crate::engine::bridge::material::restore_raster_textures(items).await;
 }
 
-/// Classify a restored raster texture's COLOR SPACE on reload. **Data** maps
-/// (normal / metallic-roughness / occlusion / clearcoat-normal) must upload as
-/// LINEAR (`srgb_to_linear = false`, sampled verbatim); **color** maps (base
-/// color / emissive / env / created) upload as sRGB. Without this, a reloaded
-/// normal map decoded through sRGB has corrupted normals → visibly different
-/// (warmer/duller) shading than a fresh import — the save→reload "dark patch".
-///
-/// The texture asset doesn't store its `TextureColorInfo` kind yet, so we derive
-/// it from the import-assigned display name: the editor names every imported
-/// texture `"<material> · <slot>"` (see `ensure_import_texture` call sites in
-/// `state.rs`), making the slot suffix a reliable classifier. The matching fresh
-/// IMPORT path already gets this right via the per-slot `linear` flag in
-/// `material::create_texture`; this brings RELOAD to parity.
-fn restored_texture_is_linear(display_name: &str) -> bool {
+/// Best-effort recovery of a texture's [`TextureColorKind`] for OLD projects that
+/// didn't persist it: the editor names every imported texture `"<material> · <slot>"`
+/// (see `ensure_import_texture` call sites in `state.rs`), so the slot suffix
+/// recovers the role. New projects store the kind on the asset and never reach this.
+fn infer_texture_color_kind(display_name: &str) -> awsm_renderer_editor_protocol::TextureColorKind {
+    use awsm_renderer_editor_protocol::TextureColorKind as K;
     let n = display_name;
-    n.contains("normal") || n.contains("metal/rough") || n.contains("occlusion")
+    if n.contains("normal") {
+        K::Normal
+    } else if n.contains("metal/rough") {
+        K::MetallicRoughness
+    } else if n.contains("occlusion") {
+        K::Occlusion
+    } else if n.contains("emissive") {
+        K::Emissive
+    } else {
+        K::Albedo
+    }
 }
 
 /// Restore captured-mesh bytes into the [`mesh_cache`] store from a loaded

--- a/packages/frontend/editor/src/controller/persistence.rs
+++ b/packages/frontend/editor/src/controller/persistence.rs
@@ -272,7 +272,7 @@ where
     Fut: std::future::Future<Output = Result<Vec<u8>, String>>,
 {
     use awsm_renderer_glb_export::ImageMime;
-    let mut items: Vec<(AssetId, Vec<u8>, String)> = Vec::new();
+    let mut items: Vec<(AssetId, Vec<u8>, String, bool)> = Vec::new();
     for (id, entry) in project.assets.entries.iter() {
         let AssetSource::Texture(TextureDef::Raster { display_name }) = &entry.source else {
             continue;
@@ -285,12 +285,31 @@ where
             Some("jpg") | Some("jpeg") => ("image/jpeg", ImageMime::Jpeg),
             _ => continue,
         };
+        let linear = restored_texture_is_linear(display_name);
         if let Ok(bytes) = read(format!("assets/{name}")).await {
             crate::engine::bridge::texture_cache::store(*id, bytes.clone(), mime);
-            items.push((*id, bytes, mime_str.to_string()));
+            items.push((*id, bytes, mime_str.to_string(), linear));
         }
     }
     crate::engine::bridge::material::restore_raster_textures(items).await;
+}
+
+/// Classify a restored raster texture's COLOR SPACE on reload. **Data** maps
+/// (normal / metallic-roughness / occlusion / clearcoat-normal) must upload as
+/// LINEAR (`srgb_to_linear = false`, sampled verbatim); **color** maps (base
+/// color / emissive / env / created) upload as sRGB. Without this, a reloaded
+/// normal map decoded through sRGB has corrupted normals → visibly different
+/// (warmer/duller) shading than a fresh import — the save→reload "dark patch".
+///
+/// The texture asset doesn't store its `TextureColorInfo` kind yet, so we derive
+/// it from the import-assigned display name: the editor names every imported
+/// texture `"<material> · <slot>"` (see `ensure_import_texture` call sites in
+/// `state.rs`), making the slot suffix a reliable classifier. The matching fresh
+/// IMPORT path already gets this right via the per-slot `linear` flag in
+/// `material::create_texture`; this brings RELOAD to parity.
+fn restored_texture_is_linear(display_name: &str) -> bool {
+    let n = display_name;
+    n.contains("normal") || n.contains("metal/rough") || n.contains("occlusion")
 }
 
 /// Restore captured-mesh bytes into the [`mesh_cache`] store from a loaded

--- a/packages/frontend/editor/src/controller/persistence.rs
+++ b/packages/frontend/editor/src/controller/persistence.rs
@@ -615,6 +615,59 @@ where
     }
 }
 
+/// The skybox/IBL KTX2 (HDR cubemap) asset ids referenced by an environment
+/// config. The `Equirect` panorama rides `texture_cache` (persists like an imported
+/// texture); only the KTX HDR bytes live session-only in `env_sync`, so only those
+/// need explicit side files.
+fn env_ktx_ids(env: &awsm_renderer_editor_protocol::EnvironmentConfig) -> Vec<AssetId> {
+    use awsm_renderer_editor_protocol::{IblConfig, SkyboxConfig};
+    let mut ids = Vec::new();
+    if let SkyboxConfig::Ktx { asset_id } = env.skybox {
+        ids.push(asset_id);
+    }
+    if let IblConfig::Ktx {
+        prefiltered_asset_id,
+        irradiance_asset_id,
+    } = env.ibl
+    {
+        ids.push(prefiltered_asset_id);
+        ids.push(irradiance_asset_id);
+    }
+    ids
+}
+
+/// Per-environment KTX2/HDR cubemap side files (`assets/<id>.ktx2`). The
+/// `EnvironmentConfig` ids round-trip in `project.toml`, but the HDR BYTES live
+/// session-only in `env_sync`'s stash — so without this an HDR skybox/IBL reverts to
+/// the built-in default on reload. Mirrors `texture_files` for the env's KTX assets.
+pub fn ktx_files(ctrl: &EditorController) -> Vec<(String, Vec<u8>)> {
+    let env = ctrl.scene.environment.get_cloned();
+    env_ktx_ids(&env)
+        .into_iter()
+        .filter_map(|id| {
+            crate::engine::bridge::env_sync::ktx_bytes(id)
+                .map(|bytes| (format!("assets/{}.ktx2", id.0), bytes))
+        })
+        .collect()
+}
+
+/// Restore the env's KTX2 HDR bytes into `env_sync`'s stash from a loaded project
+/// (via `read`, reading `assets/<id>.ktx2`). Call BEFORE [`apply_project`] sets the
+/// environment, so the `env_sync` watcher resolves the skybox/IBL the first time it
+/// applies — a DECLARED LOAD INPUT. Missing files are skipped (non-HDR / older).
+async fn restore_ktx<F, Fut>(project: &EditorProject, mut read: F)
+where
+    F: FnMut(String) -> Fut,
+    Fut: std::future::Future<Output = Result<Vec<u8>, String>>,
+{
+    for id in env_ktx_ids(&project.environment) {
+        let path = format!("assets/{}.ktx2", id.0);
+        if let Ok(bytes) = read(path).await {
+            crate::engine::bridge::env_sync::stash_ktx(id, bytes);
+        }
+    }
+}
+
 /// Per-clip animation side files — the full authored model serialized as TOML
 /// (mirrors `material_files`). Each path matches the `CustomAnimationRef.file` in
 /// `project.toml` via the shared [`animation_file_path`] (so the writer can't
@@ -718,56 +771,172 @@ pub fn apply_project(ctrl: &EditorController, project: EditorProject) {
     ctrl.scene.bump_revision();
 }
 
+/// SAVE-COMPLETENESS INVARIANT — "a Save loses nothing, or fails loudly".
+///
+/// A project's `project.toml` carries everything serializable inline (scene tree,
+/// material params/uniforms, animation, env, the asset *table*). But the BYTES of
+/// imported geometry + textures live ONLY in session-local caches
+/// ([`mesh_cache`](crate::engine::bridge::mesh_cache) /
+/// [`texture_cache`](crate::engine::bridge::texture_cache)); Save streams them out
+/// as `.mesh.bin` / `.png` side files. If a cache is incomplete at Save time (e.g.
+/// an import's async populate hasn't settled), those side files silently go
+/// missing — the reload then shows missing meshes / white materials, and re-saving
+/// that broken project overwrites the good one. This check makes that condition a
+/// hard, RETRYABLE error instead of silent data loss.
+///
+/// Only NON-regenerable assets are required: a captured/imported/edited mesh
+/// ([`MeshBase::Captured`]) has no recipe — its `.mesh.bin` IS the source of
+/// truth; primitive/lathe/sweep/SDF meshes are exempt (the loader re-bakes them
+/// from their stack). An imported raster texture's encoded bytes are likewise the
+/// only copy. Returns a human-readable summary of what's not yet persistable.
+/// Census of persistable-byte completeness for the live project — the read-only
+/// truth behind [`check_save_complete`] and the `SaveCensus` query (Phase 0.2 of
+/// the roundtrip plan). `*_assets` = how many of that kind exist in the asset
+/// table; `*_missing_cache` = how many lack their bytes in the session cache (so a
+/// save would drop them); `texture_unhashed` = raster textures whose import never
+/// captured a content_hash (can't be addressed/persisted at all).
+#[derive(Debug, Clone, Default, serde::Serialize)]
+pub struct SaveCensus {
+    pub mesh_assets: usize,
+    pub mesh_missing_cache: usize,
+    pub texture_assets: usize,
+    pub texture_missing_cache: usize,
+    pub texture_unhashed: usize,
+}
+
+impl SaveCensus {
+    pub fn is_complete(&self) -> bool {
+        self.mesh_missing_cache == 0 && self.texture_missing_cache == 0 && self.texture_unhashed == 0
+    }
+}
+
+/// Compute the [`SaveCensus`] for the live project (read-only; no mutation, no I/O).
+pub fn save_census(ctrl: &EditorController) -> SaveCensus {
+    use crate::engine::bridge::{mesh_cache, texture_cache};
+    use awsm_renderer_editor_protocol::{MeshBase, MeshRef};
+    let assets = ctrl.scene.assets.lock().unwrap();
+    let mut c = SaveCensus::default();
+    for (id, entry) in assets.entries.iter() {
+        match &entry.source {
+            // Captured-base meshes (imported / collapsed / raw-edited) are
+            // non-regenerable: their bytes must be live in the cache to persist.
+            AssetSource::Mesh(def) => {
+                c.mesh_assets += 1;
+                if let MeshBase::Captured(MeshRef(snap)) = &def.stack.base {
+                    let snap = *snap;
+                    if mesh_cache::get_captured(*id).is_none()
+                        || (snap != *id && mesh_cache::get_captured(snap).is_none())
+                    {
+                        c.mesh_missing_cache += 1;
+                    }
+                }
+            }
+            // Imported raster textures: the encoded bytes are the only copy. An
+            // empty content_hash means the import never captured them (so they
+            // can't be addressed/persisted at all) — also a loss.
+            AssetSource::Texture(TextureDef::Raster { .. }) => {
+                c.texture_assets += 1;
+                if entry.content_hash.is_empty() {
+                    c.texture_unhashed += 1;
+                } else if texture_cache::get(*id).is_none() {
+                    c.texture_missing_cache += 1;
+                }
+            }
+            _ => {}
+        }
+    }
+    c
+}
+
+pub fn check_save_complete(ctrl: &EditorController) -> Result<(), String> {
+    let c = save_census(ctrl);
+    // Census on every save — surfaces a 38→N drop even when the guard passes.
+    tracing::info!(
+        "save census: mesh_assets={} (missing_cache={}) texture_assets={} \
+         (missing_cache={} unhashed={})",
+        c.mesh_assets,
+        c.mesh_missing_cache,
+        c.texture_assets,
+        c.texture_missing_cache,
+        c.texture_unhashed
+    );
+    if c.is_complete() {
+        return Ok(());
+    }
+    let (missing_mesh, missing_tex, unhashed_tex) =
+        (c.mesh_missing_cache, c.texture_missing_cache, c.texture_unhashed);
+    let mut parts = Vec::new();
+    if missing_mesh > 0 {
+        parts.push(format!("{missing_mesh} mesh(es)"));
+    }
+    if missing_tex > 0 {
+        parts.push(format!("{missing_tex} texture(s)"));
+    }
+    if unhashed_tex > 0 {
+        parts.push(format!("{unhashed_tex} texture(s) with no captured bytes"));
+    }
+    Err(format!(
+        "refusing to save — {} have no persistable bytes yet (import not fully \
+         settled). Nothing was written, so your existing save is untouched. Wait \
+         for the import to finish (or re-import the model) and Save again.",
+        parts.join(", ")
+    ))
+}
+
 /// Save the project to a picked directory (File System Access): writes
 /// `project.toml` at the root plus each custom material's and clip's side files
 /// under `assets/` — material bodies in `assets/materials/<slug>-<id>/` and clips
 /// as `assets/animations/animation-<slug>-<id>.toml` (the stable id keeps
 /// same-named entries from colliding), matching the ref paths recorded in
 /// `project.toml`. `write_text` creates the subdirectories as it writes.
+///
+/// Refuses up-front (writing NOTHING) if the save would drop imported geometry /
+/// textures — see [`check_save_complete`]. This is the "lose nothing" backstop: a
+/// partial save must never silently clobber a good one.
 pub async fn save_to_dir(ctrl: &EditorController, dir: &crate::fs::ProjectDir) -> EditorResult<()> {
-    dir.write_text("project.toml", &project_to_toml(ctrl)?)
-        .await
-        .map_err(|e| EditorError::Msg(e.to_string()))?;
-    for (name, content) in material_files(ctrl) {
-        dir.write_text(&name, &content)
+    check_save_complete(ctrl).map_err(EditorError::Msg)?;
+    // Gather every side file up-front (counts are known before any I/O), then write
+    // with a per-phase tracing breadcrumb + a final "wrote N/N" summary. If the save
+    // ever stops mid-loop (a backend hang or a future abort), the LAST breadcrumb
+    // pinpoints exactly which phase/file it died on instead of leaving a silent
+    // partial project — pairs with `write_bytes`'s per-file write-verify.
+    let text_files: Vec<(String, String)> = std::iter::once(("project.toml".to_string(), project_to_toml(ctrl)?))
+        .chain(material_files(ctrl))
+        .chain(animation_files(ctrl))
+        .collect();
+    let byte_files: Vec<(String, Vec<u8>)> = mesh_files(ctrl)
+        .into_iter()
+        .chain(rig_glb_files(ctrl))
+        .chain(bind_pose_files(ctrl))
+        .chain(texture_files(ctrl))
+        .chain(cluster_files(ctrl))
+        .chain(ktx_files(ctrl))
+        .collect();
+    let total = text_files.len() + byte_files.len();
+    let mut written = 0usize;
+    for (name, content) in &text_files {
+        tracing::debug!("save: writing {name} ({}/{total})", written + 1);
+        dir.write_text(name, content)
             .await
-            .map_err(|e| EditorError::Msg(e.to_string()))?;
+            .map_err(|e| EditorError::Msg(format!("save {name}: {e}")))?;
+        written += 1;
     }
-    for (name, content) in animation_files(ctrl) {
-        dir.write_text(&name, &content)
+    for (name, bytes) in &byte_files {
+        tracing::debug!("save: writing {name} ({}/{total})", written + 1);
+        dir.write_bytes(name, bytes)
             .await
-            .map_err(|e| EditorError::Msg(e.to_string()))?;
+            .map_err(|e| EditorError::Msg(format!("save {name}: {e}")))?;
+        written += 1;
     }
-    for (name, bytes) in mesh_files(ctrl) {
-        dir.write_bytes(&name, &bytes)
-            .await
-            .map_err(|e| EditorError::Msg(e.to_string()))?;
-    }
-    for (name, bytes) in rig_glb_files(ctrl) {
-        dir.write_bytes(&name, &bytes)
-            .await
-            .map_err(|e| EditorError::Msg(e.to_string()))?;
-    }
-    for (name, bytes) in bind_pose_files(ctrl) {
-        dir.write_bytes(&name, &bytes)
-            .await
-            .map_err(|e| EditorError::Msg(e.to_string()))?;
-    }
-    for (name, bytes) in texture_files(ctrl) {
-        dir.write_bytes(&name, &bytes)
-            .await
-            .map_err(|e| EditorError::Msg(e.to_string()))?;
-    }
-    for (name, bytes) in cluster_files(ctrl) {
-        dir.write_bytes(&name, &bytes)
-            .await
-            .map_err(|e| EditorError::Msg(e.to_string()))?;
-    }
+    tracing::info!("save complete: wrote {written}/{total} files to {}", dir.name());
     Ok(())
 }
 
 /// Load a project from a picked directory: reads `project.toml` + rebuilds the
-/// live scene. (Reloading custom-material bodies into the Studio is the follow-on.)
+/// live scene. Custom-material bodies (wgsl / alpha / vertex / uniforms / textures /
+/// includes) ride the inline `StoredMaterial` in `project.toml` and are restored into
+/// `custom_materials` + re-registered by `apply_project` (`material_from_stored` +
+/// `spawn_auto_register`), so the Studio shows them on reload.
 pub async fn load_from_dir(
     ctrl: &EditorController,
     dir: &crate::fs::ProjectDir,
@@ -797,6 +966,10 @@ pub async fn load_from_dir(
     // Re-read view-only cluster ("nanite") DAGs into the cluster_cache BEFORE the
     // scene materialises, so ClusterMesh nodes render after a cold reload.
     restore_cluster_meshes(&project, |path| async move {
+        dir.read_bytes(&path).await.map_err(|e| e.to_string())
+    })
+    .await;
+    restore_ktx(&project, |path| async move {
         dir.read_bytes(&path).await.map_err(|e| e.to_string())
     })
     .await;
@@ -836,6 +1009,7 @@ pub fn serialize_inmem(
     byte_files.extend(bind_pose_files(ctrl));
     byte_files.extend(texture_files(ctrl));
     byte_files.extend(cluster_files(ctrl));
+    byte_files.extend(ktx_files(ctrl));
     Ok((toml, byte_files))
 }
 
@@ -879,6 +1053,11 @@ pub async fn apply_inmem(
     restore_cluster_meshes(&project, |path| {
         let bytes = byte_files.get(&path).cloned();
         async move { bytes.ok_or_else(|| format!("missing in-memory cluster DAG: {path}")) }
+    })
+    .await;
+    restore_ktx(&project, |path| {
+        let bytes = byte_files.get(&path).cloned();
+        async move { bytes.ok_or_else(|| format!("missing in-memory ktx: {path}")) }
     })
     .await;
     apply_project(ctrl, project);
@@ -960,6 +1139,7 @@ pub async fn load_project_from_url(ctrl: &EditorController, base_url: &str) -> E
     restore_textures(&project, http_bytes!()).await;
     // Re-read cluster ("nanite") DAGs BEFORE apply_project (so ClusterMesh nodes render).
     restore_cluster_meshes(&project, http_bytes!()).await;
+    restore_ktx(&project, http_bytes!()).await;
     apply_project(ctrl, project);
     // Restore rig glb (bundle export) + bind poses (drop_skinning) AFTER apply.
     restore_rig_glb(ctrl, http_bytes!()).await;

--- a/packages/frontend/editor/src/controller/state.rs
+++ b/packages/frontend/editor/src/controller/state.rs
@@ -7720,10 +7720,7 @@ fn build_editor_subtree(
     asset_id: AssetId,
     mat_ids: &[AssetId],
     default_mat_id: Option<AssetId>,
-    node_meshes: &std::collections::HashMap<
-        (u32, Option<u32>),
-        (awsm_renderer_glb_export::MeshData, Option<Vec<[f32; 4]>>),
-    >,
+    node_meshes: &crate::engine::bridge::gltf::NodeMeshMaps,
     node_flat_indices: &std::collections::HashMap<u32, u32>,
     fallback_name: Option<&str>,
     node_map: &mut std::collections::HashMap<u32, NodeId>,

--- a/packages/frontend/editor/src/controller/state.rs
+++ b/packages/frontend/editor/src/controller/state.rs
@@ -7932,7 +7932,8 @@ fn build_editor_subtree(
                     Trs::IDENTITY,
                     NodeKind::Group,
                 );
-                if let Some((mesh, tangents)) = node_meshes.get(&(tn.gltf_node_index, Some(i as u32)))
+                if let Some((mesh, tangents)) =
+                    node_meshes.get(&(tn.gltf_node_index, Some(i as u32)))
                 {
                     let mesh_ref =
                         mint_imported_mesh(part.id, &part_label, mesh, tangents.as_ref(), asset_id);

--- a/packages/frontend/editor/src/controller/state.rs
+++ b/packages/frontend/editor/src/controller/state.rs
@@ -13,7 +13,7 @@ use crate::engine::scene::{mutate, AssetId, NodeId, NodeKind, Scene};
 use crate::error::EditorResult;
 use awsm_renderer_editor_protocol::{
     AssetEntry, AssetSource as SceneAssetSource, BoundedHistory, MaterialDef, ModifierStack,
-    ProceduralTextureDef, TextureDef,
+    ProceduralTextureDef, TextureColorKind, TextureDef,
 };
 use std::sync::Arc;
 
@@ -2707,6 +2707,7 @@ impl EditorController {
                     AssetEntry::new_with_hash(
                         SceneAssetSource::Texture(TextureDef::Raster {
                             display_name: format!("env-{}.{ext}", &id.to_string()[..8]),
+                            color_kind: None,
                         }),
                         hash,
                     ),
@@ -2963,6 +2964,7 @@ impl EditorController {
                             id,
                             AssetEntry::new(SceneAssetSource::Texture(TextureDef::Raster {
                                 display_name: name,
+                                color_kind: None,
                             })),
                         );
                         self.scene.bump_revision();
@@ -3007,6 +3009,7 @@ impl EditorController {
                             id,
                             AssetEntry::new(SceneAssetSource::Texture(TextureDef::Raster {
                                 display_name: format!("created-{}", &id.to_string()[..8]),
+                                color_kind: None,
                             })),
                         );
                         self.scene.bump_revision();
@@ -3802,6 +3805,7 @@ impl EditorController {
             AssetId,
             String,
             Option<(String, awsm_renderer_glb_export::ImageMime)>,
+            TextureColorKind,
         )> = Vec::new();
         let mut mat_ids: Vec<AssetId> = Vec::with_capacity(import.materials.len());
 
@@ -3817,6 +3821,7 @@ impl EditorController {
                 &mut texture_entries,
                 ex.textures.base_color,
                 &format!("{label} · base color"),
+                TextureColorKind::Albedo,
                 &import.texture_images,
             );
             def.metallic_roughness_texture = ensure_import_texture(
@@ -3824,6 +3829,7 @@ impl EditorController {
                 &mut texture_entries,
                 ex.textures.metallic_roughness,
                 &format!("{label} · metal/rough"),
+                TextureColorKind::MetallicRoughness,
                 &import.texture_images,
             );
             def.normal_texture = ensure_import_texture(
@@ -3831,6 +3837,7 @@ impl EditorController {
                 &mut texture_entries,
                 ex.textures.normal,
                 &format!("{label} · normal"),
+                TextureColorKind::Normal,
                 &import.texture_images,
             );
             def.occlusion_texture = ensure_import_texture(
@@ -3838,6 +3845,7 @@ impl EditorController {
                 &mut texture_entries,
                 ex.textures.occlusion,
                 &format!("{label} · occlusion"),
+                TextureColorKind::Occlusion,
                 &import.texture_images,
             );
             def.emissive_texture = ensure_import_texture(
@@ -3845,17 +3853,20 @@ impl EditorController {
                 &mut texture_entries,
                 ex.textures.emissive,
                 &format!("{label} · emissive"),
+                TextureColorKind::Emissive,
                 &import.texture_images,
             );
             // KHR-extension texture slots (clearcoat normal map, specular colour
             // map, sheen colour map, …): create a texture asset for each + write
-            // the TextureRef onto the matching extension field.
+            // the TextureRef onto the matching extension field. The slot name maps
+            // to the texture's color kind (so its color space + mipmaps persist).
             for (slot, baked) in &ex.ext_textures {
                 let tref = ensure_import_texture(
                     &mut tex_for_key,
                     &mut texture_entries,
                     Some(*baked),
                     &format!("{label} · {slot}"),
+                    ext_slot_color_kind(slot),
                     &import.texture_images,
                 );
                 set_ext_texture(&mut def.extensions, slot, tref);
@@ -3883,20 +3894,24 @@ impl EditorController {
         let img_ids: Vec<AssetId> = texture_entries.iter().map(|(id, ..)| *id).collect();
         let asset_id = {
             let mut table = self.scene.assets.lock().unwrap();
-            for (id, name, hash_mime) in &texture_entries {
+            for (id, name, hash_mime, color_kind) in &texture_entries {
                 // Captured bytes ⇒ a file-backed entry (content_hash addresses
                 // `assets/<hash>.<ext>`; the ext rides the display_name so
                 // `asset_filename` derives it). Otherwise a plain (session-only)
                 // entry — e.g. an external-file-URI texture we couldn't capture.
+                // `color_kind` carries the slot's semantic (color space + mipmaps)
+                // so a Save→reload re-uploads with the same meaning.
                 let entry = match hash_mime {
                     Some((hash, mime)) => AssetEntry::new_with_hash(
                         SceneAssetSource::Texture(TextureDef::Raster {
                             display_name: format!("{name}.{}", mime.ext()),
+                            color_kind: Some(*color_kind),
                         }),
                         hash.clone(),
                     ),
                     None => AssetEntry::new(SceneAssetSource::Texture(TextureDef::Raster {
                         display_name: name.clone(),
+                        color_kind: Some(*color_kind),
                     })),
                 };
                 table.entries.insert(*id, entry);
@@ -7522,12 +7537,14 @@ fn ensure_import_texture(
         AssetId,
         String,
         Option<(String, awsm_renderer_glb_export::ImageMime)>,
+        TextureColorKind,
     )>,
     baked: Option<(
         awsm_renderer::textures::TextureKey,
         crate::engine::bridge::gltf::TexBinding,
     )>,
     name: &str,
+    color_kind: TextureColorKind,
     texture_images: &std::collections::HashMap<
         awsm_renderer::textures::TextureKey,
         awsm_renderer_glb_export::ExportImage,
@@ -7558,8 +7575,27 @@ fn ensure_import_texture(
         crate::engine::bridge::texture_cache::store(id, img.bytes.clone(), img.mime);
         (hash, img.mime)
     });
-    texture_entries.push((id, name.to_string(), hash_mime));
+    texture_entries.push((id, name.to_string(), hash_mime, color_kind));
     Some(mk(id))
+}
+
+/// Map a KHR-extension texture slot name (the keys of `ExtractedMaterial::ext_textures`)
+/// to its color kind, so persisted extension textures reload with the right color
+/// space + mipmaps. Unknown slots default to `Albedo` (sRGB) — the safe default for a
+/// color-ish map; the linear data-map extensions are matched explicitly.
+fn ext_slot_color_kind(slot: &str) -> TextureColorKind {
+    match slot {
+        s if s.contains("clearcoat_normal") => TextureColorKind::Normal,
+        s if s.contains("clearcoat") => TextureColorKind::MetallicRoughness, // roughness/factor maps — linear
+        s if s.contains("specular_color") || s.contains("sheen_color") => {
+            TextureColorKind::SpecularColor
+        }
+        s if s.contains("specular") || s.contains("sheen") => TextureColorKind::Specular,
+        s if s.contains("transmission") => TextureColorKind::Transmission,
+        s if s.contains("thickness") || s.contains("volume") => TextureColorKind::VolumeThickness,
+        s if s.contains("iridescence") || s.contains("anisotropy") => TextureColorKind::Normal, // linear data
+        _ => TextureColorKind::Albedo,
+    }
 }
 
 /// SHA-256 hex of texture bytes — the `content_hash` that addresses the on-disk
@@ -8580,7 +8616,7 @@ mod equirect_persistence_tests {
                 .get(&id)
                 .expect("env texture asset registered");
             assert!(
-                matches!(&entry.source, SceneAssetSource::Texture(TextureDef::Raster { display_name }) if display_name.ends_with(".png")),
+                matches!(&entry.source, SceneAssetSource::Texture(TextureDef::Raster { display_name, .. }) if display_name.ends_with(".png")),
                 "env asset must be a .png raster texture"
             );
             assert!(

--- a/packages/frontend/editor/src/controller/state.rs
+++ b/packages/frontend/editor/src/controller/state.rs
@@ -1436,8 +1436,9 @@ impl EditorController {
                 // the node's kind. Reuses the import bake path (deterministic id =
                 // node id), so it persists like any captured mesh.
                 let label = n.name.get_cloned();
-                // drop_skinning bakes the bind pose; UV sets ride mesh.uvs.
-                let mesh_ref = mint_imported_mesh(node, &label, &mesh, skin.source);
+                // drop_skinning bakes the bind pose; UV sets ride mesh.uvs. No authored
+                // tangents on a baked bind pose → None (regenerated at commit).
+                let mesh_ref = mint_imported_mesh(node, &label, &mesh, None, skin.source);
                 // Hide the now-orphaned skinned populate copy so it stops rendering
                 // (the node now renders its captured bind-pose Mesh instead).
                 if let Some(template) = crate::engine::bridge::bridge().get_template(skin.source) {
@@ -5205,6 +5206,10 @@ impl EditorController {
                     entries,
                 })
             }
+            EditorQuery::SaveCensus => QueryResult::Text(
+                serde_json::to_string(&crate::controller::persistence::save_census(self))
+                    .unwrap_or_default(),
+            ),
             EditorQuery::MemoryStats => {
                 use serde_json::json;
                 // Renderer-side object counts (under the renderer guard)…
@@ -7578,6 +7583,7 @@ fn mint_imported_mesh(
     node_id: NodeId,
     label: &str,
     mesh: &awsm_renderer_glb_export::MeshData,
+    tangents: Option<&Vec<[f32; 4]>>,
     source_asset: AssetId,
 ) -> awsm_renderer_editor_protocol::MeshRef {
     use crate::engine::bridge::mesh_cache;
@@ -7585,8 +7591,12 @@ fn mint_imported_mesh(
     use awsm_renderer_editor_protocol::{MeshBase, ModifierStack};
 
     let mesh_id = AssetId(node_id.0);
-    // `from_mesh_data` folds every UV set (incl. TEXCOORD_1) from `mesh.uvs`.
-    mesh_cache::store_with_id(mesh_id, mesh_cache::from_mesh_data(mesh.clone()));
+    // `from_mesh_data` folds every UV set (incl. TEXCOORD_1) from `mesh.uvs`; attach
+    // the authored glTF tangents (if any) so the captured mesh preserves the exact
+    // basis a normal map was baked against across save→reload.
+    let mut captured = mesh_cache::from_mesh_data(mesh.clone());
+    captured.tangents = tangents.cloned();
+    mesh_cache::store_with_id(mesh_id, captured);
     let stack = ModifierStack {
         base: MeshBase::Captured(MeshRef(mesh_id)),
         modifiers: vec![],
@@ -7674,7 +7684,10 @@ fn build_editor_subtree(
     asset_id: AssetId,
     mat_ids: &[AssetId],
     default_mat_id: Option<AssetId>,
-    node_meshes: &std::collections::HashMap<(u32, Option<u32>), awsm_renderer_glb_export::MeshData>,
+    node_meshes: &std::collections::HashMap<
+        (u32, Option<u32>),
+        (awsm_renderer_glb_export::MeshData, Option<Vec<[f32; 4]>>),
+    >,
     node_flat_indices: &std::collections::HashMap<u32, u32>,
     fallback_name: Option<&str>,
     node_map: &mut std::collections::HashMap<u32, NodeId>,
@@ -7764,7 +7777,7 @@ fn build_editor_subtree(
             let material = instance_for(mat_indices.first().copied().flatten());
             // Stash the bind-pose geometry (no JOINTS/WEIGHTS) so `drop_skinning`
             // can bake it to a static editable Mesh later.
-            if let Some(mesh) = node_meshes.get(&(tn.gltf_node_index, None)) {
+            if let Some((mesh, _tangents)) = node_meshes.get(&(tn.gltf_node_index, None)) {
                 crate::engine::bridge::skinned_bake_cache::store(
                     asset_id,
                     tn.gltf_node_index,
@@ -7804,7 +7817,9 @@ fn build_editor_subtree(
                         .map(|m| m.name.get_cloned())
                     })
                     .unwrap_or_else(|| format!("{name} · part {i}"));
-                if let Some(mesh) = node_meshes.get(&(tn.gltf_node_index, Some(i as u32))) {
+                if let Some((mesh, _tangents)) =
+                    node_meshes.get(&(tn.gltf_node_index, Some(i as u32)))
+                {
                     crate::engine::bridge::skinned_bake_cache::store(
                         asset_id,
                         tn.gltf_node_index,
@@ -7845,8 +7860,9 @@ fn build_editor_subtree(
             let material = instance_for(mat_indices.first().copied().flatten());
             // The whole-node merged geometry (every primitive concatenated).
             let mesh_node = Node::new_with_transform_and_kind(name.clone(), trs, NodeKind::Group);
-            if let Some(mesh) = node_meshes.get(&(tn.gltf_node_index, None)) {
-                let mesh_ref = mint_imported_mesh(mesh_node.id, &name, mesh, asset_id);
+            if let Some((mesh, tangents)) = node_meshes.get(&(tn.gltf_node_index, None)) {
+                let mesh_ref =
+                    mint_imported_mesh(mesh_node.id, &name, mesh, tangents.as_ref(), asset_id);
                 mesh_node.kind.set(NodeKind::Mesh {
                     mesh: mesh_ref,
                     material,
@@ -7880,8 +7896,10 @@ fn build_editor_subtree(
                     Trs::IDENTITY,
                     NodeKind::Group,
                 );
-                if let Some(mesh) = node_meshes.get(&(tn.gltf_node_index, Some(i as u32))) {
-                    let mesh_ref = mint_imported_mesh(part.id, &part_label, mesh, asset_id);
+                if let Some((mesh, tangents)) = node_meshes.get(&(tn.gltf_node_index, Some(i as u32)))
+                {
+                    let mesh_ref =
+                        mint_imported_mesh(part.id, &part_label, mesh, tangents.as_ref(), asset_id);
                     part.kind.set(NodeKind::Mesh {
                         mesh: mesh_ref,
                         material,

--- a/packages/frontend/editor/src/engine/bridge/env_sync.rs
+++ b/packages/frontend/editor/src/engine/bridge/env_sync.rs
@@ -46,6 +46,13 @@ fn stashed_ktx(id: AssetId) -> Option<Vec<u8>> {
     KTX_BYTES.with(|m| m.borrow().get(&id).cloned())
 }
 
+/// The stashed KTX bytes for `id` — the persistence seam (`persistence::ktx_files`
+/// writes them to `assets/<id>.ktx2`; `restore_ktx` re-stashes them via [`stash_ktx`]
+/// on reload so an HDR skybox/IBL survives Save→reload).
+pub fn ktx_bytes(id: AssetId) -> Option<Vec<u8>> {
+    stashed_ktx(id)
+}
+
 /// A decoded equirect panorama: RGBA8 pixels + `(width, height)` (§18).
 type EquirectImage = (Vec<u8>, u32, u32);
 

--- a/packages/frontend/editor/src/engine/bridge/gltf.rs
+++ b/packages/frontend/editor/src/engine/bridge/gltf.rs
@@ -53,7 +53,7 @@ pub struct GltfImport {
     /// accessor values; the editor node carries the glTF node's local transform,
     /// so the geometry is used as-is (no extra matrix). Skinned meshes bake to
     /// their bind pose (JOINTS/WEIGHTS are not read).
-    pub node_meshes: HashMap<(u32, Option<u32>), MeshData>,
+    pub node_meshes: HashMap<(u32, Option<u32>), (MeshData, Option<Vec<[f32; 4]>>)>,
     /// `Some` when the import carries skins: the whole rig (geometry + skeleton +
     /// joints/weights + morph) re-exported through our writer into a clean glb
     /// (materials/animations dropped). This is what the player bundle ships for
@@ -211,7 +211,7 @@ pub async fn import_file(name: &str, url: &str) -> Result<GltfImport, String> {
 /// (see [`awsm_renderer_glb_export::extract_node_mesh`] on the no-double-transform rule).
 /// Per-node primary geometry keyed by `(node_index, primitive_index)`. ALL UV sets
 /// (incl. `TEXCOORD_1`) ride `MeshData.uvs` now — no separate parallel map.
-type NodeMeshMaps = HashMap<(u32, Option<u32>), MeshData>;
+type NodeMeshMaps = HashMap<(u32, Option<u32>), (MeshData, Option<Vec<[f32; 4]>>)>;
 
 fn extract_node_meshes(data: &GltfData) -> NodeMeshMaps {
     let buffers = &data.buffers.raw;
@@ -219,11 +219,12 @@ fn extract_node_meshes(data: &GltfData) -> NodeMeshMaps {
     for node in data.doc.nodes() {
         let Some(mesh) = node.mesh() else { continue };
         let node_index = node.index() as u32;
-        // Whole-node merge (the common, single-material case).
+        // Whole-node merge (the common, single-material case). `ex.tangents` rides
+        // alongside the geometry so the captured mesh preserves the authored basis.
         if let Some(ex) =
             awsm_renderer_glb_export::extract_node_mesh(&data.doc, buffers, node_index, None)
         {
-            out.insert((node_index, None), ex.mesh);
+            out.insert((node_index, None), (ex.mesh, ex.tangents));
         }
         // Per-primitive (used when a node's primitives carry different materials
         // and the controller destructures it into one Mesh child per primitive).
@@ -236,7 +237,7 @@ fn extract_node_meshes(data: &GltfData) -> NodeMeshMaps {
                     node_index,
                     Some(i),
                 ) {
-                    out.insert((node_index, Some(i)), ex.mesh);
+                    out.insert((node_index, Some(i)), (ex.mesh, ex.tangents));
                 }
             }
         }
@@ -264,8 +265,14 @@ async fn import_typed(
     // Grab the ENCODED texture bytes (PNG/JPEG) off the document before populate
     // consumes it — the renderer keeps only decoded pixels, so these are what we
     // persist (paired with the baked TextureKeys below). Keyed by glTF tex index.
-    let tex_images_by_index =
-        awsm_renderer_glb_export::extract_texture_images(&data.doc, &data.buffers.raw);
+    // Resolve embedded AND external-URI images: the loader re-fetched external-file
+    // image bytes into `data.encoded_images`, so persistence captures them too
+    // (else an external-URI texture drops on save→reload — P0-A).
+    let tex_images_by_index = awsm_renderer_glb_export::extract_texture_images_with_external(
+        &data.doc,
+        &data.buffers.raw,
+        &data.encoded_images,
+    );
     // Parse animations off the document before `data` is moved into populate.
     // A parse error must not abort the whole import — log it + import zero clips.
     let animations = match extract_animations(&data.doc, &data.buffers.raw) {

--- a/packages/frontend/editor/src/engine/bridge/gltf.rs
+++ b/packages/frontend/editor/src/engine/bridge/gltf.rs
@@ -53,7 +53,7 @@ pub struct GltfImport {
     /// accessor values; the editor node carries the glTF node's local transform,
     /// so the geometry is used as-is (no extra matrix). Skinned meshes bake to
     /// their bind pose (JOINTS/WEIGHTS are not read).
-    pub node_meshes: HashMap<(u32, Option<u32>), (MeshData, Option<Vec<[f32; 4]>>)>,
+    pub node_meshes: NodeMeshMaps,
     /// `Some` when the import carries skins: the whole rig (geometry + skeleton +
     /// joints/weights + morph) re-exported through our writer into a clean glb
     /// (materials/animations dropped). This is what the player bundle ships for
@@ -209,9 +209,10 @@ pub async fn import_file(name: &str, url: &str) -> Result<GltfImport, String> {
 /// single Mesh node or destructure a multi-material node per-primitive — exactly
 /// the cases the old `Model` path covered. Positions are raw local accessor values
 /// (see [`awsm_renderer_glb_export::extract_node_mesh`] on the no-double-transform rule).
-/// Per-node primary geometry keyed by `(node_index, primitive_index)`. ALL UV sets
-/// (incl. `TEXCOORD_1`) ride `MeshData.uvs` now — no separate parallel map.
-type NodeMeshMaps = HashMap<(u32, Option<u32>), (MeshData, Option<Vec<[f32; 4]>>)>;
+/// Per-node primary geometry keyed by `(node_index, primitive_index)`, with the
+/// node's optional authored tangents alongside its `MeshData`. ALL UV sets (incl.
+/// `TEXCOORD_1`) ride `MeshData.uvs` — no separate parallel map.
+pub type NodeMeshMaps = HashMap<(u32, Option<u32>), (MeshData, Option<Vec<[f32; 4]>>)>;
 
 fn extract_node_meshes(data: &GltfData) -> NodeMeshMaps {
     let buffers = &data.buffers.raw;

--- a/packages/frontend/editor/src/engine/bridge/material.rs
+++ b/packages/frontend/editor/src/engine/bridge/material.rs
@@ -222,20 +222,24 @@ pub(crate) async fn create_texture(
 /// uploads + the single pool-finalising `commit_load` happen under one lock in
 /// ONE batch (not per-texture — transaction-aligned).
 ///
-/// Color space: re-uploaded as sRGB albedo (the visible base-color case is
-/// correct). The per-slot linear-vs-sRGB classification isn't persisted on the
-/// texture asset yet, so normal/metallic-roughness/occlusion maps restore in the
-/// albedo color space — a follow-up (store the `TextureColorInfo` kind per
-/// `TextureDef::Raster`).
-pub(crate) async fn restore_raster_textures(items: Vec<(AssetId, Vec<u8>, String)>) {
+/// Color space: each item carries a `linear` flag (4th tuple field) — `true` for
+/// DATA maps (normal / metallic-roughness / occlusion) which upload verbatim
+/// (`srgb_to_linear = false`), `false` for color maps (base color / emissive)
+/// which sRGB-decode. The caller (`persistence::restore_textures`) derives it from
+/// the import-assigned display-name slot. This matches the per-slot color space
+/// the fresh-import path sets in [`create_texture`]; a normal map reloaded as sRGB
+/// has corrupted normals → the save→reload shading drift.
+pub(crate) async fn restore_raster_textures(items: Vec<(AssetId, Vec<u8>, String, bool)>) {
     if items.is_empty() {
         return;
     }
-    // Decode all (async, network/codec) BEFORE taking the renderer lock.
-    let mut decoded: Vec<(AssetId, Vec<u8>, u32, u32)> = Vec::with_capacity(items.len());
-    for (id, bytes, mime) in &items {
+    // Decode all (async, network/codec) BEFORE taking the renderer lock. Carry the
+    // per-texture `linear` flag (true for DATA maps — normal/metal-rough/occlusion —
+    // which must NOT be sRGB-decoded) through to the upload.
+    let mut decoded: Vec<(AssetId, Vec<u8>, u32, u32, bool)> = Vec::with_capacity(items.len());
+    for (id, bytes, mime, linear) in &items {
         match decode_rgba_from_bytes(bytes, mime).await {
-            Ok((rgba, w, h)) => decoded.push((*id, rgba, w, h)),
+            Ok((rgba, w, h)) => decoded.push((*id, rgba, w, h, *linear)),
             Err(e) => tracing::warn!("restore texture {id}: {e}"),
         }
     }
@@ -248,12 +252,14 @@ pub(crate) async fn restore_raster_textures(items: Vec<(AssetId, Vec<u8>, String
         tracing::warn!("restore textures: no sampler");
         return;
     };
-    let color = TextureColorInfo {
-        mipmap_kind: MipmapTextureKind::Albedo,
-        srgb_to_linear: true,
-        premultiplied_alpha: None,
-    };
-    for (id, rgba, w, h) in &decoded {
+    for (id, rgba, w, h, linear) in &decoded {
+        // sRGB for color maps; LINEAR (sampled verbatim) for data maps — matches the
+        // per-slot color space the fresh-import path sets in `create_texture`.
+        let color = TextureColorInfo {
+            mipmap_kind: MipmapTextureKind::Albedo,
+            srgb_to_linear: !*linear,
+            premultiplied_alpha: None,
+        };
         match r
             .textures
             .add_image_rgba_raw(rgba, *w, *h, sampler_key, color)

--- a/packages/frontend/editor/src/engine/bridge/material.rs
+++ b/packages/frontend/editor/src/engine/bridge/material.rs
@@ -15,7 +15,8 @@ use awsm_renderer_core::sampler::{AddressMode, FilterMode, MipmapFilterMode};
 use awsm_renderer_core::texture::mipmap::MipmapTextureKind;
 use awsm_renderer_core::texture::texture_pool::TextureColorInfo;
 use awsm_renderer_editor_protocol::{
-    AssetSource, MaterialDef, MaterialShading, ProceduralTextureDef, TextureDef, TextureRef,
+    AssetSource, MaterialDef, MaterialShading, ProceduralTextureDef, TextureColorKind, TextureDef,
+    TextureRef,
 };
 
 use crate::engine::scene::AssetId;
@@ -222,24 +223,50 @@ pub(crate) async fn create_texture(
 /// uploads + the single pool-finalising `commit_load` happen under one lock in
 /// ONE batch (not per-texture — transaction-aligned).
 ///
-/// Color space: each item carries a `linear` flag (4th tuple field) — `true` for
-/// DATA maps (normal / metallic-roughness / occlusion) which upload verbatim
-/// (`srgb_to_linear = false`), `false` for color maps (base color / emissive)
-/// which sRGB-decode. The caller (`persistence::restore_textures`) derives it from
-/// the import-assigned display-name slot. This matches the per-slot color space
-/// the fresh-import path sets in [`create_texture`]; a normal map reloaded as sRGB
-/// has corrupted normals → the save→reload shading drift.
-pub(crate) async fn restore_raster_textures(items: Vec<(AssetId, Vec<u8>, String, bool)>) {
+/// The renderer upload descriptor for a texture's semantic role — the SINGLE place
+/// that maps a [`TextureColorKind`] to its `TextureColorInfo` (color space + mipmap
+/// kind), so the import and reload paths can never disagree. `premultiplied_alpha`
+/// stays `None` (use the image's own setting), matching `renderer-gltf::populate`.
+pub(crate) fn color_info_for_kind(kind: TextureColorKind) -> TextureColorInfo {
+    let mipmap_kind = match kind {
+        TextureColorKind::Albedo => MipmapTextureKind::Albedo,
+        TextureColorKind::Normal => MipmapTextureKind::Normal,
+        TextureColorKind::MetallicRoughness => MipmapTextureKind::MetallicRoughness,
+        TextureColorKind::Occlusion => MipmapTextureKind::Occlusion,
+        TextureColorKind::Emissive => MipmapTextureKind::Emissive,
+        TextureColorKind::Specular => MipmapTextureKind::Specular,
+        TextureColorKind::SpecularColor => MipmapTextureKind::SpecularColor,
+        TextureColorKind::Transmission => MipmapTextureKind::Transmission,
+        TextureColorKind::VolumeThickness => MipmapTextureKind::VolumeThickness,
+    };
+    TextureColorInfo {
+        mipmap_kind,
+        srgb_to_linear: kind.is_srgb(),
+        premultiplied_alpha: None,
+    }
+}
+
+/// Color space + mipmaps: each item carries its [`TextureColorKind`] (4th tuple
+/// field) — the texture's semantic role persisted on the asset. [`color_info_for_kind`]
+/// maps it to the full `TextureColorInfo` (sRGB-decode for color kinds, verbatim for
+/// data kinds; role-specific mipmap kind). This makes RELOAD upload textures with the
+/// exact same meaning as fresh IMPORT — a normal map reloaded as sRGB albedo has
+/// corrupted normals + wrong mipmaps (the save→reload shading drift).
+pub(crate) async fn restore_raster_textures(
+    items: Vec<(AssetId, Vec<u8>, String, TextureColorKind)>,
+) {
     if items.is_empty() {
         return;
     }
     // Decode all (async, network/codec) BEFORE taking the renderer lock. Carry the
-    // per-texture `linear` flag (true for DATA maps — normal/metal-rough/occlusion —
-    // which must NOT be sRGB-decoded) through to the upload.
-    let mut decoded: Vec<(AssetId, Vec<u8>, u32, u32, bool)> = Vec::with_capacity(items.len());
-    for (id, bytes, mime, linear) in &items {
+    // per-texture semantic ROLE through so the upload picks the right color space +
+    // mipmap kind (data maps — normal/metal-rough/occlusion — must NOT sRGB-decode
+    // and get role-specific mipmaps).
+    let mut decoded: Vec<(AssetId, Vec<u8>, u32, u32, TextureColorKind)> =
+        Vec::with_capacity(items.len());
+    for (id, bytes, mime, kind) in &items {
         match decode_rgba_from_bytes(bytes, mime).await {
-            Ok((rgba, w, h)) => decoded.push((*id, rgba, w, h, *linear)),
+            Ok((rgba, w, h)) => decoded.push((*id, rgba, w, h, *kind)),
             Err(e) => tracing::warn!("restore texture {id}: {e}"),
         }
     }
@@ -252,14 +279,10 @@ pub(crate) async fn restore_raster_textures(items: Vec<(AssetId, Vec<u8>, String
         tracing::warn!("restore textures: no sampler");
         return;
     };
-    for (id, rgba, w, h, linear) in &decoded {
-        // sRGB for color maps; LINEAR (sampled verbatim) for data maps — matches the
-        // per-slot color space the fresh-import path sets in `create_texture`.
-        let color = TextureColorInfo {
-            mipmap_kind: MipmapTextureKind::Albedo,
-            srgb_to_linear: !*linear,
-            premultiplied_alpha: None,
-        };
+    for (id, rgba, w, h, kind) in &decoded {
+        // The role's full TextureColorInfo (color space + mipmap kind) — identical
+        // to what the fresh-import path uses, so RELOAD == IMPORT.
+        let color = color_info_for_kind(*kind);
         match r
             .textures
             .add_image_rgba_raw(rgba, *w, *h, sampler_key, color)

--- a/packages/frontend/editor/src/engine/bridge/mesh_cache.rs
+++ b/packages/frontend/editor/src/engine/bridge/mesh_cache.rs
@@ -29,6 +29,9 @@ pub fn from_mesh_data(m: MeshData) -> CapturedMesh {
         uvs: uv_sets.next(),
         uvs1: uv_sets.next(),
         colors: m.colors,
+        // `MeshData` carries no tangents; the import path sets `CapturedMesh.tangents`
+        // separately (from the glTF TANGENT attr) after this conversion.
+        tangents: None,
         indices: m.indices,
     }
 }
@@ -70,6 +73,9 @@ pub fn get_raw(id: AssetId) -> Option<RawMeshData> {
             uv_sets: m.uvs.clone().into_iter().chain(m.uvs1.clone()).collect(),
             colors: m.colors.clone(),
             indices: m.indices.clone(),
+            // Authored tangents (imported glTF TANGENT) → used verbatim at commit;
+            // `None` for edited/procedural meshes → regenerated as before.
+            tangents: m.tangents.clone(),
             ..Default::default()
         })
     })

--- a/packages/frontend/editor/src/engine/bridge/node_sync.rs
+++ b/packages/frontend/editor/src/engine/bridge/node_sync.rs
@@ -993,6 +993,7 @@ fn raw_mesh_from_rig(skin: &awsm_renderer_editor_protocol::SkinnedMeshRef) -> Op
         return None;
     }
 
+    let tangents = decode.tangents;
     let m = decode.mesh;
     Some(RawMeshData {
         positions: m.positions,
@@ -1001,6 +1002,8 @@ fn raw_mesh_from_rig(skin: &awsm_renderer_editor_protocol::SkinnedMeshRef) -> Op
         uv_sets: m.uvs,
         colors: m.colors,
         indices: m.indices,
+        // Authored tangents from the rig glb decode → used verbatim (else regenerated).
+        tangents,
         skin: raw_skin,
         morph: raw_morph,
     })

--- a/packages/frontend/editor/src/engine/bridge/skinned_bake_cache.rs
+++ b/packages/frontend/editor/src/engine/bridge/skinned_bake_cache.rs
@@ -12,12 +12,13 @@
 //! triple a [`SkinnedMeshRef`](awsm_renderer_editor_protocol::SkinnedMeshRef) carries — so a
 //! `drop_skinning` on any skinned node resolves its bake directly.
 //!
-//! TODO(cross-reload persistence): like the old `model_source_cache`, this is
-//! session-local — it does NOT survive a project Save → reload. A reloaded
-//! project's `SkinnedMesh` nodes re-render only if the source is re-imported; a
-//! `drop_skinning` after a cold reload (no cached bake) currently errors. Full
-//! persistence would write each skinned node's bind-pose bytes to the project's
-//! `assets/` on Save and read them back on Load.
+//! Cross-reload persistence (DONE): `persistence::bind_pose_files` writes each
+//! skinned node's bind-pose bytes to `assets/<source>.<node>.<prim>.bake.bin` on
+//! Save, and `restore_bind_poses` re-stashes them on Load — so `drop_skinning`
+//! works after a cold reload. The clean rig glb (`rig_glb_files`/
+//! `restore_skinned_templates`) similarly makes `SkinnedMesh` nodes re-render
+//! without a re-import. (This store itself stays session-local; the side files are
+//! the persisted source of truth.)
 
 use std::cell::RefCell;
 use std::collections::HashMap;

--- a/packages/frontend/editor/src/engine/context.rs
+++ b/packages/frontend/editor/src/engine/context.rs
@@ -204,7 +204,10 @@ struct AppContext {
 fn editor_features() -> RendererFeatures {
     use awsm_renderer::features::FeatureToggle;
     RendererFeatures {
-        gpu_culling: true,
+        // GPU-driven HZB occlusion culling. `?noocclusion` forces it off — used to
+        // confirm/repro occlusion-cull false-positives (small meshes nestled between
+        // occluders vanishing at distance).
+        gpu_culling: !url_has_flag("noocclusion"),
         decals: true,
         coverage_lod: false,
         // The canvas wires `.pick()` to pointer-down for node selection (M6).

--- a/packages/frontend/editor/src/engine/context.rs
+++ b/packages/frontend/editor/src/engine/context.rs
@@ -204,10 +204,7 @@ struct AppContext {
 fn editor_features() -> RendererFeatures {
     use awsm_renderer::features::FeatureToggle;
     RendererFeatures {
-        // GPU-driven HZB occlusion culling. `?noocclusion` forces it off — used to
-        // confirm/repro occlusion-cull false-positives (small meshes nestled between
-        // occluders vanishing at distance).
-        gpu_culling: !url_has_flag("noocclusion"),
+        gpu_culling: true,
         decals: true,
         coverage_lod: false,
         // The canvas wires `.pick()` to pointer-down for node selection (M6).

--- a/packages/frontend/editor/src/fs.rs
+++ b/packages/frontend/editor/src/fs.rs
@@ -158,6 +158,24 @@ impl ProjectDir {
         uint8.copy_from(content);
         JsFuture::from(stream.write_with_buffer_source(&uint8)?).await?;
         JsFuture::from(stream.close()).await?;
+        // Verify the bytes actually landed. Some File System Access backends (esp.
+        // a picked cross-process directory) can resolve `close()` yet drop/truncate
+        // the write — which would silently produce a partial project (missing
+        // meshes / textures on reload). Re-read the file size and fail LOUD on a
+        // mismatch so the save errors (and the prior good save is untouched) rather
+        // than half-writing. Cheap: one getFile per file.
+        let file_value = JsFuture::from(file_handle.get_file()).await?;
+        let file: web_sys::File = file_value
+            .dyn_into()
+            .map_err(|_| FsError::Js("write verify: getFile() did not return a File".into()))?;
+        let wrote = file.size() as usize;
+        if wrote != content.len() {
+            return Err(FsError::Js(format!(
+                "write verify failed for {path}: wrote {} bytes but file is {wrote} \
+                 (File System Access dropped/truncated the write)",
+                content.len()
+            )));
+        }
         Ok(())
     }
 

--- a/packages/frontend/editor/src/scene_mode/content_browser.rs
+++ b/packages/frontend/editor/src/scene_mode/content_browser.rs
@@ -517,7 +517,7 @@ fn shading_badge(def: &MaterialDef) -> (String, Tone) {
 
 fn texture_view(def: &TextureDef) -> (String, String, String) {
     match def {
-        TextureDef::Raster { display_name } => (
+        TextureDef::Raster { display_name, .. } => (
             display_name.clone(),
             "raster".to_string(),
             "linear-gradient(135deg, oklch(0.4 0.03 255), oklch(0.25 0.02 255))".to_string(),

--- a/packages/frontend/editor/src/scene_mode/inspector.rs
+++ b/packages/frontend/editor/src/scene_mode/inspector.rs
@@ -1725,7 +1725,7 @@ pub(crate) fn collect_texture_assets() -> Vec<(AssetId, String)> {
                         }
                     }
                     .to_string(),
-                    awsm_renderer_editor_protocol::TextureDef::Raster { display_name } => {
+                    awsm_renderer_editor_protocol::TextureDef::Raster { display_name, .. } => {
                         display_name.clone()
                     }
                 };
@@ -4372,7 +4372,7 @@ fn asset_name(id: AssetId, source: &AssetSource) -> String {
         AssetSource::Material(_) => "Material".to_string(),
         AssetSource::Mesh(def) if !def.label.is_empty() => def.label.clone(),
         AssetSource::Mesh(_) => "Mesh".to_string(),
-        AssetSource::Texture(TextureDef::Raster { display_name }) => display_name.clone(),
+        AssetSource::Texture(TextureDef::Raster { display_name, .. }) => display_name.clone(),
         AssetSource::Texture(TextureDef::Procedural(ProceduralTextureDef::Checker { .. })) => {
             "Checker".to_string()
         }

--- a/packages/mcp/editor-protocol/src/assets.rs
+++ b/packages/mcp/editor-protocol/src/assets.rs
@@ -47,7 +47,7 @@ impl AssetSource {
     pub fn display_name(&self) -> Option<&str> {
         match self {
             Self::Filename(name) => Some(name.as_str()),
-            Self::Texture(TextureDef::Raster { display_name }) => Some(display_name.as_str()),
+            Self::Texture(TextureDef::Raster { display_name, .. }) => Some(display_name.as_str()),
             _ => None,
         }
     }
@@ -165,7 +165,7 @@ pub fn asset_filename(id: AssetId, entry: &AssetEntry) -> Option<String> {
     }
     let display = match &entry.source {
         AssetSource::Filename(name) => name.as_str(),
-        AssetSource::Texture(TextureDef::Raster { display_name }) => display_name.as_str(),
+        AssetSource::Texture(TextureDef::Raster { display_name, .. }) => display_name.as_str(),
         _ => return None,
     };
     let ext = display.rsplit_once('.').map(|(_, e)| e).unwrap_or("");

--- a/packages/mcp/editor-protocol/src/mesh_def.rs
+++ b/packages/mcp/editor-protocol/src/mesh_def.rs
@@ -188,6 +188,14 @@ pub struct CapturedMesh {
     #[serde(default)]
     pub uvs1: Option<Vec<[f32; 2]>>,
     pub colors: Option<Vec<[f32; 4]>>,
+    /// Optional authored per-vertex `TANGENT` (vec4: xyz + handedness), vertex-aligned
+    /// with `positions`. Carried from an imported glTF's TANGENT attribute so the
+    /// captured mesh preserves the EXACT tangent basis a normal map was baked against
+    /// across save→reload (else the renderer regenerates via MikkTSpace and shades
+    /// differently — the dark-patch bug). `#[serde(default)]` so pre-feature
+    /// `.mesh.bin` files (and edited/procedural meshes, which carry none) round-trip.
+    #[serde(default)]
+    pub tangents: Option<Vec<[f32; 4]>>,
     pub indices: Vec<u32>,
 }
 
@@ -239,6 +247,7 @@ impl CapturedMesh {
         check("uvs", self.uvs.as_ref().map(|v| v.len()))?;
         check("uvs1", self.uvs1.as_ref().map(|v| v.len()))?;
         check("colors", self.colors.as_ref().map(|v| v.len()))?;
+        check("tangents", self.tangents.as_ref().map(|v| v.len()))?;
         Ok(())
     }
 }

--- a/packages/mcp/editor-protocol/src/query.rs
+++ b/packages/mcp/editor-protocol/src/query.rs
@@ -273,6 +273,13 @@ pub enum EditorQuery {
     /// slopes mean healthy; a steady climb on an idle scene is a leak. A read —
     /// no mutation.
     MemoryStats,
+    /// Save-completeness census (Phase 0.2 roundtrip oracle): how many mesh /
+    /// raster-texture assets exist vs how many lack their persistable bytes in the
+    /// session cache (so a save would drop them). Returned as a JSON `Text` payload
+    /// (`SaveCensus`). The decisive "did the import fully populate the persistence
+    /// caches" probe — `*_missing_cache`/`*_unhashed` of 0 means a lossless save.
+    /// A read — no mutation.
+    SaveCensus,
     /// Renderer-side animation runtime state (clip/channel lowering diagnostics):
     /// how many clip groups + RESOLVED channels actually lowered into the
     /// renderer, the rest-cache size, and the mixer layer count — plus the

--- a/packages/mcp/editor-protocol/tests/mesh_roundtrip.rs
+++ b/packages/mcp/editor-protocol/tests/mesh_roundtrip.rs
@@ -43,6 +43,7 @@ fn sample_captured_mesh() -> CapturedMesh {
             [0.0, 0.0, 1.0, 1.0],
             [1.0, 1.0, 1.0, 0.5],
         ]),
+        tangents: None,
         indices: vec![0, 1, 2, 0, 2, 3],
     }
 }
@@ -101,6 +102,48 @@ fn mesh_asset_entry_bitcode_roundtrip() {
     assert_eq!(project, back);
 }
 
+/// P2-D: a NON-empty modifier stack (the audit flagged this as untested) must
+/// round-trip exactly through both project.json (serde-JSON) and the per-game
+/// bitcode artifact — so an edited mesh's recipe reloads identically.
+#[test]
+fn mesh_modifier_stack_roundtrips() {
+    use awsm_renderer_meshgen::recipe::{Axis, Modifier};
+    let asset_id = AssetId::new();
+    let mut project = project_with_mesh_asset(asset_id, "modded");
+    if let AssetSource::Mesh(def) = &mut project.assets.entries.get_mut(&asset_id).unwrap().source {
+        def.stack.modifiers = vec![
+            Modifier::Twist {
+                axis: Axis::Y,
+                turns: 0.75,
+            },
+            Modifier::Inflate { amount: 0.2 },
+            Modifier::Array {
+                count: 4,
+                offset: [1.0, 0.0, 0.5],
+            },
+            Modifier::Displace {
+                expr: "sin(x*3.0)".to_string(),
+            },
+        ];
+    }
+    let json = serde_json::to_string(&project).expect("serialize");
+    assert_eq!(
+        project,
+        serde_json::from_str::<EditorProject>(&json).expect("deserialize"),
+        "modifier stack json roundtrip"
+    );
+    let bytes = bitcode::serialize(&project).expect("bitcode serialize");
+    assert_eq!(
+        project,
+        bitcode::deserialize::<EditorProject>(&bytes).expect("bitcode deserialize"),
+        "modifier stack bitcode roundtrip"
+    );
+    match &project.assets.entries.get(&asset_id).unwrap().source {
+        AssetSource::Mesh(def) => assert_eq!(def.stack.modifiers.len(), 4),
+        other => panic!("expected Mesh, got {other:?}"),
+    }
+}
+
 #[test]
 fn captured_mesh_bitcode_roundtrip() {
     // The on-disk side-file shape — bitcode is what the editor's Save
@@ -130,6 +173,7 @@ fn captured_mesh_handles_optional_attrs() {
         uvs: None,
         uvs1: None,
         colors: None,
+        tangents: None,
         indices: vec![0, 1, 2],
     };
     let bytes = bitcode::serialize(&mesh).expect("bitcode serialize");
@@ -314,6 +358,7 @@ fn captured_mesh_validate_rejects_empty_and_degenerate() {
         uvs: None,
         uvs1: None,
         colors: None,
+        tangents: None,
         indices: vec![],
     };
     assert!(empty.validate(false).is_err(), "empty should be rejected");


### PR DESCRIPTION
Two independent fixes that came up together.

## 1. Save → Load is lossless (the main work)

**Root cause of the data loss:** the project Save was a fire-and-forget `spawn_local`; doing anything else mid-write (re-import, new project, navigate) cut the write loop off at a variable point → a silent partial project on disk (variable `.mesh.bin` count, missing textures, no error). Extraction and the byte caches were always complete — proven with a no-browser oracle and an in-editor census.

**Fixes:**
- **Interrupted-save guard** — Save now holds a blocking modal (`app.rs` → `begin_activity` → `busy_overlay`) across the write, plus per-file write-verify (`fs.rs`) and a save-completeness guard/census (`persistence.rs`). A partial save can never silently clobber a good one.
- **Texture color space + mipmaps survive reload** — `restore_raster_textures` was uploading every reloaded texture as sRGB albedo; normal / metallic-roughness / occlusion maps must be **linear** with their own mipmap kind. `TextureDef::Raster` now persists a `color_kind` (the glTF slot role), and one seam — `material::color_info_for_kind` — maps it to the full `TextureColorInfo` on reload, so **reload == import**. Old projects fall back to inferring the role from the texture's display name. This was the "dark patch / wrong tone after reload."
- **Authored-tangent parity** through the static/captured + skinned + player paths (no MikkTSpace regeneration when the model authors tangents).
- **External-URI textures** now persist (`extract_texture_images_with_external` feeds the loader's `encoded_images`).
- **KTX/HDR environment** bytes persist as side files (`ktx_files`/`restore_ktx`).
- Phase-0 **no-browser extraction oracle** + in-editor `SaveCensus` query, a non-empty **modifier-stack roundtrip test**, and stale-comment/TODO cleanups.

Editor-only on the persistence path; the player already handles per-texture srgb via `scene-loader::texture`. No render-hot-path changes, no per-frame allocations. Plan/record: `docs/plans/save-load-roundtrip.md`.

Open follow-ups (product decisions, not regressions): procedural-texture persistence, runtime morph multi-track mixing, and "a reloaded captured mesh isn't editable until re-imported."

## 2. HZB occlusion-cull false-positives (small meshes vanishing at distance)

Small meshes nestled between larger occluders (e.g. a robot's neck between head and torso) were being occlusion-culled and vanishing when small on screen — both ortho and perspective, "sometimes." The cull sampled a **single HZB texel at the AABB's projected center** at a coarse mip; that one texel can land on closer neighbouring geometry and miss the farther-depth part of the footprint, so the test over-culls. Now it samples the **2×2 texels covering the AABB footprint** (at a mip where the footprint spans ≤2 texels) and takes their max — the standard conservative test. The 2×2 max only ever raises the compared depth, so it removes false-positives without weakening genuine occlusion. Verified at radius 4→16, front and side.

Cost: +3 `textureLoad`s in the cull compute pass — negligible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)