### PR TITLE
editor: colliders size from shape, lock scale, live wireframe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,7 +187,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "askama",
@@ -214,7 +214,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-core"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "binpack2d",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-curves"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "glam 0.32.1",
  "serde",
@@ -248,7 +248,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-debugging"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-editor"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-editor-protocol"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "awsm-renderer-meshgen",
  "awsm-renderer-scene",
@@ -323,7 +323,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-geometry"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "glam 0.32.1",
  "serde",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-glb-export"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "awsm-renderer-meshgen",
  "awsm-renderer-tangents",
@@ -346,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-gltf"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-gltf-convert"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "awsm-renderer-glb-export",
  "awsm-renderer-meshgen",
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-lod-bake"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "glam 0.32.1",
  "serde",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-lod-bake-cli"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "awsm-renderer-glb-export",
@@ -410,7 +410,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-materials"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "awsm-renderer-core",
  "thiserror 2.0.18",
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-meshgen"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "awsm-renderer-curves",
  "awsm-renderer-geometry",
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-model-tests"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-multithreaded-example"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "awsm-renderer",
  "awsm-renderer-core",
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-particles"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "awsm-renderer-curves",
  "awsm-renderer-geometry",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-render-worker-example"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-scene"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "bitcode",
  "glam 0.32.1",
@@ -535,7 +535,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-scene-loader"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-scene-mcp"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "awsm-renderer-editor-protocol",
@@ -578,14 +578,14 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-tangents"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "bevy_mikktspace",
 ]
 
 [[package]]
 name = "awsm-renderer-web-shared"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "awsm-renderer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ resolver = "2"
 [workspace.package]
 description = "awsm renderer"
 edition = "2021"
-version = "0.7.1"
+version = "0.7.2"
 license = "MIT OR Apache-2.0"
 authors = ["David Komer"]
 # 1.85 floor: rmcp 1.x (the MCP server SDK) is edition-2024, which requires
@@ -118,23 +118,23 @@ opt-level = 1
 # `workspace.package.version` so the published crates carry concrete
 # version requirements on each other (crates.io rejects path-only deps).
 # Bump this block together with the version above on every release.
-awsm-renderer-curves = { path = "packages/crates/curves", version = "0.7.1" }
-awsm-renderer-geometry = { path = "packages/crates/geometry", version = "0.7.1" }
-awsm-renderer-scene = { path = "packages/crates/scene", version = "0.7.1" }
-awsm-renderer-scene-loader = { path = "packages/crates/scene-loader", version = "0.7.1" }
-awsm-renderer-editor-protocol = { path = "packages/mcp/editor-protocol", version = "0.7.1" }
-awsm-renderer-core = { path = "packages/crates/renderer-core", version = "0.7.1" }
-awsm-renderer-meshgen = { path = "packages/crates/meshgen", version = "0.7.1" }
-awsm-renderer-glb-export = { path = "packages/crates/glb-export", version = "0.7.1" }
-awsm-renderer-gltf-convert = { path = "packages/crates/gltf-convert", version = "0.7.1" }
-awsm-renderer-tangents = { path = "packages/crates/tangents", version = "0.7.1" }
-awsm-renderer-lod-bake = { path = "packages/crates/lod-bake", version = "0.7.1" }
-awsm-renderer-particles = { path = "packages/crates/particles", version = "0.7.1" }
-awsm-renderer-materials = { path = "packages/crates/materials", version = "0.7.1" }
-awsm-renderer = { path = "packages/crates/renderer", version = "0.7.1" }
-awsm-renderer-gltf = { path = "packages/crates/renderer-gltf", version = "0.7.1" }
+awsm-renderer-curves = { path = "packages/crates/curves", version = "0.7.2" }
+awsm-renderer-geometry = { path = "packages/crates/geometry", version = "0.7.2" }
+awsm-renderer-scene = { path = "packages/crates/scene", version = "0.7.2" }
+awsm-renderer-scene-loader = { path = "packages/crates/scene-loader", version = "0.7.2" }
+awsm-renderer-editor-protocol = { path = "packages/mcp/editor-protocol", version = "0.7.2" }
+awsm-renderer-core = { path = "packages/crates/renderer-core", version = "0.7.2" }
+awsm-renderer-meshgen = { path = "packages/crates/meshgen", version = "0.7.2" }
+awsm-renderer-glb-export = { path = "packages/crates/glb-export", version = "0.7.2" }
+awsm-renderer-gltf-convert = { path = "packages/crates/gltf-convert", version = "0.7.2" }
+awsm-renderer-tangents = { path = "packages/crates/tangents", version = "0.7.2" }
+awsm-renderer-lod-bake = { path = "packages/crates/lod-bake", version = "0.7.2" }
+awsm-renderer-particles = { path = "packages/crates/particles", version = "0.7.2" }
+awsm-renderer-materials = { path = "packages/crates/materials", version = "0.7.2" }
+awsm-renderer = { path = "packages/crates/renderer", version = "0.7.2" }
+awsm-renderer-gltf = { path = "packages/crates/renderer-gltf", version = "0.7.2" }
 # Frontend-only (not published); workspace dep keeps consumers path-agnostic.
-awsm-renderer-web-shared = { path = "packages/frontend/web-shared", version = "0.7.1" }
+awsm-renderer-web-shared = { path = "packages/frontend/web-shared", version = "0.7.2" }
 
 # Misc
 cfg-if = "1.0.4"

--- a/packages/crates/scene/src/collider.rs
+++ b/packages/crates/scene/src/collider.rs
@@ -5,6 +5,13 @@ use glam::{Quat, Vec3};
 /// the collider's local frame — to orient them along X or Z, rotate
 /// the containing node.
 ///
+/// SIZE LIVES HERE, NOT IN NODE SCALE. These extents
+/// (`half_extents` / `radius` / `half_height`) are the collider's only
+/// size source: a Rapier collider has no scale, so the node's transform
+/// scale is locked to `[1,1,1]` in the editor and dropped at export
+/// (`ColliderSpec::from_node` reads translation + rotation only). To
+/// resize a collider, change these values — never the node scale.
+///
 /// Ellipsoid is the one shape Rapier doesn't expose natively: the
 /// runtime tessellates a unit sphere into 42 vertices, scales each
 /// per-axis, and hands the result to `ColliderBuilder::convex_hull`.

--- a/packages/crates/scene/src/tree.rs
+++ b/packages/crates/scene/src/tree.rs
@@ -208,6 +208,15 @@ pub struct ClusterMeshRef {
 pub enum NodeKind {
     Group,
     Light(LightConfig),
+    /// A physics collider. Its SIZE comes entirely from the `ColliderShape`
+    /// extents (`half_extents` / `radius` / `half_height`) — NOT from the node's
+    /// transform scale. A Rapier collider has no scale: its placement is an
+    /// isometry, so only the node's translation + rotation are honored at export
+    /// (`ColliderSpec::from_node`). Node scale on a collider is locked to
+    /// `[1,1,1]` by the editor and ignored by the runtime — to make a collider
+    /// bigger, edit its shape extents, never the transform scale. Rotation IS
+    /// honored and is the only way to orient a Y-aligned Capsule/Cylinder/Cone
+    /// along X or Z, or to tilt a Box.
     Collider(ColliderShape),
     Camera(CameraConfig),
     /// The sole procedural-geometry node. Backed by an `AssetSource::Mesh`

--- a/packages/frontend/editor/src/controller/state.rs
+++ b/packages/frontend/editor/src/controller/state.rs
@@ -8,7 +8,7 @@ use wasm_bindgen_futures::spawn_local;
 use super::animation::{find_clip, CustomAnimation as CA};
 use super::custom_material::{find_material, CustomMaterial as CM};
 use super::*;
-use crate::engine::scene::{mutate, AssetId, NodeId, NodeKind, Scene};
+use crate::engine::scene::{mutate, AssetId, ColliderShape, NodeId, NodeKind, Scene};
 use crate::error::EditorResult;
 use awsm_renderer_editor_protocol::{
     AssetEntry, AssetSource as SceneAssetSource, BoundedHistory, MaterialDef, ModifierStack,
@@ -923,9 +923,18 @@ impl EditorController {
                 }))
                 .await
             }
-            EditorCommand::SetTransform { id, transform } => {
+            EditorCommand::SetTransform { id, mut transform } => {
                 match mutate::find_by_id(&self.scene, id) {
                     Some(node) => {
+                        // A Rapier collider has no scale: its size is the
+                        // ColliderShape extents and its placement is an isometry
+                        // (translation + rotation). Scale on a collider node is
+                        // silently dropped at export (`ColliderSpec::from_node`), so
+                        // lock it to unit here — the single chokepoint every write
+                        // (gizmo, inspector, MCP, import) flows through. (FIXES.md #2.)
+                        if matches!(node.kind.get_cloned(), NodeKind::Collider(_)) {
+                            transform.scale = [1.0, 1.0, 1.0];
+                        }
                         let prev = node.transform.get();
                         node.transform.set(transform);
                         self.scene.bump_revision();
@@ -5770,27 +5779,35 @@ impl EditorController {
     async fn node_bounds(&self, nodes: &[NodeId]) -> query::QueryResult {
         use serde_json::json;
         let ids = self.resolve_node_ids(nodes);
-        // (id, local-aabb) pairs from the scene; world matrices from the renderer.
-        let locals: Vec<(NodeId, Aabb3)> = ids
+        // (id, local-aabb, is_collider) tuples from the scene; world matrices from
+        // the renderer. `is_collider` strips node scale below — a collider's size
+        // is its shape extents, not its transform scale.
+        let locals: Vec<(NodeId, Aabb3, bool)> = ids
             .iter()
             .filter_map(|id| {
-                mutate::find_by_id(&self.scene, *id)
-                    .map(|n| (*id, local_aabb(&n.kind.get_cloned())))
+                mutate::find_by_id(&self.scene, *id).map(|n| {
+                    let kind = n.kind.get_cloned();
+                    let is_collider = matches!(kind, NodeKind::Collider(_));
+                    (*id, local_aabb(&kind), is_collider)
+                })
             })
             .collect();
         // Resolve per-node renderer meshes + transform keys BEFORE taking the
         // renderer lock: renderer_meshes_for_node locks the bridge nodes map,
         // which must never nest inside a scope already holding that lock.
-        let resolved: Vec<(
+        // (id, local-aabb, is_collider, renderer meshes, transform key).
+        type Resolved = (
             NodeId,
             Aabb3,
+            bool,
             Vec<awsm_renderer::meshes::MeshKey>,
             Option<awsm_renderer::transforms::TransformKey>,
-        )> = {
+        );
+        let resolved: Vec<Resolved> = {
             let bridge = crate::engine::bridge::bridge();
             locals
                 .iter()
-                .map(|(id, aabb)| {
+                .map(|(id, aabb, is_collider)| {
                     let meshes = renderer_meshes_for_node(*id);
                     let tk = bridge
                         .nodes
@@ -5798,16 +5815,23 @@ impl EditorController {
                         .unwrap()
                         .get(id)
                         .map(|n| n.transform_key);
-                    (*id, *aabb, meshes, tk)
+                    (*id, *aabb, *is_collider, meshes, tk)
                 })
                 .collect()
         };
         let entries = crate::engine::context::with_renderer_mut(move |r| {
             let mut m = std::collections::BTreeMap::new();
-            for (id, (lmin, lmax), meshes, tk) in &resolved {
-                let world = tk
+            for (id, (lmin, lmax), is_collider, meshes, tk) in &resolved {
+                let mut world = tk
                     .and_then(|tk| r.transforms.get_world(tk).ok().copied())
                     .unwrap_or(glam::Mat4::IDENTITY);
+                // Collider bounds compose the shape's local AABB with the node's
+                // world translation + rotation only — scale (the node's own, or an
+                // ancestor's) is not part of a Rapier collider. (FIXES.md #1.)
+                if *is_collider {
+                    let (_s, rot, trans) = world.to_scale_rotation_translation();
+                    world = glam::Mat4::from_rotation_translation(rot, trans);
+                }
                 // §8 facing hint: the node's local axes in WORLD space (see
                 // `world_forward_up_right`).
                 let (forward, up, right) = world_forward_up_right(world);
@@ -6081,11 +6105,44 @@ fn local_aabb(kind: &NodeKind) -> Aabb3 {
                 }
             }
         }
+        // A collider's bounds come from its `ColliderShape` extents — never from
+        // node scale (which a collider doesn't have; see `ColliderSpec::from_node`).
+        // The shapes are centered on the node origin and Capsule/Cylinder/Cone are
+        // Y-aligned in their local frame. (FIXES.md #1.)
+        NodeKind::Collider(shape) => return collider_local_aabb(shape),
         _ => {}
     }
     // Lights / cameras / empties / un-baked meshes: a small unit box centered on
     // the node.
     ([-0.5, -0.5, -0.5], [0.5, 0.5, 0.5])
+}
+
+/// Local-space AABB of a collider shape, in the collider's own frame (centered
+/// on the node origin). Pair with the node's world translation + rotation — but
+/// NOT its scale — to get world bounds. Mirrors the dimensions the wireframe
+/// (`collider_wire`) and runtime (`ColliderSpec`) read.
+fn collider_local_aabb(shape: &ColliderShape) -> Aabb3 {
+    let half = |hx: f32, hy: f32, hz: f32| ([-hx, -hy, -hz], [hx, hy, hz]);
+    match shape {
+        ColliderShape::Box { half_extents } | ColliderShape::Ellipsoid { half_extents } => {
+            half(half_extents[0], half_extents[1], half_extents[2])
+        }
+        ColliderShape::Sphere { radius } => half(*radius, *radius, *radius),
+        // Capsule total half-height = half_height + radius; girth = radius on X/Z.
+        ColliderShape::Capsule {
+            half_height,
+            radius,
+        } => half(*radius, *half_height + *radius, *radius),
+        // Cylinder / Cone span `half_height` on Y, `radius` on X/Z.
+        ColliderShape::Cylinder {
+            half_height,
+            radius,
+        }
+        | ColliderShape::Cone {
+            half_height,
+            radius,
+        } => half(*radius, *half_height, *radius),
+    }
 }
 
 /// Transform a local AABB by a world matrix and return the enclosing world AABB.

--- a/packages/frontend/editor/src/engine/bridge/node_sync.rs
+++ b/packages/frontend/editor/src/engine/bridge/node_sync.rs
@@ -312,9 +312,17 @@ async fn add_node(
         loader.load(clone!(entry => async move {
             entry.node.transform.signal().for_each(move |trs| {
                 clone!(entry => async move {
+                    let tk = entry.transform_key;
                     with_renderer_mut(move |r| {
-                        let _ = r.transforms.set_local(entry.transform_key, trs_to_transform(&trs));
+                        let _ = r.transforms.set_local(tk, trs_to_transform(&trs));
                     }).await;
+                    // A collider's wireframe is world-baked line geometry (not
+                    // parented to the node transform), so a move/rotate leaves it
+                    // stale — re-bake it from the fresh transform so the on-screen
+                    // affordance keeps matching where the collider actually is.
+                    if let NodeKind::Collider(shape) = entry.node.kind.get_cloned() {
+                        materialize_collider(entry.clone(), shape).await;
+                    }
                 })
             }).await;
         }));
@@ -1431,20 +1439,64 @@ async fn materialize_sprite(
 }
 
 /// Collider (`NodeKind::Collider`) → an editor-overlay wireframe of the shape,
-/// drawn as a world-baked fat-line segment list (one-shot; re-materializes on
-/// shape/transform change via the kind observer).
+/// drawn as a world-baked fat-line segment list. Idempotent: it drains any
+/// existing wireframe first, so it doubles as the re-bake called by both the kind
+/// observer (shape change) and the transform observer (move/rotate). The geometry
+/// is world-baked (not parented to the node transform), so it must be rebuilt
+/// whenever the node's world changes or the wireframe would lie about where the
+/// collider is.
 async fn materialize_collider(
     entry: Arc<RendererNode>,
     shape: awsm_renderer_editor_protocol::ColliderShape,
 ) {
-    let parent_tk = entry.transform_key;
+    let key = entry.transform_key;
+    let node_id = entry.node_id;
     let entry2 = entry.clone();
+    // Drain existing lines so this re-bakes cleanly (the transform observer calls
+    // it on every move; the kind observer's teardown already drained, so this is a
+    // harmless no-op on the initial materialize).
+    let old_lines: Vec<_> = entry.line_keys.lock().unwrap().drain(..).collect();
     let line_key = with_renderer_mut(move |r| {
-        let world = r
+        for lk in old_lines {
+            r.remove_line(lk);
+        }
+        // Fresh world = parent's CURRENT world × this node's local. `get_world`
+        // returns a cached matrix only refreshed by the render loop's
+        // update_transforms, so reading this node's own cached world right after a
+        // `set_local` would be stale; recompute from the parent (unchanged when the
+        // collider itself moves) instead.
+        let local = r
             .transforms
-            .get_world(parent_tk)
-            .copied()
+            .get_local(key)
+            .map(|t| t.to_matrix())
             .unwrap_or(glam::Mat4::IDENTITY);
+        let parent_world = r
+            .transforms
+            .get_parent(key)
+            .ok()
+            .and_then(|p| r.transforms.get_world(p).ok().copied())
+            .unwrap_or(glam::Mat4::IDENTITY);
+        let world = parent_world * local;
+        // A Rapier collider has no scale — its size comes entirely from the
+        // ColliderShape extents and its placement is an isometry (translation +
+        // rotation). Strip scale from the world matrix so the wireframe shows the
+        // exact dimensions/placement physics sees, instead of folding node (or
+        // ancestor) scale on top of the shape extents. (FIXES.md #1.)
+        let (scale, rot, trans) = world.to_scale_rotation_translation();
+        // The collider's own scale is locked to unit (see SetTransform), so any
+        // non-unit world scale here is an ANCESTOR's — which the runtime ignores,
+        // re-introducing the gizmo/physics divergence #2 warns about. Flag it so
+        // the divergence is visible rather than silent. (FIXES.md #2 caveat.)
+        if (scale - glam::Vec3::ONE).abs().max_element() > 1e-3 {
+            tracing::warn!(
+                "collider node {node_id:?} has non-unit ancestor scale {:?}; \
+                 the runtime ignores scale on colliders, so the wireframe (and \
+                 physics) use shape extents only — the visual may diverge from \
+                 scaled siblings",
+                scale.to_array(),
+            );
+        }
+        let world = glam::Mat4::from_rotation_translation(rot, trans);
         let (positions, colors) = super::collider_wire::build(&shape, &world);
         if positions.is_empty() {
             return None;

--- a/packages/frontend/editor/src/engine/gizmo.rs
+++ b/packages/frontend/editor/src/engine/gizmo.rs
@@ -45,6 +45,11 @@ pub enum GizmoMode {
 
 thread_local! {
     static GIZMO_MODE: Mutable<GizmoMode> = Mutable::new(GizmoMode::Move);
+    /// Whether the current gizmo anchor is a collider node — resolved once per
+    /// selection (in `sync_gizmo_selection`) and read by the per-frame visibility
+    /// update, so the hot path never rescans the node map. Colliders never show a
+    /// scale handle (they have no scale — FIXES.md #2).
+    static SELECTION_IS_COLLIDER: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
 
 /// The shared gizmo-mode handle (the palette sets it; the gizmo observes it).
@@ -219,6 +224,25 @@ fn transform_key_for_node(id: NodeId) -> Option<TransformKey> {
         .map(|n| n.transform_key)
 }
 
+/// Whether `id` is a collider node. Colliders have no scale (size comes from the
+/// ColliderShape, placement is translation + rotation only), so the scale handle
+/// set is suppressed for them. (FIXES.md #2.)
+fn node_is_collider(id: NodeId) -> bool {
+    use crate::engine::scene::NodeKind;
+    bridge()
+        .nodes
+        .lock()
+        .unwrap()
+        .get(&id)
+        .map(|n| matches!(n.node.kind.get_cloned(), NodeKind::Collider(_)))
+        .unwrap_or(false)
+}
+
+/// Cached collider-ness of the current gizmo anchor (see `SELECTION_IS_COLLIDER`).
+fn selection_is_collider() -> bool {
+    SELECTION_IS_COLLIDER.with(|c| c.get())
+}
+
 async fn sync_gizmo_selection(id: Option<NodeId>) {
     let transform_key = id.and_then(transform_key_for_node);
 
@@ -229,6 +253,10 @@ async fn sync_gizmo_selection(id: Option<NodeId>) {
         let Some(controller) = guard.as_mut() else {
             return;
         };
+        // Cache collider-ness once per selection so the per-frame update can gate
+        // the scale handle without rescanning the node map.
+        let is_collider = id.is_some_and(node_is_collider);
+        SELECTION_IS_COLLIDER.with(|c| c.set(is_collider));
         let gizmo_enabled = controller_gizmo_enabled();
         match transform_key {
             Some(key) => {
@@ -237,7 +265,9 @@ async fn sync_gizmo_selection(id: Option<NodeId>) {
                     instance: None,
                 });
                 if gizmo_enabled {
-                    let (th, rh, sh) = hidden_for_mode(gizmo_mode().get());
+                    let (th, rh, mut sh) = hidden_for_mode(gizmo_mode().get());
+                    // Colliders never expose a scale handle.
+                    sh |= is_collider;
                     let _ = controller.set_hidden(&mut renderer, th, rh, sh);
                 } else {
                     let _ = controller.set_hidden(&mut renderer, true, true, true);
@@ -270,8 +300,10 @@ pub fn per_frame_update(renderer: &mut AwsmRenderer) {
             let _ = controller.set_hidden(renderer, true, true, true);
             return;
         }
-        // Show only the active tool's handle set (Select shows none).
-        let (th, rh, sh) = hidden_for_mode(gizmo_mode().get());
+        // Show only the active tool's handle set (Select shows none); never the
+        // scale handle for a collider (it has no scale — FIXES.md #2).
+        let (th, rh, mut sh) = hidden_for_mode(gizmo_mode().get());
+        sh |= selection_is_collider();
         let _ = controller.set_hidden(renderer, th, rh, sh);
         let Some(matrices) = renderer.camera.last_matrices.as_ref().cloned() else {
             return;

--- a/packages/frontend/editor/src/scene_mode/inspector.rs
+++ b/packages/frontend/editor/src/scene_mode/inspector.rs
@@ -4046,16 +4046,23 @@ fn transform_section(node: &Arc<Node>) -> Dom {
         }))
     });
 
-    // Scale
-    let n_scale = node.clone();
-    let scale = row(
-        "Scale",
-        vec3_signal(node.transform.signal_ref(|t| f3(t.scale)), 0.1, move |v| {
-            let mut t = n_scale.transform.get();
-            t.scale = [v[0] as f32, v[1] as f32, v[2] as f32];
-            dispatch_transform(id, t);
-        }),
-    );
+    // Scale — locked to 1×1×1 for collider nodes. A Rapier collider has no scale
+    // (size comes from the ColliderShape extents; placement is translation +
+    // rotation only), so editing it here would author a value the runtime silently
+    // drops. Show a read-only note instead of editable fields. (FIXES.md #2.)
+    let scale = if matches!(node.kind.get_cloned(), NodeKind::Collider(_)) {
+        ro_row("Scale", "1, 1, 1 · locked (size via Collider shape)")
+    } else {
+        let n_scale = node.clone();
+        row(
+            "Scale",
+            vec3_signal(node.transform.signal_ref(|t| f3(t.scale)), 0.1, move |v| {
+                let mut t = n_scale.transform.get();
+                t.scale = [v[0] as f32, v[1] as f32, v[2] as f32];
+                dispatch_transform(id, t);
+            }),
+        )
+    };
 
     Section::new("Transform")
         .child(pos)

--- a/packages/mcp/src/mcp.rs
+++ b/packages/mcp/src/mcp.rs
@@ -1501,7 +1501,7 @@ impl EditorMcp {
 
     #[tool(
         annotations(read_only_hint = true),
-        description = "World-space AABB { min, max } for each node (CPU-estimated; pass node UUIDs, or empty for all). Use to frame the camera or size objects."
+        description = "World-space AABB { min, max } for each node (CPU-estimated; pass node UUIDs, or empty for all). Use to frame the camera or size objects. Collider nodes report bounds from their ColliderShape extents at the node's world translation+rotation (scale is not part of a collider) — so this matches what the collider gizmo and physics actually use."
     )]
     async fn get_node_bounds(
         &self,
@@ -1905,7 +1905,7 @@ impl EditorMcp {
     }
 
     #[tool(
-        description = "Set a node's local transform: translation [x,y,z], rotation quaternion [x,y,z,w], scale [x,y,z]."
+        description = "Set a node's local transform: translation [x,y,z], rotation quaternion [x,y,z,w], scale [x,y,z]. NOTE: collider nodes have no scale — `scale` is forced to [1,1,1] for them (a Rapier collider's size is its ColliderShape extents, and only translation+rotation export). To resize a collider, edit its shape (set_kind/patch_kind), not this scale."
     )]
     async fn node_set_transform(
         &self,


### PR DESCRIPTION
Implements the collider fixes from the `single-player-game-physics` template's `FIXES.md`. A collider node's size belongs to its `ColliderShape` extents, not its transform scale — a Rapier collider has no scale (placement is an isometry, and `ColliderSpec::from_node` drops scale at export). The editor contradicted this in three places, so you could author a physically-correct scene that looked wrong, or a good-looking scene that was physically wrong.

## Changes

**#1 — Gizmo & `get_node_bounds` follow the shape, not scale**
- Collider wireframe is built from the `ColliderShape` extents composed with the node's world translation + rotation; scale is stripped from the world matrix.
- `local_aabb` gains a `Collider` arm (real per-shape AABB) and `node_bounds` strips scale for colliders.

**#2 — Scale locked on collider nodes**
- Forced to `[1,1,1]` at the `SetTransform` chokepoint (covers gizmo, inspector, MCP, import).
- Inspector shows a read-only "`1, 1, 1 · locked (size via Collider shape)`" row instead of editable fields.
- Viewport scale handle is suppressed when a collider is selected (cached once per selection so the per-frame path doesn't rescan).
- Warn when a collider has non-unit **ancestor** scale (runtime ignores it → visual can diverge from scaled siblings).

**#3 — Rotation left enabled** (it round-trips — it's half the isometry, and the only way to orient Y-aligned capsule/cylinder/cone or tilt a box).

**Bonus (found while testing):** the collider wireframe is world-baked line geometry that only re-baked on shape change, so a *moved* collider drew its wireframe at the old spot — defeating #1's goal. The transform observer now re-bakes it on move, computing a fresh `parent_world × local` (the renderer's cached world isn't refreshed until the render loop). Re-bake fires per transform commit, not per drag-frame.

**MCP** — the no-scale rule is surfaced through the tooling agents use to build colliders: `NodeKind::Collider` + `ColliderShape` schema docs (via `get_kind_schema`), and the `node_set_transform` / `get_node_bounds` tool descriptions.

## Testing

`task lint` clean (rustfmt + clippy `-D warnings` all-features tests). Verified live in the editor over MCP (`task mcp-dev`) with chrome-devtools screenshots:
- Box `[3,0.1,2]` renders as a wide flat frame (not a unit cube, not scale-multiplied); `get_node_bounds` → `min[-3,0.9,-2] max[3,1.1,2]`.
- `node_set_transform` with `scale:[5,5,5]` → stored `[1,1,1]`; inspector shows the locked row; scale tool shows no handles.
- 30° rotation round-trips and the wireframe tilts; a transform-only move relocates the wireframe (gizmo co-located).
- Ancestor-scale warning fires when a collider is created under a `[2,2,2]` group.

**Known limitation:** the live re-bake follows the collider's *own* moves; moving a *scaled ancestor group* won't re-trigger the child's re-bake until the collider itself is touched (the warning still flags that config). Follow-up only if colliders get parented under animated/scaled groups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)