### PR TITLE
Fix project save on per-vertex overrides + GLB-export session expiry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,7 +187,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "askama",
@@ -214,7 +214,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-core"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "binpack2d",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-curves"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "glam 0.32.1",
  "serde",
@@ -248,7 +248,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-debugging"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-editor"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-editor-protocol"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "awsm-renderer-meshgen",
  "awsm-renderer-scene",
@@ -323,7 +323,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-geometry"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "glam 0.32.1",
  "serde",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-glb-export"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "awsm-renderer-meshgen",
  "awsm-renderer-tangents",
@@ -346,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-gltf"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-gltf-convert"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "awsm-renderer-glb-export",
  "awsm-renderer-meshgen",
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-lod-bake"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "glam 0.32.1",
  "serde",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-lod-bake-cli"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "awsm-renderer-glb-export",
@@ -410,7 +410,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-materials"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "awsm-renderer-core",
  "thiserror 2.0.18",
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-meshgen"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "awsm-renderer-curves",
  "awsm-renderer-geometry",
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-model-tests"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-multithreaded-example"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "awsm-renderer",
  "awsm-renderer-core",
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-particles"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "awsm-renderer-curves",
  "awsm-renderer-geometry",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-render-worker-example"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-scene"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "bitcode",
  "glam 0.32.1",
@@ -535,7 +535,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-scene-loader"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-scene-mcp"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "awsm-renderer-editor-protocol",
@@ -578,14 +578,14 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-tangents"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "bevy_mikktspace",
 ]
 
 [[package]]
 name = "awsm-renderer-web-shared"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "awsm-renderer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ resolver = "2"
 [workspace.package]
 description = "awsm renderer"
 edition = "2021"
-version = "0.7.0"
+version = "0.7.1"
 license = "MIT OR Apache-2.0"
 authors = ["David Komer"]
 # 1.85 floor: rmcp 1.x (the MCP server SDK) is edition-2024, which requires
@@ -118,23 +118,23 @@ opt-level = 1
 # `workspace.package.version` so the published crates carry concrete
 # version requirements on each other (crates.io rejects path-only deps).
 # Bump this block together with the version above on every release.
-awsm-renderer-curves = { path = "packages/crates/curves", version = "0.7.0" }
-awsm-renderer-geometry = { path = "packages/crates/geometry", version = "0.7.0" }
-awsm-renderer-scene = { path = "packages/crates/scene", version = "0.7.0" }
-awsm-renderer-scene-loader = { path = "packages/crates/scene-loader", version = "0.7.0" }
-awsm-renderer-editor-protocol = { path = "packages/mcp/editor-protocol", version = "0.7.0" }
-awsm-renderer-core = { path = "packages/crates/renderer-core", version = "0.7.0" }
-awsm-renderer-meshgen = { path = "packages/crates/meshgen", version = "0.7.0" }
-awsm-renderer-glb-export = { path = "packages/crates/glb-export", version = "0.7.0" }
-awsm-renderer-gltf-convert = { path = "packages/crates/gltf-convert", version = "0.7.0" }
-awsm-renderer-tangents = { path = "packages/crates/tangents", version = "0.7.0" }
-awsm-renderer-lod-bake = { path = "packages/crates/lod-bake", version = "0.7.0" }
-awsm-renderer-particles = { path = "packages/crates/particles", version = "0.7.0" }
-awsm-renderer-materials = { path = "packages/crates/materials", version = "0.7.0" }
-awsm-renderer = { path = "packages/crates/renderer", version = "0.7.0" }
-awsm-renderer-gltf = { path = "packages/crates/renderer-gltf", version = "0.7.0" }
+awsm-renderer-curves = { path = "packages/crates/curves", version = "0.7.1" }
+awsm-renderer-geometry = { path = "packages/crates/geometry", version = "0.7.1" }
+awsm-renderer-scene = { path = "packages/crates/scene", version = "0.7.1" }
+awsm-renderer-scene-loader = { path = "packages/crates/scene-loader", version = "0.7.1" }
+awsm-renderer-editor-protocol = { path = "packages/mcp/editor-protocol", version = "0.7.1" }
+awsm-renderer-core = { path = "packages/crates/renderer-core", version = "0.7.1" }
+awsm-renderer-meshgen = { path = "packages/crates/meshgen", version = "0.7.1" }
+awsm-renderer-glb-export = { path = "packages/crates/glb-export", version = "0.7.1" }
+awsm-renderer-gltf-convert = { path = "packages/crates/gltf-convert", version = "0.7.1" }
+awsm-renderer-tangents = { path = "packages/crates/tangents", version = "0.7.1" }
+awsm-renderer-lod-bake = { path = "packages/crates/lod-bake", version = "0.7.1" }
+awsm-renderer-particles = { path = "packages/crates/particles", version = "0.7.1" }
+awsm-renderer-materials = { path = "packages/crates/materials", version = "0.7.1" }
+awsm-renderer = { path = "packages/crates/renderer", version = "0.7.1" }
+awsm-renderer-gltf = { path = "packages/crates/renderer-gltf", version = "0.7.1" }
 # Frontend-only (not published); workspace dep keeps consumers path-agnostic.
-awsm-renderer-web-shared = { path = "packages/frontend/web-shared", version = "0.7.0" }
+awsm-renderer-web-shared = { path = "packages/frontend/web-shared", version = "0.7.1" }
 
 # Misc
 cfg-if = "1.0.4"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -143,12 +143,9 @@ tasks:
       #    release on CI (.github/workflows/release.yml). Idempotent like the
       #    commit above: if the tag already exists (a re-run after a partial
       #    release — e.g. crates.io rate-limited mid-publish), keep it and move on.
-      - |
-        if git rev-parse -q --verify "refs/tags/v{{.VERSION}}" >/dev/null; then
-          echo "  Tag v{{.VERSION}} already exists — keeping it (resuming a partial release)."
-        else
-          git tag -a "v{{.VERSION}}" -m "v{{.VERSION}}"
-        fi
+      - task: tag-push
+        vars:
+          VERSION: "{{.VERSION}}"
       # 4. Publish the library crates to crates.io (the explicit, ordered set).
       - task: crates-publish
       # 5. Deploy both frontends to Cloudflare Pages (scene editor + model tester).
@@ -157,6 +154,18 @@ tasks:
       - git push
       - git push origin "v{{.VERSION}}"
       - echo "✅ v{{.VERSION}} — crates published, frontends deployed, tag pushed (MCP binary release building on CI)."
+
+  tag-push:
+    desc: "Push the current branch + the given tag (no-op if already pushed). Usage: task tag-push -- <version>"
+    requires:
+      vars: [VERSION]
+    cmds:
+      - |
+        if git rev-parse -q --verify "refs/tags/v{{.VERSION}}" >/dev/null; then
+          echo "  Tag v{{.VERSION}} already exists — keeping it (resuming a partial release)."
+        else
+          git tag -a "v{{.VERSION}}" -m "v{{.VERSION}}"
+        fi
 
   crates-publish:
     desc: "Publish the 13 awsm-renderer library crates to crates.io (dependency-ordered)."

--- a/packages/frontend/editor/src/controller/export.rs
+++ b/packages/frontend/editor/src/controller/export.rs
@@ -1,10 +1,10 @@
 //! GLB export — lower the live editor scene (or one subtree) to a baked
 //! [`awsm_renderer_glb_export::GlbScene`] and serialize it to a `.glb`.
 //!
-//! This is the standalone "get geometry out" path behind
-//! [`EditorQuery::ExportGlb`](awsm_renderer_editor_protocol::query::EditorQuery::ExportGlb)
-//! / the `export_scene_glb` + `export_node_glb` MCP tools. The whole-runtime
-//! player publish (Phase 6) reuses the same `GlbScene` IR + `write_glb`.
+//! This is the standalone "get geometry out" path behind `Request::ExportGlb`
+//! (the `EditorController::export_glb_bytes` side-channel) and the
+//! `export_scene_glb` / `export_node_glb` MCP tools. The whole-runtime player
+//! publish (Phase 6) reuses the same `GlbScene` IR + `write_glb`.
 //!
 //! ## Material policy (locked)
 //! - assigned/inline **PBR** → glTF PBR; **Unlit** → `KHR_materials_unlit`;

--- a/packages/frontend/editor/src/controller/state.rs
+++ b/packages/frontend/editor/src/controller/state.rs
@@ -4402,6 +4402,17 @@ impl EditorController {
         serde_json::to_string(&self.snapshot()).unwrap_or_else(|e| format!("{{\"error\":\"{e}\"}}"))
     }
 
+    /// Bake a node's subtree (`Some`) or the whole scene (`None`) to a binary
+    /// glTF. Whole-scene export includes animations; single-node does not. The
+    /// raw `.glb` bytes ride the `/glb/<id>` side-channel (see `Request::ExportGlb`)
+    /// rather than the control link, so a large export can't blow the session.
+    pub async fn export_glb_bytes(&self, node: Option<NodeId>) -> Result<Vec<u8>, String> {
+        match node {
+            Some(id) => crate::controller::export::export_glb(&self.scene, Some(id)).await,
+            None => crate::controller::export::export_scene_glb(self).await,
+        }
+    }
+
     /// Run a read-only [`EditorQuery`] and return a serializable result.
     /// Read-only: never mutates persisted state, never records undo, never
     /// broadcasts; the pinning handler saves + restores the transport.
@@ -4461,20 +4472,6 @@ impl EditorController {
                     None => QueryResult::Error {
                         error: format!("no custom material {material}"),
                     },
-                }
-            }
-            EditorQuery::ExportGlb { node } => {
-                // Whole-scene export includes animations; single-node does not.
-                let result = match node {
-                    Some(id) => crate::controller::export::export_glb(&self.scene, Some(id)).await,
-                    None => crate::controller::export::export_scene_glb(self).await,
-                };
-                match result {
-                    Ok(bytes) => {
-                        use base64::Engine;
-                        QueryResult::Text(base64::engine::general_purpose::STANDARD.encode(bytes))
-                    }
-                    Err(e) => QueryResult::Error { error: e },
                 }
             }
             EditorQuery::ExportPlayerBundle { name } => {

--- a/packages/frontend/editor/src/engine/bridge/dynamic.rs
+++ b/packages/frontend/editor/src/engine/bridge/dynamic.rs
@@ -222,19 +222,51 @@ fn build_custom(renderer: &mut AwsmRenderer, inst: &MaterialInstance) -> Option<
             }
         }
         // Per-mesh buffer-slot overrides (#4.2): bind a loaded `.bin`'s words.
-        if !inst.buffer_overrides.is_empty() {
-            let buf_slots: Vec<String> = renderer
-                .dynamic_material_registration(dm.shader_id)
-                .map(|reg| reg.layout.buffers.iter().map(|b| b.name.clone()).collect())
-                .unwrap_or_default();
-            for (i, name) in buf_slots.iter().enumerate() {
-                if let Some(bref) = inst.buffer_overrides.get(name) {
-                    if let Some(words) = super::buffer_cache::get(bref.asset) {
+        // Snapshot the declared slots UNCONDITIONALLY (not only when an override
+        // exists) together with whether each has a registration default — so we
+        // can flag a declared, default-less slot that ends up with no bound data.
+        // Such a slot silently packs `(offset, length) = (0, 0)` and the author's
+        // WGSL reads zeros (garbage) with no other signal (silent-empty).
+        let buf_slots: Vec<(String, bool)> = renderer
+            .dynamic_material_registration(dm.shader_id)
+            .map(|reg| {
+                reg.layout
+                    .buffers
+                    .iter()
+                    .enumerate()
+                    .map(|(i, b)| {
+                        let has_default = reg.buffer_defaults.get(i).is_some_and(|d| !d.is_empty());
+                        (b.name.clone(), has_default)
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        if !buf_slots.is_empty() {
+            let mut unbound: Vec<&str> = Vec::new();
+            for (i, (name, has_default)) in buf_slots.iter().enumerate() {
+                match inst
+                    .buffer_overrides
+                    .get(name)
+                    .and_then(|bref| super::buffer_cache::get(bref.asset))
+                {
+                    Some(words) => {
                         if let Some(slot) = dm.buffers.get_mut(i) {
                             *slot = Some(words);
                         }
                     }
+                    // No per-instance data, but a registration default covers it.
+                    None if *has_default => {}
+                    // Declared, default-less, and unbound → reads zeros.
+                    None => unbound.push(name),
                 }
+            }
+            if !unbound.is_empty() {
+                tracing::warn!(
+                    "custom material {} on this mesh declares buffer slot(s) {:?} with no bound \
+                     data — they read zeros; bind data via set_material_buffer",
+                    inst.asset,
+                    unbound,
+                );
             }
         }
         // Per-mesh texture-slot overrides (#4.2): resolve each TextureRef to a

--- a/packages/frontend/editor/src/remote.rs
+++ b/packages/frontend/editor/src/remote.rs
@@ -27,7 +27,7 @@ use gloo_net::websocket::Message;
 use wasm_bindgen_futures::spawn_local;
 
 use awsm_renderer_editor_protocol::{
-    EditorEvent, PngHandle, Request, Response, WsClientMsg, WsServerMsg,
+    EditorEvent, GlbHandle, PngHandle, Request, Response, WsClientMsg, WsServerMsg,
 };
 
 use crate::controller::controller;
@@ -402,7 +402,25 @@ async fn dispatch(req: Request) -> Response {
             Ok(data_url) => png_from_data_url(&data_url).await,
             Err(e) => Response::Err(e),
         },
+        Request::ExportGlb { node } => glb_response(ctrl.export_glb_bytes(node).await).await,
     }
+}
+
+/// POST exported `.glb` bytes to the server's `/glb/<id>` side-channel (off the
+/// control link) and return a [`GlbHandle`]. Mirrors [`png_from_data_url`]: the
+/// bytes never ride the link, so a multi-MiB export can't blow the session.
+async fn glb_response(result: Result<Vec<u8>, String>) -> Response {
+    let bytes = match result {
+        Ok(bytes) => bytes,
+        Err(e) => return Response::Err(e),
+    };
+    let byte_len = bytes.len();
+    let id = uuid::Uuid::new_v4().to_string();
+    let origin = ORIGIN.with(|o| o.get_cloned());
+    if let Err(e) = upload_bytes(&origin, "glb", &id, bytes).await {
+        return Response::Err(format!("glb upload failed: {e}"));
+    }
+    Response::Glb(GlbHandle { id, byte_len })
 }
 
 /// Turn an optional `data:image/png;base64,…` URL into a [`Response::Png`] handle
@@ -428,7 +446,7 @@ async fn png_from_data_url(data_url: &str) -> Response {
     let byte_len = bytes.len();
     let id = uuid::Uuid::new_v4().to_string();
     let origin = ORIGIN.with(|o| o.get_cloned());
-    if let Err(e) = upload_png(&origin, &id, bytes).await {
+    if let Err(e) = upload_bytes(&origin, "png", &id, bytes).await {
         return Response::Err(format!("png upload failed: {e}"));
     }
     Response::Png(PngHandle {
@@ -451,12 +469,12 @@ fn png_dimensions(bytes: &[u8]) -> Option<(u32, u32)> {
     Some((w, h))
 }
 
-/// POST raw PNG bytes to `<origin>/png/<id>` over plain HTTP — a separate
-/// connection from the control link, so a multi-MiB render never blocks small
-/// frames. Posting *before* replying guarantees the server has the bytes by the
-/// time it sees the handle.
-async fn upload_png(origin: &str, id: &str, bytes: Vec<u8>) -> Result<(), String> {
-    let url = format!("{}/png/{id}", http_base(origin, tls().get()));
+/// POST raw bytes to `<origin>/<kind>/<id>` (`kind` is `png` or `glb`) over plain
+/// HTTP — a separate connection from the control link, so a multi-MiB payload
+/// never blocks small frames. Posting *before* replying guarantees the server has
+/// the bytes by the time it sees the handle.
+async fn upload_bytes(origin: &str, kind: &str, id: &str, bytes: Vec<u8>) -> Result<(), String> {
+    let url = format!("{}/{kind}/{id}", http_base(origin, tls().get()));
     let body = js_sys::Uint8Array::from(bytes.as_slice());
     let resp = gloo_net::http::Request::post(&url)
         .header("content-type", "application/octet-stream")

--- a/packages/mcp/editor-protocol/src/lib.rs
+++ b/packages/mcp/editor-protocol/src/lib.rs
@@ -55,7 +55,9 @@ pub use query::{
     VertexPredicate,
 };
 pub use texture_payload::{decode_texture_payload, TexturePayload};
-pub use transport::{EditorEvent, PngHandle, Request, Response, WsClientMsg, WsServerMsg};
+pub use transport::{
+    EditorEvent, GlbHandle, PngHandle, Request, Response, WsClientMsg, WsServerMsg,
+};
 
 // Re-export the meshgen recipe types so editor + mcp callers that build/send a
 // modifier stack have a single import path alongside the commands that carry it.

--- a/packages/mcp/editor-protocol/src/mesh_def.rs
+++ b/packages/mcp/editor-protocol/src/mesh_def.rs
@@ -53,14 +53,58 @@ pub struct MeshDef {
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct VertexOverrides {
-    #[serde(default, deserialize_with = "de_int_keyed_map")]
+    #[serde(
+        default,
+        serialize_with = "ser_int_keyed_map",
+        deserialize_with = "de_int_keyed_map"
+    )]
     pub positions: std::collections::HashMap<u32, [f32; 3]>,
-    #[serde(default, deserialize_with = "de_int_keyed_map")]
+    #[serde(
+        default,
+        serialize_with = "ser_int_keyed_map",
+        deserialize_with = "de_int_keyed_map"
+    )]
     pub colors: std::collections::HashMap<u32, [f32; 4]>,
-    #[serde(default, deserialize_with = "de_int_keyed_map")]
+    #[serde(
+        default,
+        serialize_with = "ser_int_keyed_map",
+        deserialize_with = "de_int_keyed_map"
+    )]
     pub normals: std::collections::HashMap<u32, [f32; 3]>,
-    #[serde(default, deserialize_with = "de_int_keyed_map")]
+    #[serde(
+        default,
+        serialize_with = "ser_int_keyed_map",
+        deserialize_with = "de_int_keyed_map"
+    )]
     pub uvs: std::collections::HashMap<u32, [f32; 2]>,
+}
+
+/// Serialize a `u32`-keyed override map. The complement of [`de_int_keyed_map`]:
+/// human-readable formats (TOML / JSON) require **string** map keys — TOML's
+/// serializer outright errors with "map key was not a string" on an integer key,
+/// which used to make any project carrying per-vertex overrides unsaveable — so
+/// stringify the index there. Non-self-describing binary formats (bitcode — the
+/// `.mesh.bin` / project persistence) keep the native `u32` key, so existing
+/// `.mesh.bin` files keep round-tripping byte-for-byte. Keys are emitted in
+/// sorted order to keep `project.toml` diffs deterministic.
+fn ser_int_keyed_map<S, V>(map: &std::collections::HashMap<u32, V>, s: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+    V: serde::Serialize,
+{
+    use serde::ser::SerializeMap;
+    let mut entries: Vec<(&u32, &V)> = map.iter().collect();
+    entries.sort_by_key(|(k, _)| **k);
+    let human_readable = s.is_human_readable();
+    let mut m = s.serialize_map(Some(entries.len()))?;
+    for (k, v) in entries {
+        if human_readable {
+            m.serialize_entry(&k.to_string(), v)?;
+        } else {
+            m.serialize_entry(k, v)?;
+        }
+    }
+    m.end()
 }
 
 /// Deserialize a `u32`-keyed map whose keys may arrive as integers (bitcode /

--- a/packages/mcp/editor-protocol/src/query.rs
+++ b/packages/mcp/editor-protocol/src/query.rs
@@ -295,16 +295,6 @@ pub enum EditorQuery {
         #[serde(default = "default_log_limit")]
         limit: u32,
     },
-    /// Bake geometry + materials to a binary glTF (`.glb`) and return the bytes
-    /// base64-encoded (in a `QueryResult::Text`). `None` exports the whole scene;
-    /// `Some(node)` exports just that subtree. A read — no mutation, no undo.
-    /// Built-in PBR → glTF PBR; Unlit → `KHR_materials_unlit`; custom/Toon →
-    /// `AWSM_materials_none` (no embedded material). MCP: `export_scene_glb` /
-    /// `export_node_glb`.
-    ExportGlb {
-        #[serde(default)]
-        node: Option<NodeId>,
-    },
     /// Select the vertices of a node's resolved mesh matching `predicate`. By
     /// default returns `{ count, indices }` (a read — feed the indices to
     /// `SetVertexPositions` / `SoftTransformVertices`). §10: `store: true` keeps

--- a/packages/mcp/editor-protocol/src/transport.rs
+++ b/packages/mcp/editor-protocol/src/transport.rs
@@ -10,7 +10,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use awsm_renderer_scene::AssetId;
+use awsm_renderer_scene::{AssetId, NodeId};
 
 use crate::{EditorCommand, EditorMode, EditorQuery, QueryResult};
 
@@ -42,6 +42,13 @@ pub enum Request {
     },
     /// PNG of a texture asset thumbnail (raw bytes).
     TexturePng(AssetId),
+    /// Bake a node (and its subtree) — or the whole scene when `node` is `None` —
+    /// to a binary glTF. Like the PNG variants, the (potentially multi-MiB) `.glb`
+    /// bytes never ride the control link: the editor POSTs them to the server's
+    /// `/glb/<id>` side-channel and replies with a small [`GlbHandle`]. Returning
+    /// the base64 inline (the old `EditorQuery::ExportGlb` path) reliably blew the
+    /// session on meshes past a couple thousand verts.
+    ExportGlb { node: Option<NodeId> },
     /// The current workspace mode.
     Mode,
 }
@@ -105,6 +112,19 @@ pub struct PngHandle {
     pub height: u32,
 }
 
+/// A reference to a `.glb` the editor uploaded out-of-band. Like [`PngHandle`],
+/// the bytes do **not** ride the control link — the editor POSTs them to the
+/// server's `/glb/<id>` HTTP route and returns this small handle here instead, so
+/// a multi-MiB export can't blow the session.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GlbHandle {
+    /// Opaque id (uuid v4) the editor minted and POSTed the bytes under; the
+    /// server stores them at a temp path keyed by this id.
+    pub id: String,
+    /// Size of the uploaded `.glb` in bytes.
+    pub byte_len: usize,
+}
+
 /// Editor → server. The reply to a [`Request`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Response {
@@ -116,6 +136,9 @@ pub enum Response {
     /// A rendered PNG, uploaded out-of-band (see [`PngHandle`]); only this handle
     /// crosses the control link.
     Png(PngHandle),
+    /// An exported `.glb`, uploaded out-of-band (see [`GlbHandle`]); only this
+    /// handle crosses the control link.
+    Glb(GlbHandle),
     /// The current workspace mode.
     Mode(EditorMode),
     /// The request failed; the string is a human-readable reason.
@@ -436,6 +459,13 @@ mod wire_roundtrip_tests {
             },
             "scene_png",
         );
+        assert_roundtrips(&Request::ExportGlb { node: None }, "export_glb_scene");
+        assert_roundtrips(
+            &Request::ExportGlb {
+                node: Some(NodeId::new()),
+            },
+            "export_glb_node",
+        );
         assert_roundtrips(&Request::Mode, "mode");
     }
 
@@ -466,6 +496,17 @@ mod wire_roundtrip_tests {
             }),
         };
         let j = serde_json::to_string(&client).unwrap();
+        let back: WsClientMsg = serde_json::from_str(&j).unwrap();
+        assert_eq!(j, serde_json::to_string(&back).unwrap());
+
+        let glb = WsClientMsg::Response {
+            id: 8,
+            resp: Response::Glb(GlbHandle {
+                id: "def".to_string(),
+                byte_len: 65536,
+            }),
+        };
+        let j = serde_json::to_string(&glb).unwrap();
         let back: WsClientMsg = serde_json::from_str(&j).unwrap();
         assert_eq!(j, serde_json::to_string(&back).unwrap());
 

--- a/packages/mcp/editor-protocol/tests/mesh_roundtrip.rs
+++ b/packages/mcp/editor-protocol/tests/mesh_roundtrip.rs
@@ -316,6 +316,44 @@ fn vertex_overrides_uvs_roundtrip() {
     let back: VertexOverrides = bitcode::deserialize(&bytes).expect("bitcode deserialize");
     assert_eq!(ov, back, "bitcode drift");
     assert!(!back.is_empty());
+
+    // TOML is the editor's `project.toml` Save format. Integer map keys used to
+    // make `toml::to_string_pretty` fail with "map key was not a string",
+    // rendering any project carrying per-vertex overrides unsaveable. The keys
+    // must serialize as strings here and parse back to the same u32 indices.
+    let toml_str = toml::to_string_pretty(&ov).expect("toml serialize");
+    let back: VertexOverrides = toml::from_str(&toml_str).expect("toml deserialize");
+    assert_eq!(ov, back, "TOML drift");
+    assert_eq!(back.uvs.get(&7), Some(&[0.5, 0.25]));
+}
+
+#[test]
+fn project_with_vertex_overrides_toml_roundtrip() {
+    // The editor's Save flow serializes the whole `EditorProject` to `project.toml`
+    // via `toml::to_string_pretty`. A `MeshDef` carrying any per-vertex override
+    // used to make that call fail with "map key was not a string" (integer map
+    // keys), so the project became unsaveable. Exercise the full project shape.
+    let asset_id = AssetId::new();
+    let mut project = project_with_mesh_asset(asset_id, "Tank tread");
+    match &mut project.assets.entries.get_mut(&asset_id).unwrap().source {
+        AssetSource::Mesh(def) => {
+            def.overrides.uvs.insert(0, [0.0, 0.0]);
+            def.overrides.uvs.insert(1259, [1.0, 0.5]);
+            def.overrides.positions.insert(42, [0.1, 0.2, 0.3]);
+        }
+        other => panic!("expected Mesh source, got {other:?}"),
+    }
+
+    let toml_str = toml::to_string_pretty(&project).expect("project toml serialize");
+    let back: EditorProject = toml::from_str(&toml_str).expect("project toml deserialize");
+    assert_eq!(project, back, "project TOML drift");
+    match &back.assets.entries.get(&asset_id).unwrap().source {
+        AssetSource::Mesh(def) => {
+            assert_eq!(def.overrides.uvs.get(&1259), Some(&[1.0, 0.5]));
+            assert_eq!(def.overrides.positions.get(&42), Some(&[0.1, 0.2, 0.3]));
+        }
+        other => panic!("expected Mesh source, got {other:?}"),
+    }
 }
 
 #[test]

--- a/packages/mcp/src/http.rs
+++ b/packages/mcp/src/http.rs
@@ -5,6 +5,9 @@
 //! - `POST /png/{id}` / `GET /png/{id}` — the PNG byte side-channel: the editor
 //!   POSTs rendered image bytes here (off the control link); the rmcp tool layer
 //!   (and humans/tooling) read them back.
+//! - `POST /glb/{id}` / `GET /glb/{id}` — the same side-channel for exported `.glb`
+//!   bytes (`export_scene_glb` / `export_node_glb`); the tool layer returns the
+//!   temp-file path so the bytes never cross the control link or the token stream.
 //! - `GET  /health`      — agent-facing liveness (editor attached? last boot error?).
 //! - `POST /boot-error`  — the editor reports a renderer/init failure (before any
 //!   MCP attach), so a boot crash is visible to agents via `/health`.
@@ -38,11 +41,19 @@ use crate::mcp::EditorMcp;
 /// evicted oldest-first and their files deleted.
 const MAX_RETAINED_PNGS: usize = 32;
 
+/// Cap on retained `.glb` files (bounds temp-dir disk use). Exports past this are
+/// evicted oldest-first and their files deleted.
+const MAX_RETAINED_GLBS: usize = 16;
+
 /// Body-size cap for a PNG upload. A high-res scene render is a few MiB, well past
 /// Axum's 2 MB default — which would silently 413 a non-trivial screenshot. This
 /// is a loopback-only side-channel from the trusted local editor; the cap exists
 /// only to bound memory (the body is buffered before the temp-file write).
 const PNG_BODY_LIMIT: usize = 256 * 1024 * 1024;
+
+/// Body-size cap for a `.glb` upload — a whole-scene export can be large, so use
+/// the same generous loopback-only cap as PNG (see [`PNG_BODY_LIMIT`]).
+const GLB_BODY_LIMIT: usize = 256 * 1024 * 1024;
 
 /// On-disk path the editor's PNG upload lands at (and the rmcp tool reads back).
 /// Both sides agree on this naming so the tool needs no shared in-memory map.
@@ -50,11 +61,20 @@ pub(crate) fn png_path(id: &str) -> PathBuf {
     std::env::temp_dir().join(format!("awsm-renderer-scene-mcp-{id}.png"))
 }
 
+/// On-disk path the editor's `.glb` export upload lands at. The rmcp tool returns
+/// this path verbatim (it does not inline the bytes), and `GET /glb/<id>` serves
+/// it for humans / tooling.
+pub(crate) fn glb_path(id: &str) -> PathBuf {
+    std::env::temp_dir().join(format!("awsm-renderer-scene-mcp-{id}.glb"))
+}
+
 #[derive(Clone)]
 struct AppState {
     link: EditorLink,
     /// Insertion-ordered PNG ids for LRU eviction (see [`MAX_RETAINED_PNGS`]).
     pngs: Arc<Mutex<VecDeque<String>>>,
+    /// Insertion-ordered `.glb` ids for LRU eviction (see [`MAX_RETAINED_GLBS`]).
+    glbs: Arc<Mutex<VecDeque<String>>>,
     /// The most recent editor BOOT error (renderer/init failure reported by the
     /// page before any MCP attach happened), with a timestamp. Agents read it via
     /// `GET /health` — without this, a boot-time failure is invisible outside the
@@ -68,6 +88,7 @@ pub async fn serve(addr: SocketAddr, link: EditorLink) -> Result<()> {
     let state = AppState {
         link: link.clone(),
         pngs: Arc::new(Mutex::new(VecDeque::new())),
+        glbs: Arc::new(Mutex::new(VecDeque::new())),
         boot_error: Arc::new(Mutex::new(None)),
     };
 
@@ -111,12 +132,20 @@ pub async fn serve(addr: SocketAddr, link: EditorLink) -> Result<()> {
                 .get(png_download)
                 .layer(DefaultBodyLimit::max(PNG_BODY_LIMIT)),
         )
+        // The `.glb` side-channel: the editor POSTs exported glTF bytes here; the
+        // rmcp tool returns the temp-file path (never the inline bytes).
+        .route(
+            "/glb/{id}",
+            post(glb_upload)
+                .get(glb_download)
+                .layer(DefaultBodyLimit::max(GLB_BODY_LIMIT)),
+        )
         .nest_service("/mcp", mcp_service)
         .layer(cors)
         .with_state(state);
 
     let listener = tokio::net::TcpListener::bind(addr).await?;
-    tracing::info!("http listening on http://{addr} (/mcp, /editor, /debug, /png, /health)");
+    tracing::info!("http listening on http://{addr} (/mcp, /editor, /debug, /png, /glb, /health)");
     axum::serve(listener, app).await?;
     Ok(())
 }
@@ -185,5 +214,34 @@ async fn png_download(Path(id): Path<String>) -> impl IntoResponse {
     match std::fs::read(png_path(id)) {
         Ok(bytes) => ([(header::CONTENT_TYPE, "image/png")], bytes).into_response(),
         Err(_) => (StatusCode::NOT_FOUND, "no such png").into_response(),
+    }
+}
+
+/// `POST /glb/{id}` — the editor uploads an exported `.glb` here (off the control
+/// link). We write it to a temp file and remember the id for LRU eviction.
+async fn glb_upload(State(s): State<AppState>, Path(id): Path<String>, body: Bytes) -> StatusCode {
+    let path = glb_path(&id);
+    if let Err(e) = std::fs::write(&path, &body) {
+        tracing::warn!("glb upload write failed ({}): {e}", path.display());
+        return StatusCode::INTERNAL_SERVER_ERROR;
+    }
+    tracing::debug!("glb {id}: {} bytes → {}", body.len(), path.display());
+    // Track for eviction; drop the oldest beyond the cap.
+    let mut q = s.glbs.lock().unwrap();
+    q.push_back(id);
+    while q.len() > MAX_RETAINED_GLBS {
+        if let Some(old) = q.pop_front() {
+            let _ = std::fs::remove_file(glb_path(&old));
+        }
+    }
+    StatusCode::OK
+}
+
+/// `GET /glb/{id}` — serve a previously-exported `.glb` (for humans / tooling).
+async fn glb_download(Path(id): Path<String>) -> impl IntoResponse {
+    let id = id.strip_suffix(".glb").unwrap_or(&id);
+    match std::fs::read(glb_path(id)) {
+        Ok(bytes) => ([(header::CONTENT_TYPE, "model/gltf-binary")], bytes).into_response(),
+        Err(_) => (StatusCode::NOT_FOUND, "no such glb").into_response(),
     }
 }

--- a/packages/mcp/src/mcp.rs
+++ b/packages/mcp/src/mcp.rs
@@ -1515,21 +1515,21 @@ impl EditorMcp {
 
     #[tool(
         annotations(read_only_hint = true),
-        description = "Bake the whole scene to a binary glTF and return the .glb bytes base64-encoded. Built-in PBR → glTF PBR; Unlit → KHR_materials_unlit; custom/Toon → AWSM_materials_none (no embedded material). Textures are referenced-only."
+        description = "Bake the whole scene to a binary glTF. Writes the .glb to a temp file and returns its path + byte length as JSON (the bytes are NOT inlined — read the file to consume it). Built-in PBR → glTF PBR; Unlit → KHR_materials_unlit; custom/Toon → AWSM_materials_none (no embedded material). Textures are referenced-only."
     )]
     async fn export_scene_glb(&self) -> Result<CallToolResult, McpError> {
-        self.query(EditorQuery::ExportGlb { node: None }).await
+        self.glb(Request::ExportGlb { node: None }).await
     }
 
     #[tool(
         annotations(read_only_hint = true),
-        description = "Bake one node (and its subtree) to a binary glTF and return the .glb bytes base64-encoded. Same material mapping as export_scene_glb."
+        description = "Bake one node (and its subtree) to a binary glTF. Writes the .glb to a temp file and returns its path + byte length as JSON (the bytes are NOT inlined — read the file to consume it). Same material mapping as export_scene_glb."
     )]
     async fn export_node_glb(
         &self,
         Parameters(p): Parameters<ExportNodeParams>,
     ) -> Result<CallToolResult, McpError> {
-        self.query(EditorQuery::ExportGlb {
+        self.glb(Request::ExportGlb {
             node: Some(parse_node(&p.node)?),
         })
         .await
@@ -4052,6 +4052,35 @@ impl EditorMcp {
                     STANDARD.encode(bytes),
                     "image/png".to_string(),
                 )]))
+            }
+            Response::Err(e) => Err(McpError::internal_error(e, None)),
+            other => Err(unexpected(other)),
+        }
+    }
+
+    /// Run a `.glb` export request. The bytes rode the `/glb/<id>` side-channel
+    /// (not the control link, which a multi-MiB export would blow), and we return
+    /// the temp-file **path** rather than inlining the base64 — keeping the payload
+    /// off both the link and the token stream. The caller reads the file to use it.
+    async fn glb(&self, r: Request) -> Result<CallToolResult, McpError> {
+        match self.req(r).await? {
+            Response::Glb(handle) => {
+                let path = crate::http::glb_path(&handle.id);
+                // Confirm the upload actually landed before reporting success.
+                if !path.exists() {
+                    return Err(McpError::internal_error(
+                        format!("glb {} not found at {}", handle.id, path.display()),
+                        None,
+                    ));
+                }
+                Ok(text(
+                    serde_json::json!({
+                        "glb_path": path.display().to_string(),
+                        "byte_len": handle.byte_len,
+                        "url": format!("/glb/{}", handle.id),
+                    })
+                    .to_string(),
+                ))
             }
             Response::Err(e) => Err(McpError::internal_error(e, None)),
             other => Err(unexpected(other)),


### PR DESCRIPTION
Implements the actionable fixes from `robot-test/UPSTREAM-FIXES.md` (the tank-tread rig session).

## #1 (BLOCKER) — Project save fails on per-vertex overrides
**Symptom:** after any per-vertex authoring op (`set_vertex_uvs` / `set_vertex_positions` / `set_vertex_normals` / `paint_vertex_colors`), **Save** failed with `serialize project: map key was not a string`, leaving the project unsaveable.

**Cause:** `VertexOverrides` stores each channel as an integer-keyed `HashMap<u32, …>`. It had a custom *deserializer* (`de_int_keyed_map`, accepts integer **and** integer-string keys) but no custom *serializer*, so TOML — which requires string map keys — rejected it. JSON/bitcode round-trip tests existed but never exercised TOML, so the gap went unnoticed.

**Fix:** add `ser_int_keyed_map`, the symmetric complement:
- human-readable formats (TOML/JSON) → **string** keys (what `de_int_keyed_map` already parses back);
- non-self-describing binary (bitcode — `.mesh.bin` / project persistence) → native **u32** keys, so existing files round-trip byte-for-byte;
- keys emitted **sorted** for deterministic `project.toml` diffs.

Tests: TOML round-trips at both the `VertexOverrides` and full-`EditorProject` levels (the real Save path).

## #4 (ROBUSTNESS) — `export_node_glb` expires the MCP session
**Cause:** the GLB was base64-encoded and shipped *inline* over the WebSocket control link; a ~2.5k-vert mesh was big enough to blow the session (`MCP server session expired`) and drop the connection.

**Fix:** route the bytes through the same side-channel screenshots already use. The editor POSTs the `.glb` to a new `/glb/<id>` HTTP route and replies with a small `GlbHandle`; the MCP tool returns the temp-file **path** (not the inline bytes), keeping the payload off both the control link and the token stream. Generalizes the editor's `upload_png` → `upload_bytes`, and replaces the old `EditorQuery::ExportGlb` query path with a dedicated `Request::ExportGlb`. Wire round-trip tests cover the new `Request`/`Response` variants.

## #2b (HARDENING) — Silent-empty buffer slot
The custom-material bridge now `warn!`s when a node uses a custom material that declares a buffer slot with **no bound data and no registration default** — previously it silently read zeros and rendered garbage with no signal. (The editor's `tracing::warn!` surfaces in the browser console.)

## Deliberately not done
- **#2a** legacy `buffer_overrides { path = … }` tolerance — per review, outdated files should **fail loudly** (current `missing field 'asset'` behavior is desired); no change.
- **#3** model matrix to fragments — the only matrix cheaply available in the shading (compute) pass is the node base `model_world`, which is **wrong** for skinned/instanced/billboard meshes (the rig is skinned). A footgun, not a nice-to-have; skipped.
- **#5** pairing churn — already resolved by the single-session refactor.

## Verification
- `cargo fmt --all -- --check` ✅
- `task lint` (`clippy --all --all-features --tests -D warnings`) ✅
- `cargo test --all-features` for `awsm-renderer-editor-protocol` ✅ (vertex-override TOML round-trips + transport wire round-trips)

⚠️ The live MCP↔editor bridge for #4 (and the #2b runtime warning) compiles and is unit-tested, but the end-to-end side-channel was **not** exercised against a running editor in this change — worth a manual `export_node_glb` on a large mesh before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)