### PR TITLE
Persist custom-material buffer slots as first-class assets

### DIFF
--- a/packages/crates/scene-loader/src/dynamic.rs
+++ b/packages/crates/scene-loader/src/dynamic.rs
@@ -10,7 +10,7 @@
 //!
 //! Scope: uniforms (defaults + per-mesh `uniform_overrides`), per-mesh
 //! `texture_overrides` (the bake emits each as `assets/<id>.png`), and per-mesh
-//! `buffer_overrides` (the bake emits each as `assets/buffer-<id>.bin` of
+//! `buffer_overrides` (the bake emits each as `assets/<asset>.bin` of
 //! little-endian u32 words) — all bound here like the editor's `build_custom`.
 //! Texture/buffer slots with no per-mesh override stay unbound (correct: an
 //! unbound texture samples transparent-black; there is no "default texture"
@@ -33,7 +33,7 @@ use awsm_renderer_materials::{
 };
 use awsm_renderer_scene::{
     AssetId, FieldType as SFieldType, MaterialAlphaMode as SAlphaMode, MaterialDefinition,
-    MaterialInstance, Scene, UniformValue as SUniformValue,
+    MaterialInstance, Scene, UniformValue as SUniformValue, ASSETS_DIR,
 };
 
 use crate::assets::SceneAssets;
@@ -80,7 +80,7 @@ pub async fn register_custom_materials(
 /// Build a per-mesh `Material::Custom` for a registered custom material, applying
 /// the instance's `uniform_overrides` (by name + type), `texture_overrides` (each
 /// `assets/<id>.png` decoded + staged), and `buffer_overrides` (each
-/// `assets/buffer-<id>.bin` of little-endian u32 words) — exactly like the
+/// `assets/<asset>.bin` of little-endian u32 words) — exactly like the
 /// editor's `build_custom`. Returns `None` if the shader id isn't registered.
 /// Slots without an override stay unbound (no "default texture" concept).
 pub async fn build_custom_material(
@@ -161,20 +161,23 @@ pub async fn build_custom_material(
         }
     }
 
-    // Per-mesh buffer overrides (slot order): the bake emitted each as a `.bin`
-    // (little-endian u32 words) at the BufferRef path; read them back into the
-    // slot. An override whose `.bin` is absent leaves the slot unbound.
+    // Per-mesh buffer overrides (slot order): the bake emitted each as
+    // `assets/<asset>.bin` (little-endian u32 words), keyed by the override's
+    // asset id — exactly like a texture's `assets/<asset>.png`. Read it back into
+    // the slot; an override whose `.bin` is absent leaves the slot unbound.
     let mut buffers: Vec<Option<Vec<u32>>> = vec![None; buffer_slots.len()];
     for (i, name) in buffer_slots.iter().enumerate() {
         if let Some(bref) = inst.buffer_overrides.get(name) {
-            let path = bref.path.to_string_lossy();
-            if let Ok(bytes) = assets.fetch(path.as_ref()).await {
+            let path = format!("{ASSETS_DIR}/{}.bin", bref.asset);
+            if let Ok(bytes) = assets.fetch(&path).await {
                 buffers[i] = Some(
                     bytes
                         .chunks_exact(4)
                         .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
                         .collect(),
                 );
+            } else {
+                tracing::warn!("scene-loader: bundle missing buffer `{path}` — slot left unbound");
             }
         }
     }

--- a/packages/crates/scene/src/dynamic_material.rs
+++ b/packages/crates/scene/src/dynamic_material.rs
@@ -311,16 +311,30 @@ pub struct MaterialInstance {
     pub buffer_overrides: HashMap<String, BufferRef>,
 }
 
-/// Project-relative pointer to a `.bin` buffer file. Mirrors
-/// [`crate::primitive::TextureRef`]; the type exists separately so the
-/// editor can flag the field with a `.bin` file-picker UI rather than a
-/// texture-asset picker.
-#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+/// Pointer to a buffer-data asset bound into a custom-material buffer slot.
+/// Mirrors [`crate::primitive::TextureRef`]: it carries a durable `AssetId`, not
+/// a path. The bytes (raw little-endian `u32` words) are content-addressed like a
+/// raster texture — the editor caches them and persists `assets/<content_hash>.bin`;
+/// the player fetches `assets/<asset>.bin`. (Earlier builds stored a transient
+/// `session://buffer/<id>` path here, which didn't survive a project reload.)
+#[derive(Clone, Copy, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct BufferRef {
-    /// Project-relative path to a `.bin` file.
-    pub path: PathBuf,
+    /// Stable id of the buffer-data asset bound to this slot.
+    pub asset: AssetId,
+}
+
+impl BufferRef {
+    pub fn new(asset: AssetId) -> Self {
+        Self { asset }
+    }
+}
+
+impl From<AssetId> for BufferRef {
+    fn from(asset: AssetId) -> Self {
+        Self::new(asset)
+    }
 }
 
 /// Resolved, in-memory representation of a custom-material folder.

--- a/packages/frontend/editor/src/controller/export.rs
+++ b/packages/frontend/editor/src/controller/export.rs
@@ -96,15 +96,15 @@ pub async fn bake_player_bundle(
     use awsm_renderer_editor_protocol::{lower_mesh, project_to_scene};
 
     let project = crate::controller::persistence::to_editor_project(ctrl);
-    let mut scene = project_to_scene(&project);
+    let scene = project_to_scene(&project);
     let mut files: Vec<BundleFile> = Vec::new();
 
-    // 0. Custom-material BUFFER overrides: the per-mesh `buffer_overrides` carry a
-    //    session path into the editor's in-memory word store. Emit each as
-    //    `assets/buffer-<id>.bin` and rewrite the path to that bundle-relative
-    //    location so the player can read it back (the words don't otherwise
-    //    survive the bake — they're not in the asset table like textures).
-    rewrite_buffer_overrides(&mut scene.nodes, &mut files);
+    // 0. Custom-material BUFFER overrides → `assets/<asset>.bin`. Each override
+    //    references a content-addressed buffer asset whose words live in the
+    //    session `buffer_cache`; emit them keyed by asset id (mirroring how
+    //    textures emit `assets/<id>.png`). No ref rewrite needed — the player
+    //    fetches `assets/<bref.asset>.bin` directly.
+    emit_buffer_overrides(&scene.nodes, &mut files);
 
     // Mesh assets whose referencing nodes opt **in** to LOD (default on). The
     // toggle is per-node but geometry/levels are per-asset, so an asset gets LOD
@@ -236,37 +236,45 @@ fn collect_lod_static_assets(
     }
 }
 
-/// Emit each custom-material BUFFER override's words as `assets/buffer-<id>.bin`
-/// and rewrite its `BufferRef` path to that bundle location. The editor stores
-/// override words in an in-memory session map keyed by a `session://buffer/<id>`
-/// path; that path means nothing to the player, and (unlike textures) the words
-/// aren't in the asset table — so the bake must materialize them. Recurses the
-/// whole tree (operates on the baked `Scene`'s plain nodes, pre-serialization).
-fn rewrite_buffer_overrides(
-    nodes: &mut [awsm_renderer_editor_protocol::EditorNode],
+/// Emit each custom-material BUFFER override's words as `assets/<asset>.bin`
+/// (content-addressed buffer asset, words read from the session `buffer_cache`) —
+/// the same id-keyed scheme textures use (`assets/<id>.png`). The player fetches
+/// `assets/<bref.asset>.bin`, so the `BufferRef` needs no rewrite. Deduped by
+/// asset id (a buffer shared across meshes emits once). Recurses the whole tree
+/// (operates on the baked `Scene`'s plain nodes).
+fn emit_buffer_overrides(
+    nodes: &[awsm_renderer_editor_protocol::EditorNode],
     files: &mut Vec<awsm_renderer_editor_protocol::BundleFile>,
 ) {
-    use awsm_renderer_editor_protocol::{BundleFile, NodeKind, ASSETS_DIR};
-    for node in nodes {
-        let material = match &mut node.kind {
-            NodeKind::Mesh { material, .. } | NodeKind::SkinnedMesh { material, .. } => {
-                material.as_mut()
-            }
-            _ => None,
-        };
-        if let Some(inst) = material {
-            for bref in inst.buffer_overrides.values_mut() {
-                let path = bref.path.to_string_lossy().to_string();
-                if let Some(words) = crate::engine::bridge::dynamic::buffer_words_for(&path) {
-                    let leaf = format!("buffer-{}.bin", AssetId::new().0);
-                    let bytes: Vec<u8> = words.iter().flat_map(|w| w.to_le_bytes()).collect();
-                    files.push(BundleFile::asset(leaf.clone(), bytes));
-                    bref.path = std::path::PathBuf::from(format!("{ASSETS_DIR}/{leaf}"));
+    fn walk(
+        nodes: &[awsm_renderer_editor_protocol::EditorNode],
+        files: &mut Vec<awsm_renderer_editor_protocol::BundleFile>,
+        seen: &mut HashSet<AssetId>,
+    ) {
+        use awsm_renderer_editor_protocol::{BundleFile, NodeKind};
+        for node in nodes {
+            let material = match &node.kind {
+                NodeKind::Mesh { material, .. } | NodeKind::SkinnedMesh { material, .. } => {
+                    material.as_ref()
+                }
+                _ => None,
+            };
+            if let Some(inst) = material {
+                for bref in inst.buffer_overrides.values() {
+                    if !seen.insert(bref.asset) {
+                        continue;
+                    }
+                    if let Some(words) = crate::engine::bridge::buffer_cache::get(bref.asset) {
+                        let bytes: Vec<u8> = words.iter().flat_map(|w| w.to_le_bytes()).collect();
+                        files.push(BundleFile::asset(format!("{}.bin", bref.asset), bytes));
+                    }
                 }
             }
+            walk(&node.children, files, seen);
         }
-        rewrite_buffer_overrides(&mut node.children, files);
     }
+    let mut seen = HashSet::new();
+    walk(nodes, files, &mut seen);
 }
 
 /// Walk a subtree collecting the (unique, ordered) texture asset ids referenced

--- a/packages/frontend/editor/src/controller/persistence.rs
+++ b/packages/frontend/editor/src/controller/persistence.rs
@@ -303,6 +303,78 @@ where
     crate::engine::bridge::material::restore_raster_textures(items).await;
 }
 
+/// Per-buffer-asset side files (`assets/<content_hash>.bin`) — the raw
+/// little-endian u32 words bound to a custom-material buffer slot via
+/// `set_material_buffer`, content-addressed exactly like an imported raster
+/// texture. The renderer only keeps the words packed into its extras pool, so the
+/// originals live session-locally in
+/// [`buffer_cache`](crate::engine::bridge::buffer_cache) until Save reads them;
+/// without this side file the slot binds to nothing on reload and the mesh renders
+/// garbage. Mirrors [`texture_files`]. The player-bundle bake emits the same words
+/// keyed by asset id (`export::emit_buffer_overrides`).
+pub fn buffer_files(ctrl: &EditorController) -> Vec<(String, Vec<u8>)> {
+    use crate::engine::bridge::buffer_cache;
+    let mut out = Vec::new();
+    let assets = ctrl.scene.assets.lock().unwrap();
+    for (id, entry) in assets.entries.iter() {
+        if !matches!(&entry.source, AssetSource::Buffer(_)) {
+            continue;
+        }
+        let Some(name) = asset_filename(*id, entry) else {
+            continue; // no content_hash → not addressable (shouldn't happen)
+        };
+        if let Some(words) = buffer_cache::get(*id) {
+            let bytes: Vec<u8> = words.iter().flat_map(|w| w.to_le_bytes()).collect();
+            out.push((format!("assets/{name}"), bytes));
+        }
+    }
+    out
+}
+
+/// Restore buffer-asset bytes on LOAD: for each `AssetSource::Buffer` entry in the
+/// project's asset table, read its `assets/<content_hash>.bin` side file, decode
+/// the little-endian u32 words, and seed the
+/// [`buffer_cache`](crate::engine::bridge::buffer_cache) (so a buffer override
+/// resolves by asset id the first time the mesh materializes — and a later re-save
+/// persists it again). Called **before** [`apply_project`] — a DECLARED LOAD
+/// INPUT, like [`restore_textures`]. Returns the labels of buffer assets whose
+/// backing file couldn't be resolved (the caller surfaces these in
+/// `missing_assets`); previously such a slot failed silently and the mesh rendered
+/// garbage with no warning.
+async fn restore_buffers<F, Fut>(project: &EditorProject, mut read: F) -> Vec<String>
+where
+    F: FnMut(String) -> Fut,
+    Fut: std::future::Future<Output = Result<Vec<u8>, String>>,
+{
+    let mut missing = Vec::new();
+    for (id, entry) in project.assets.entries.iter() {
+        if !matches!(&entry.source, AssetSource::Buffer(_)) {
+            continue;
+        }
+        let Some(name) = asset_filename(*id, entry) else {
+            continue;
+        };
+        match read(format!("assets/{name}")).await {
+            Ok(bytes) if bytes.len() % 4 == 0 => {
+                let words: Vec<u32> = bytes
+                    .chunks_exact(4)
+                    .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+                    .collect();
+                crate::engine::bridge::buffer_cache::store(*id, words);
+            }
+            Ok(_) => {
+                tracing::warn!("buffer {id}: {name} length not a multiple of 4");
+                missing.push(format!("material buffer ({name})"));
+            }
+            Err(_) => {
+                tracing::warn!("buffer {id}: missing side file {name}");
+                missing.push(format!("material buffer ({name})"));
+            }
+        }
+    }
+    missing
+}
+
 /// Best-effort recovery of a texture's [`TextureColorKind`] for OLD projects that
 /// didn't persist it: the editor names every imported texture `"<material> · <slot>"`
 /// (see `ensure_import_texture` call sites in `state.rs`), so the slot suffix
@@ -832,6 +904,8 @@ pub struct SaveCensus {
     pub texture_assets: usize,
     pub texture_missing_cache: usize,
     pub texture_unhashed: usize,
+    pub buffer_assets: usize,
+    pub buffer_missing_cache: usize,
 }
 
 impl SaveCensus {
@@ -839,12 +913,13 @@ impl SaveCensus {
         self.mesh_missing_cache == 0
             && self.texture_missing_cache == 0
             && self.texture_unhashed == 0
+            && self.buffer_missing_cache == 0
     }
 }
 
 /// Compute the [`SaveCensus`] for the live project (read-only; no mutation, no I/O).
 pub fn save_census(ctrl: &EditorController) -> SaveCensus {
-    use crate::engine::bridge::{mesh_cache, texture_cache};
+    use crate::engine::bridge::{buffer_cache, mesh_cache, texture_cache};
     use awsm_renderer_editor_protocol::{MeshBase, MeshRef};
     let assets = ctrl.scene.assets.lock().unwrap();
     let mut c = SaveCensus::default();
@@ -874,6 +949,15 @@ pub fn save_census(ctrl: &EditorController) -> SaveCensus {
                     c.texture_missing_cache += 1;
                 }
             }
+            // Custom-material buffer data: the words are the only copy (the
+            // renderer keeps only the packed extras-pool slice), so they must be
+            // live in the cache to persist — same contract as a captured mesh.
+            AssetSource::Buffer(_) => {
+                c.buffer_assets += 1;
+                if !buffer_cache::contains(*id) {
+                    c.buffer_missing_cache += 1;
+                }
+            }
             _ => {}
         }
     }
@@ -885,20 +969,23 @@ pub fn check_save_complete(ctrl: &EditorController) -> Result<(), String> {
     // Census on every save — surfaces a 38→N drop even when the guard passes.
     tracing::info!(
         "save census: mesh_assets={} (missing_cache={}) texture_assets={} \
-         (missing_cache={} unhashed={})",
+         (missing_cache={} unhashed={}) buffer_assets={} (missing_cache={})",
         c.mesh_assets,
         c.mesh_missing_cache,
         c.texture_assets,
         c.texture_missing_cache,
-        c.texture_unhashed
+        c.texture_unhashed,
+        c.buffer_assets,
+        c.buffer_missing_cache
     );
     if c.is_complete() {
         return Ok(());
     }
-    let (missing_mesh, missing_tex, unhashed_tex) = (
+    let (missing_mesh, missing_tex, unhashed_tex, missing_buf) = (
         c.mesh_missing_cache,
         c.texture_missing_cache,
         c.texture_unhashed,
+        c.buffer_missing_cache,
     );
     let mut parts = Vec::new();
     if missing_mesh > 0 {
@@ -909,6 +996,9 @@ pub fn check_save_complete(ctrl: &EditorController) -> Result<(), String> {
     }
     if unhashed_tex > 0 {
         parts.push(format!("{unhashed_tex} texture(s) with no captured bytes"));
+    }
+    if missing_buf > 0 {
+        parts.push(format!("{missing_buf} material buffer(s)"));
     }
     Err(format!(
         "refusing to save — {} have no persistable bytes yet (import not fully \
@@ -947,6 +1037,7 @@ pub async fn save_to_dir(ctrl: &EditorController, dir: &crate::fs::ProjectDir) -
         .chain(texture_files(ctrl))
         .chain(cluster_files(ctrl))
         .chain(ktx_files(ctrl))
+        .chain(buffer_files(ctrl))
         .collect();
     let total = text_files.len() + byte_files.len();
     let mut written = 0usize;
@@ -1012,7 +1103,14 @@ pub async fn load_from_dir(
         dir.read_bytes(&path).await.map_err(|e| e.to_string())
     })
     .await;
+    // Rehydrate custom-material buffer assets BEFORE apply_project (their words
+    // must be in the buffer cache the first time a mesh materializes).
+    let missing_buffers = restore_buffers(&project, |path| async move {
+        dir.read_bytes(&path).await.map_err(|e| e.to_string())
+    })
+    .await;
     apply_project(ctrl, project);
+    ctrl.missing_assets.set(missing_buffers);
     // Restore each skinned source's rig glb AFTER apply_project (walks the
     // now-live SkinnedMesh nodes for `skin.source`), so a skinned model's
     // player-bundle export survives a cold reload.
@@ -1049,6 +1147,7 @@ pub fn serialize_inmem(
     byte_files.extend(texture_files(ctrl));
     byte_files.extend(cluster_files(ctrl));
     byte_files.extend(ktx_files(ctrl));
+    byte_files.extend(buffer_files(ctrl));
     Ok((toml, byte_files))
 }
 
@@ -1099,7 +1198,15 @@ pub async fn apply_inmem(
         async move { bytes.ok_or_else(|| format!("missing in-memory ktx: {path}")) }
     })
     .await;
+    // Rehydrate custom-material buffer assets BEFORE apply_project (their words
+    // must be in the buffer cache the first time a mesh materializes).
+    let missing_buffers = restore_buffers(&project, |path| {
+        let bytes = byte_files.get(&path).cloned();
+        async move { bytes.ok_or_else(|| format!("missing in-memory buffer: {path}")) }
+    })
+    .await;
     apply_project(ctrl, project);
+    ctrl.missing_assets.set(missing_buffers);
     // Restore each skinned source's rig glb AFTER apply_project (walks the
     // now-live SkinnedMesh nodes), so a skinned model's player-bundle export
     // survives the round-trip.
@@ -1179,7 +1286,10 @@ pub async fn load_project_from_url(ctrl: &EditorController, base_url: &str) -> E
     // Re-read cluster ("nanite") DAGs BEFORE apply_project (so ClusterMesh nodes render).
     restore_cluster_meshes(&project, http_bytes!()).await;
     restore_ktx(&project, http_bytes!()).await;
+    // Rehydrate custom-material buffer assets BEFORE apply_project.
+    let missing_buffers = restore_buffers(&project, http_bytes!()).await;
     apply_project(ctrl, project);
+    ctrl.missing_assets.set(missing_buffers);
     // Restore rig glb (bundle export) + bind poses (drop_skinning) AFTER apply.
     restore_rig_glb(ctrl, http_bytes!()).await;
     restore_bind_poses(ctrl, http_bytes!()).await;
@@ -1260,5 +1370,26 @@ mod cluster_persistence_tests {
         let sources = cluster_sources_from_project(&project);
         assert_eq!(sources.len(), 2, "every cluster source must be collected");
         assert!(sources.contains(&a) && sources.contains(&b));
+    }
+
+    /// A buffer asset is content-addressed as `<content_hash>.bin`. Save
+    /// (`buffer_files`) and Load (`restore_buffers`) both derive the side-file name
+    /// via the shared [`asset_filename`], so they can't drift — this pins that
+    /// contract (and that a hash-less buffer entry is unaddressable → `None`).
+    #[test]
+    fn buffer_asset_filename_is_content_hash_bin() {
+        use awsm_renderer_editor_protocol::{AssetEntry, AssetSource, BufferDef};
+        let id = AssetId::new();
+        let hashed = AssetEntry::new_with_hash(
+            AssetSource::Buffer(BufferDef { word_len: 8 }),
+            "deadbeef".to_string(),
+        );
+        assert_eq!(
+            asset_filename(id, &hashed),
+            Some("deadbeef.bin".to_string())
+        );
+
+        let unhashed = AssetEntry::new(AssetSource::Buffer(BufferDef { word_len: 8 }));
+        assert_eq!(asset_filename(id, &unhashed), None);
     }
 }

--- a/packages/frontend/editor/src/controller/state.rs
+++ b/packages/frontend/editor/src/controller/state.rs
@@ -1037,6 +1037,7 @@ impl EditorController {
                 crate::engine::bridge::bridge().clear_templates();
                 crate::engine::bridge::skinned_bake_cache::clear();
                 crate::engine::bridge::texture_cache::clear();
+                crate::engine::bridge::buffer_cache::clear();
                 self.project_name.set("untitled.awsm".to_string());
                 self.missing_assets.set(Vec::new());
                 // Seed a sane default scene: a key directional light (tilted ~50°
@@ -1113,6 +1114,7 @@ impl EditorController {
                 crate::engine::bridge::bridge().clear_templates();
                 crate::engine::bridge::skinned_bake_cache::clear();
                 crate::engine::bridge::texture_cache::clear();
+                crate::engine::bridge::buffer_cache::clear();
                 self.missing_assets.set(Vec::new());
                 self.scene.environment.set(scene.environment.clone());
                 self.scene.bump_revision();
@@ -1177,6 +1179,7 @@ impl EditorController {
                 crate::engine::bridge::bridge().clear_templates();
                 crate::engine::bridge::skinned_bake_cache::clear();
                 crate::engine::bridge::texture_cache::clear();
+                crate::engine::bridge::buffer_cache::clear();
                 // View-only cluster ("nanite") DAGs live only in `cluster_cache`;
                 // drop it too so the round-trip exercises the real save→reload
                 // restore (`restore_cluster_meshes` re-reads the persisted DAG).
@@ -2627,7 +2630,7 @@ impl EditorController {
                         ))
                     }
                 };
-                let hash = texture_content_hash(&bytes);
+                let hash = content_hash(&bytes);
                 self.scene.assets.lock().unwrap().entries.insert(
                     id,
                     AssetEntry::new_with_hash(
@@ -7053,22 +7056,20 @@ fn patch_material_texture(kind: &mut NodeKind, slot: &str, texture: Option<Asset
 }
 
 /// Bind (or clear) a buffer-data override on a node's assigned custom material.
-/// The `data` words are stashed in the session buffer store and referenced by a
-/// synthetic `session://buffer/<id>` path (the bundle bake later emits the bytes
-/// then rewrites the path to `assets/buffer-<id>.bin`). Returns false if the node
-/// has no custom-material instance.
+/// The `data` words are interned as a content-addressed [`AssetSource::Buffer`]
+/// asset (see [`intern_buffer_asset`]) and referenced by id — so the binding
+/// persists across Save/reload exactly like a texture override. Returns false if
+/// the node has no custom-material instance.
 fn patch_material_buffer(kind: &mut NodeKind, slot: &str, data: Option<Vec<u32>>) -> bool {
     let Some(inst) = node_material_mut(kind) else {
         return false;
     };
     match data {
         Some(words) => {
-            let path = crate::engine::bridge::dynamic::store_buffer_words(words);
+            let asset = intern_buffer_asset(words);
             inst.buffer_overrides.insert(
                 slot.to_string(),
-                awsm_renderer_editor_protocol::dynamic_material::BufferRef {
-                    path: std::path::PathBuf::from(path),
-                },
+                awsm_renderer_editor_protocol::dynamic_material::BufferRef { asset },
             );
         }
         None => {
@@ -7497,7 +7498,7 @@ fn ensure_import_texture(
     // on-disk side file `assets/<hash>.<ext>` (+ dedups identical textures); the
     // bytes live session-locally in texture_cache until Save reads them.
     let hash_mime = texture_images.get(&key).map(|img| {
-        let hash = texture_content_hash(&img.bytes);
+        let hash = content_hash(&img.bytes);
         crate::engine::bridge::texture_cache::store(id, img.bytes.clone(), img.mime);
         (hash, img.mime)
     });
@@ -7524,14 +7525,52 @@ fn ext_slot_color_kind(slot: &str) -> TextureColorKind {
     }
 }
 
-/// SHA-256 hex of texture bytes — the `content_hash` that addresses the on-disk
-/// `assets/<hash>.<ext>` side file (also dedups identical textures across models).
-fn texture_content_hash(bytes: &[u8]) -> String {
+/// SHA-256 hex of asset bytes — the `content_hash` that addresses the on-disk
+/// `assets/<hash>.<ext>` side file (also dedups identical assets across the
+/// project: textures, buffer-slot data, …).
+fn content_hash(bytes: &[u8]) -> String {
     use sha2::{Digest, Sha256};
     let mut h = Sha256::new();
     h.update(bytes);
     let digest = h.finalize();
     digest.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// Intern raw buffer-slot words as a content-addressed [`AssetSource::Buffer`]
+/// asset: dedups by SHA-256 (identical data across meshes shares one asset +
+/// one `.bin`), caches the words in [`buffer_cache`](crate::engine::bridge::buffer_cache)
+/// for Save, and returns the asset id to record in a `BufferRef`. The single bind
+/// path for both the `SetMaterialBuffer` command and the inspector's "Load .bin".
+pub(crate) fn intern_buffer_asset(words: Vec<u32>) -> AssetId {
+    use awsm_renderer_editor_protocol::BufferDef;
+    let bytes: Vec<u8> = words.iter().flat_map(|w| w.to_le_bytes()).collect();
+    let hash = content_hash(&bytes);
+    let ctrl = controller();
+    let id = {
+        let mut assets = ctrl.scene.assets.lock().unwrap();
+        // Reuse an existing BUFFER asset with identical bytes (a hash hit on a
+        // different asset kind — astronomically unlikely — is ignored so we never
+        // bind a texture id into a buffer slot).
+        let existing = assets.entries.iter().find_map(|(id, e)| {
+            (matches!(e.source, SceneAssetSource::Buffer(_)) && e.content_hash == hash)
+                .then_some(*id)
+        });
+        existing.unwrap_or_else(|| {
+            let id = AssetId::new();
+            assets.entries.insert(
+                id,
+                AssetEntry::new_with_hash(
+                    SceneAssetSource::Buffer(BufferDef {
+                        word_len: words.len() as u32,
+                    }),
+                    hash,
+                ),
+            );
+            id
+        })
+    };
+    crate::engine::bridge::buffer_cache::store(id, words);
+    id
 }
 
 /// Mint a captured-mesh `MeshDef` asset from CPU-extracted glTF geometry: store

--- a/packages/frontend/editor/src/engine/bridge/buffer_cache.rs
+++ b/packages/frontend/editor/src/engine/bridge/buffer_cache.rs
@@ -1,0 +1,40 @@
+//! Session-local store of custom-material **buffer-slot** data (raw little-endian
+//! `u32` words), keyed by the buffer's [`AssetId`].
+//!
+//! Buffer data bound via `set_material_buffer` is a first-class content-addressed
+//! asset (`AssetSource::Buffer`), exactly like an imported texture: the renderer
+//! only keeps the words packed into its extras pool, so the originals live here
+//! until Save. Persistence (`controller::persistence`) writes each entry to the
+//! project's `assets/<content_hash>.bin` side file on Save (via [`get`]) so a
+//! buffer override survives Save → reload; on Load the words come back from the
+//! file into this cache (`restore_buffers`), NOT preserved across the reset — same
+//! session-local caveat as [`texture_cache`](super::texture_cache) / `mesh_cache`.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+use awsm_renderer_editor_protocol::AssetId;
+
+thread_local! {
+    static BUFFER_WORDS: RefCell<HashMap<AssetId, Vec<u32>>> = RefCell::new(HashMap::new());
+}
+
+/// Stash a buffer asset's words under its id (idempotent — re-storing replaces).
+pub fn store(id: AssetId, words: Vec<u32>) {
+    BUFFER_WORDS.with(|c| c.borrow_mut().insert(id, words));
+}
+
+/// The cached words for a buffer asset, if present.
+pub fn get(id: AssetId) -> Option<Vec<u32>> {
+    BUFFER_WORDS.with(|c| c.borrow().get(&id).cloned())
+}
+
+/// Whether a buffer asset's words are cached (used by the save-completeness census).
+pub fn contains(id: AssetId) -> bool {
+    BUFFER_WORDS.with(|c| c.borrow().contains_key(&id))
+}
+
+/// Drop every cached buffer (project reset).
+pub fn clear() {
+    BUFFER_WORDS.with(|c| c.borrow_mut().clear());
+}

--- a/packages/frontend/editor/src/engine/bridge/dynamic.rs
+++ b/packages/frontend/editor/src/engine/bridge/dynamic.rs
@@ -87,25 +87,6 @@ pub fn shader_id_for_asset(id: AssetId) -> Option<MaterialShaderId> {
     registered_shader_id(id)
 }
 
-thread_local! {
-    /// Session-scoped data for per-mesh buffer-slot overrides: a synthetic
-    /// `session://buffer/<uuid>` path → the loaded `.bin`'s little-endian u32
-    /// words. (Persistence writes the `.bin` next to the project on save.)
-    static BUFFER_DATA: RefCell<HashMap<String, Vec<u32>>> = RefCell::new(HashMap::new());
-}
-
-/// Store a loaded buffer's words and return the synthetic path that references
-/// it (set as the `BufferRef::path` on a `MaterialInstance` override).
-pub(crate) fn store_buffer_words(words: Vec<u32>) -> String {
-    let path = format!("session://buffer/{}", AssetId::new().0);
-    BUFFER_DATA.with(|m| m.borrow_mut().insert(path.clone(), words));
-    path
-}
-
-pub(crate) fn buffer_words_for(path: &str) -> Option<Vec<u32>> {
-    BUFFER_DATA.with(|m| m.borrow().get(path).cloned())
-}
-
 /// Register a custom material with the renderer (locks it, finalizes textures).
 /// Returns the assigned shader id, or an error string on failure.
 pub async fn register(mat: &CustomMaterial) -> Result<MaterialShaderId, String> {
@@ -248,7 +229,7 @@ fn build_custom(renderer: &mut AwsmRenderer, inst: &MaterialInstance) -> Option<
                 .unwrap_or_default();
             for (i, name) in buf_slots.iter().enumerate() {
                 if let Some(bref) = inst.buffer_overrides.get(name) {
-                    if let Some(words) = buffer_words_for(&bref.path.to_string_lossy()) {
+                    if let Some(words) = super::buffer_cache::get(bref.asset) {
                         if let Some(slot) = dm.buffers.get_mut(i) {
                             *slot = Some(words);
                         }

--- a/packages/frontend/editor/src/engine/bridge/mod.rs
+++ b/packages/frontend/editor/src/engine/bridge/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod animation_sync;
 pub mod asset_template;
+pub mod buffer_cache;
 pub mod cluster_cache;
 pub mod collider_wire;
 pub mod dynamic;

--- a/packages/frontend/editor/src/scene_mode/inspector.rs
+++ b/packages/frontend/editor/src/scene_mode/inspector.rs
@@ -2718,13 +2718,11 @@ fn pick_buffer_bin(node: &Arc<Node>, name: &str) {
                     u32::from_le_bytes(b)
                 })
                 .collect();
-            let path = crate::engine::bridge::dynamic::store_buffer_words(words);
+            let asset = crate::controller::intern_buffer_asset(words);
             set_buffer_override(
                 &node,
                 &name,
-                Some(awsm_renderer_editor_protocol::dynamic_material::BufferRef {
-                    path: path.into(),
-                }),
+                Some(awsm_renderer_editor_protocol::dynamic_material::BufferRef { asset }),
             );
         });
     });

--- a/packages/mcp/editor-protocol/src/assets.rs
+++ b/packages/mcp/editor-protocol/src/assets.rs
@@ -35,9 +35,27 @@ pub enum AssetSource {
     Material(MaterialDef),
     /// Authored texture (raster file reference or procedural generator params).
     Texture(TextureDef),
+    /// Raw little-endian `u32` buffer data bound into a custom-material buffer
+    /// slot (via `set_material_buffer`). Content-addressed like a raster texture:
+    /// the bytes live at `assets/<content_hash>.bin` (the editor caches them until
+    /// Save) and dedup across instances. Editor-only — the bake resolves a buffer
+    /// override by its asset-id filename, so this entry isn't carried to the
+    /// runtime asset table.
+    Buffer(BufferDef),
     /// Procedural mesh placeholder (label only — actual mesh comes from the
     /// node that references it).
     Mesh(MeshDef),
+}
+
+/// Authoring metadata for an [`AssetSource::Buffer`] entry. The bytes themselves
+/// are content-addressed on disk (`assets/<content_hash>.bin`); this carries only
+/// what the UI / `get_node_details` want to show without loading the file.
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct BufferDef {
+    /// Number of little-endian `u32` words in the buffer.
+    #[serde(default)]
+    pub word_len: u32,
 }
 
 impl AssetSource {
@@ -162,6 +180,11 @@ pub fn asset_filename(id: AssetId, entry: &AssetEntry) -> Option<String> {
     }
     if entry.content_hash.is_empty() {
         return None;
+    }
+    // Buffer data is content-addressed as `<content_hash>.bin` (no display name /
+    // extension to derive from, unlike a file-backed texture).
+    if let AssetSource::Buffer(_) = &entry.source {
+        return Some(format!("{}.bin", entry.content_hash));
     }
     let display = match &entry.source {
         AssetSource::Filename(name) => name.as_str(),

--- a/packages/mcp/editor-protocol/src/bake.rs
+++ b/packages/mcp/editor-protocol/src/bake.rs
@@ -26,10 +26,16 @@ use crate::{AssetSource as AuthSource, EditorProject, MeshBase, MeshDef};
 pub fn project_to_scene(project: &EditorProject) -> Scene {
     let mut assets = RtTable::new();
     for (id, entry) in &project.assets.entries {
+        // Buffer-data entries are editor-only (the player resolves a buffer
+        // override by its asset-id filename, never via the runtime table), so
+        // they don't lower — skip them.
+        let Some(source) = lower_source(&entry.source) else {
+            continue;
+        };
         assets.entries.insert(
             *id,
             RtEntry {
-                source: lower_source(&entry.source),
+                source,
                 gltf_material_asset_ids: entry.gltf_material_asset_ids.clone(),
                 gltf_image_asset_ids: entry.gltf_image_asset_ids.clone(),
                 content_hash: entry.content_hash.clone(),
@@ -61,14 +67,18 @@ pub fn lower_mesh(def: &MeshDef) -> RuntimeMesh {
     RuntimeMesh::Glb
 }
 
-fn lower_source(src: &AuthSource) -> RtSource {
-    match src {
+/// Lower one authoring asset source to its runtime form. Returns `None` for
+/// editor-only sources that don't travel to the player (buffer data — resolved by
+/// asset-id filename, not the runtime table).
+fn lower_source(src: &AuthSource) -> Option<RtSource> {
+    Some(match src {
         AuthSource::Filename(n) => RtSource::Filename(n.clone()),
         AuthSource::Url(u) => RtSource::Url(u.clone()),
         AuthSource::Material(m) => RtSource::Material(m.clone()),
         AuthSource::Texture(t) => RtSource::Texture(t.clone()),
         AuthSource::Mesh(def) => RtSource::Mesh(lower_mesh(def)),
-    }
+        AuthSource::Buffer(_) => return None,
+    })
 }
 
 #[cfg(test)]

--- a/packages/mcp/editor-protocol/src/command.rs
+++ b/packages/mcp/editor-protocol/src/command.rs
@@ -871,9 +871,11 @@ pub enum EditorCommand {
     /// slot (by slot name), or clear it (`data: None`). The `data` is the slot's
     /// little-endian `u32` words (e.g. an `array<vec4<f32>>` of N vec4s is `4·N`
     /// words, the f32 bit patterns). Writes the node's
-    /// `MaterialInstance::buffer_overrides` — the editor stashes the words under a
-    /// session path and the bundle bake emits them as `assets/<id>.bin`. The node
-    /// must have a custom material assigned with a matching declared buffer slot.
+    /// `MaterialInstance::buffer_overrides` — the editor interns the words as a
+    /// content-addressed `Buffer` asset (persisted at `assets/<content_hash>.bin`,
+    /// the bundle bake emits `assets/<asset>.bin`), so the binding survives a
+    /// project reload. The node must have a custom material assigned with a
+    /// matching declared buffer slot.
     /// Inverse: restore the node's prior kind.
     SetMaterialBuffer {
         node: NodeId,

--- a/packages/mcp/editor-protocol/src/lib.rs
+++ b/packages/mcp/editor-protocol/src/lib.rs
@@ -37,7 +37,7 @@ mod texture_payload;
 mod transport;
 
 pub use anim_ui::{AnimSel, AnimView, StepKind};
-pub use assets::{asset_disk_path, asset_filename, AssetEntry, AssetSource, AssetTable};
+pub use assets::{asset_disk_path, asset_filename, AssetEntry, AssetSource, AssetTable, BufferDef};
 pub use bake::{lower_mesh, project_to_scene};
 pub use command::{
     BuiltinTextureSlot, CameraAxis, CustomAlphaMode, EditorCommand, EditorMode, ProceduralKind,


### PR DESCRIPTION
Buffer data bound to a custom (dynamic-WGSL) material's buffer slot via `set_material_buffer` was lost on project reload: the words lived only in a session thread-local keyed by a `session://buffer/<id>` path that was serialized verbatim and had no loader, so the slot came back empty and the mesh rendered garbage (silently — dirty:false, missing_assets:[]).

Promote buffer-slot data to a content-addressed asset, mirroring textures:

- `BufferRef { path }` -> `{ asset }` (scene crate); the player fetches `assets/<asset>.bin` like a texture's `assets/<asset>.png`.
- New authoring `AssetSource::Buffer(BufferDef)`; `asset_filename` addresses it as `<content_hash>.bin`. Editor-only: the bake resolves buffer overrides by asset-id filename, so it isn't carried into the runtime asset table.
- `set_material_buffer` interns the words as a deduped Buffer asset (`intern_buffer_asset`) cached in the new `buffer_cache` bridge module.
- Save/load via `buffer_files`/`restore_buffers` (`assets/<hash>.bin`), wired into all three load paths; unresolved buffers surface in `missing_assets`.
- `SaveCensus` gains a buffer arm, so the "save loses nothing or fails loudly" guard now covers buffer data too.
- Bundle bake emits `assets/<asset>.bin` (replaces the session-path rewrite).

No back-compat shim: an old project.toml with a bound buffer (legacy `session://` path) now fails to load — those bindings never survived reload anyway.

Verified end-to-end in the live editor via the in-memory save->reload path (serialize_inmem/apply_inmem): the override stays a durable `{asset}` ref across two round-trips with missing_assets empty, proving the bytes round-trip through the cache, not just the ref.