### PR TITLE
Fix point-light soft/PCSS shadow acne rings (kernel-width slack)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,7 +187,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "askama",
@@ -214,7 +214,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-core"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "binpack2d",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-curves"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "glam 0.32.1",
  "serde",
@@ -248,7 +248,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-debugging"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-editor"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-editor-protocol"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "awsm-renderer-meshgen",
  "awsm-renderer-scene",
@@ -323,7 +323,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-geometry"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "glam 0.32.1",
  "serde",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-glb-export"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "awsm-renderer-meshgen",
  "awsm-renderer-tangents",
@@ -346,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-gltf"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-gltf-convert"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "awsm-renderer-glb-export",
  "awsm-renderer-meshgen",
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-lod-bake"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "glam 0.32.1",
  "serde",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-lod-bake-cli"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "awsm-renderer-glb-export",
@@ -410,7 +410,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-materials"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "awsm-renderer-core",
  "thiserror 2.0.18",
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-meshgen"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "awsm-renderer-curves",
  "awsm-renderer-geometry",
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-model-tests"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-multithreaded-example"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "awsm-renderer",
  "awsm-renderer-core",
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-particles"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "awsm-renderer-curves",
  "awsm-renderer-geometry",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-render-worker-example"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-scene"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "bitcode",
  "glam 0.32.1",
@@ -535,7 +535,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-scene-loader"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-scene-mcp"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "awsm-renderer-editor-protocol",
@@ -578,14 +578,14 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-tangents"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "bevy_mikktspace",
 ]
 
 [[package]]
 name = "awsm-renderer-web-shared"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ resolver = "2"
 [workspace.package]
 description = "awsm renderer"
 edition = "2021"
-version = "0.7.2"
+version = "0.8.0"
 license = "MIT OR Apache-2.0"
 authors = ["David Komer"]
 # 1.85 floor: rmcp 1.x (the MCP server SDK) is edition-2024, which requires
@@ -118,23 +118,23 @@ opt-level = 1
 # `workspace.package.version` so the published crates carry concrete
 # version requirements on each other (crates.io rejects path-only deps).
 # Bump this block together with the version above on every release.
-awsm-renderer-curves = { path = "packages/crates/curves", version = "0.7.2" }
-awsm-renderer-geometry = { path = "packages/crates/geometry", version = "0.7.2" }
-awsm-renderer-scene = { path = "packages/crates/scene", version = "0.7.2" }
-awsm-renderer-scene-loader = { path = "packages/crates/scene-loader", version = "0.7.2" }
-awsm-renderer-editor-protocol = { path = "packages/mcp/editor-protocol", version = "0.7.2" }
-awsm-renderer-core = { path = "packages/crates/renderer-core", version = "0.7.2" }
-awsm-renderer-meshgen = { path = "packages/crates/meshgen", version = "0.7.2" }
-awsm-renderer-glb-export = { path = "packages/crates/glb-export", version = "0.7.2" }
-awsm-renderer-gltf-convert = { path = "packages/crates/gltf-convert", version = "0.7.2" }
-awsm-renderer-tangents = { path = "packages/crates/tangents", version = "0.7.2" }
-awsm-renderer-lod-bake = { path = "packages/crates/lod-bake", version = "0.7.2" }
-awsm-renderer-particles = { path = "packages/crates/particles", version = "0.7.2" }
-awsm-renderer-materials = { path = "packages/crates/materials", version = "0.7.2" }
-awsm-renderer = { path = "packages/crates/renderer", version = "0.7.2" }
-awsm-renderer-gltf = { path = "packages/crates/renderer-gltf", version = "0.7.2" }
+awsm-renderer-curves = { path = "packages/crates/curves", version = "0.8.0" }
+awsm-renderer-geometry = { path = "packages/crates/geometry", version = "0.8.0" }
+awsm-renderer-scene = { path = "packages/crates/scene", version = "0.8.0" }
+awsm-renderer-scene-loader = { path = "packages/crates/scene-loader", version = "0.8.0" }
+awsm-renderer-editor-protocol = { path = "packages/mcp/editor-protocol", version = "0.8.0" }
+awsm-renderer-core = { path = "packages/crates/renderer-core", version = "0.8.0" }
+awsm-renderer-meshgen = { path = "packages/crates/meshgen", version = "0.8.0" }
+awsm-renderer-glb-export = { path = "packages/crates/glb-export", version = "0.8.0" }
+awsm-renderer-gltf-convert = { path = "packages/crates/gltf-convert", version = "0.8.0" }
+awsm-renderer-tangents = { path = "packages/crates/tangents", version = "0.8.0" }
+awsm-renderer-lod-bake = { path = "packages/crates/lod-bake", version = "0.8.0" }
+awsm-renderer-particles = { path = "packages/crates/particles", version = "0.8.0" }
+awsm-renderer-materials = { path = "packages/crates/materials", version = "0.8.0" }
+awsm-renderer = { path = "packages/crates/renderer", version = "0.8.0" }
+awsm-renderer-gltf = { path = "packages/crates/renderer-gltf", version = "0.8.0" }
 # Frontend-only (not published); workspace dep keeps consumers path-agnostic.
-awsm-renderer-web-shared = { path = "packages/frontend/web-shared", version = "0.7.2" }
+awsm-renderer-web-shared = { path = "packages/frontend/web-shared", version = "0.8.0" }
 
 # Misc
 cfg-if = "1.0.4"

--- a/packages/crates/renderer/src/render_passes/shared/shared_wgsl/shadow/bind_groups.wgsl
+++ b/packages/crates/renderer/src/render_passes/shared/shared_wgsl/shadow/bind_groups.wgsl
@@ -251,6 +251,21 @@ fn apply_sscs(world_pos: vec3<f32>, light_dir: vec3<f32>) -> f32 {
 // for cube face generation in `Shadows::write_gpu`.
 const POINT_SHADOW_NEAR: f32 = 0.05;
 
+// Kernel-width receiver-plane slack for the point-light soft/PCSS taps
+// is the per-light `kernel_slack` shadow param, delivered in the
+// otherwise-unused `cascade_info.x` descriptor slot (see
+// `shadows::state` cube packing). A wide disc on the receiver tangent
+// plane reaches taps whose light-direction lands in cube texels storing
+// the floor's own (quantized, slope-varying) back-face depth; the
+// constant per-tap `depth_bias` can't cover that growing mismatch, so
+// the 16-tap average dips below 1.0 in radial bands → the "acne rings"
+// on a flat floor under a point light. Mirrors the 2D/cascade fix
+// (`pcss_ref -= depth_bias * penumbra_texels * 0.5`): widen the
+// comparison bias with the kernel radius so wider penumbras get
+// proportional slack. Scaled below by the local NDC.z gradient so the
+// slack is in the same units as `ref_depth` at every distance/face.
+// Hard (kernel radius 0) gets zero extra bias and stays crisp.
+
 // Point-light cube shadow sample.
 //
 // Each cube face stores perspective NDC.z written by the rasterizer
@@ -368,7 +383,12 @@ fn sample_shadow_cube(desc: ShadowDescriptor, world_pos: vec3<f32>, world_normal
                 (range / (range - near)) * (1.0 - near / max(tap_view_depth, near));
             let tap_n_dot_dir = abs(dot(tap_dir, world_normal));
             let tap_bias = desc.bias_params.x / max(tap_n_dot_dir, 0.05);
-            let tap_ref = clamp(tap_ndc_z, 0.0, 1.0) - tap_bias;
+            // Kernel-width slack: depth a tap-radius displacement can span
+            // on this receiver, in NDC.z units (gradient × world radius).
+            let tap_grad = (range / (range - near)) * near
+                / max(tap_view_depth * tap_view_depth, near * near);
+            let tap_slack = tap_grad * SOFT_WORLD_RADIUS * desc.cascade_info.x;
+            let tap_ref = clamp(tap_ndc_z, 0.0, 1.0) - tap_bias - tap_slack;
             sum += textureSampleCompareLevel(
                 shadow_cube_array,
                 shadow_cube_sampler,
@@ -515,7 +535,12 @@ fn sample_shadow_cube(desc: ShadowDescriptor, world_pos: vec3<f32>, world_normal
             (range / (range - near)) * (1.0 - near / max(tap_view_depth, near));
         let tap_n_dot_dir = abs(dot(tap_dir, world_normal));
         let tap_bias = desc.bias_params.x / max(tap_n_dot_dir, 0.05);
-        let tap_ref = clamp(tap_ndc_z, 0.0, 1.0) - tap_bias;
+        // Kernel-width slack (see soft path) — scaled by the PCSS
+        // penumbra radius so wide variable kernels don't self-shadow.
+        let tap_grad = (range / (range - near)) * near
+            / max(tap_view_depth * tap_view_depth, near * near);
+        let tap_slack = tap_grad * penumbra_world_radius * desc.cascade_info.x;
+        let tap_ref = clamp(tap_ndc_z, 0.0, 1.0) - tap_bias - tap_slack;
         sum += textureSampleCompareLevel(
             shadow_cube_array,
             shadow_cube_sampler,

--- a/packages/crates/renderer/src/shadows/light_shadow.rs
+++ b/packages/crates/renderer/src/shadows/light_shadow.rs
@@ -31,6 +31,13 @@ pub struct LightShadowParams {
     /// PCSS for back-compat, but it now governs the `Soft` mode too so a
     /// single control drives both.
     pub pcss_penumbra_scale: f32,
+    /// Point-light only. Receiver-plane slack folded into the soft/PCSS
+    /// comparison bias, scaled by the kernel radius — kills the
+    /// self-shadow "acne rings" a wide disc otherwise produces on a flat
+    /// floor under a point light. Passed to the cube shader via the
+    /// (otherwise-unused) `cascade_info.x` descriptor slot. `0.0` = off,
+    /// `2.0` = neutral default; larger trades acne for contact leak.
+    pub kernel_slack: f32,
     /// Camera-distance fadeout cutoff for this light's shadow.
     /// Camera-distance cutoff for the cascade span. `<= 0` = AUTO
     /// (follow the camera far plane) — the scale-safe default; a
@@ -67,6 +74,7 @@ impl Default for LightShadowParams {
             resolution: 1024,
             hardness: LightShadowHardness::Soft,
             pcss_penumbra_scale: 1.0,
+            kernel_slack: 2.0,
             max_distance: 0.0,
             cascade_count: 4,
             cascade_split_lambda: 0.5,

--- a/packages/crates/renderer/src/shadows/schema_convert.rs
+++ b/packages/crates/renderer/src/shadows/schema_convert.rs
@@ -62,6 +62,7 @@ impl From<schema::LightShadowConfig> for LightShadowParams {
             resolution: s.resolution,
             hardness: s.hardness.into(),
             pcss_penumbra_scale: s.pcss_penumbra_scale,
+            kernel_slack: s.kernel_slack,
             max_distance: s.max_distance,
             cascade_count: s.cascade_count,
             cascade_split_lambda: s.cascade_split_lambda,

--- a/packages/crates/renderer/src/shadows/state.rs
+++ b/packages/crates/renderer/src/shadows/state.rs
@@ -2395,6 +2395,12 @@ impl Shadows {
                     descriptor_bytes[off + 68..off + 72].copy_from_slice(&pos.y.to_ne_bytes());
                     descriptor_bytes[off + 72..off + 76].copy_from_slice(&pos.z.to_ne_bytes());
                     descriptor_bytes[off + 76..off + 80].copy_from_slice(&r.to_ne_bytes());
+                    // cascade_info.x = kernel slack (point-only; this slot
+                    // otherwise carries split_far, which the cube sampler
+                    // never reads). Soft/PCSS taps fold it into the
+                    // receiver-plane comparison bias to kill acne rings.
+                    descriptor_bytes[off + 96..off + 100]
+                        .copy_from_slice(&params.kernel_slack.to_ne_bytes());
                     // cascade_info.y = slot index (as f32)
                     descriptor_bytes[off + 100..off + 104]
                         .copy_from_slice(&(slot_index as f32).to_ne_bytes());

--- a/packages/crates/scene-loader/src/light.rs
+++ b/packages/crates/scene-loader/src/light.rs
@@ -67,6 +67,7 @@ pub fn light_shadow_params_from_config(
             s::LightShadowHardness::Pcss => r::LightShadowHardness::Pcss,
         },
         pcss_penumbra_scale: cfg.pcss_penumbra_scale,
+        kernel_slack: cfg.kernel_slack,
         max_distance: cfg.max_distance,
         cascade_count: cfg.cascade_count,
         cascade_split_lambda: cfg.cascade_split_lambda,

--- a/packages/crates/scene/src/light.rs
+++ b/packages/crates/scene/src/light.rs
@@ -60,6 +60,15 @@ pub struct LightShadowConfig {
     /// Multiplier on the estimated PCSS penumbra size.
     #[serde(default = "default_pcss_scale")]
     pub pcss_penumbra_scale: f32,
+    /// Point-light only. Receiver-plane slack added to the soft/PCSS
+    /// comparison bias, scaled by the kernel radius — counteracts the
+    /// self-shadow "acne rings" a wide disc produces on a flat floor
+    /// under a point light (the cube faces store slope-varying
+    /// back-face depth that a constant `depth_bias` can't cover as the
+    /// kernel widens). 0 = off (acne returns at large softness); larger
+    /// = more slack (eventually light-leak / peter-panning at contacts).
+    #[serde(default = "default_kernel_slack")]
+    pub kernel_slack: f32,
     /// Beyond this distance from the camera the shadow fades and the
     /// light skips its shadow pass that frame.
     #[serde(default = "default_max_distance")]
@@ -92,6 +101,7 @@ impl Default for LightShadowConfig {
             resolution: 1024,
             hardness: LightShadowHardness::Soft,
             pcss_penumbra_scale: 1.0,
+            kernel_slack: 2.0,
             max_distance: 0.0,
             cascade_count: 4,
             cascade_split_lambda: 0.5,
@@ -183,6 +193,9 @@ fn default_shadow_res() -> u32 {
 }
 fn default_pcss_scale() -> f32 {
     1.0
+}
+fn default_kernel_slack() -> f32 {
+    2.0
 }
 fn default_max_distance() -> f32 {
     // <= 0 = AUTO (follow the camera far plane) — scale-safe; see the

--- a/packages/frontend/editor/src/scene_mode/inspector.rs
+++ b/packages/frontend/editor/src/scene_mode/inspector.rs
@@ -3690,6 +3690,18 @@ fn light_shadow_editor(node: &Arc<Node>, cfg: &LightConfig) -> Dom {
 
     // Point-light cube faces.
     if matches!(cfg, LightConfig::Point { .. }) {
+        // Soft/PCSS-only knob: receiver-plane slack that removes the
+        // wide-kernel self-shadow "acne rings" on flat floors. No effect
+        // in Hard mode (zero-radius kernel).
+        let n = node.clone();
+        sec = sec.child(row(
+            "Kernel Slack",
+            NumField::new(shadow.kernel_slack as f64)
+                .min(0.0)
+                .step(0.5)
+                .on_change(move |v| update_shadow(&n, |s| s.kernel_slack = (v as f32).max(0.0)))
+                .render(),
+        ));
         let n = node.clone();
         sec = sec.child(enum_select_row(
             "Cube Update",


### PR DESCRIPTION
## Problem

A point light over a flat floor (ball + surface) produced radial **"acne rings"** of noise/mottling across the whole lit floor in **Soft (PCF)** and **PCSS** shadow modes. **Hard** mode was clean. Tuning depth/normal bias couldn't fix it — pushing bias only traded acne for peter-panning.

## Diagnosis (verified live in the editor)

Bisected empirically against the real scene:

- Shadows off → floor perfectly clean (rules out material/normals).
- **Hard** → clean. **Soft/PCSS** → rings, and they **scale with kernel width** (tiny softness = clean, full = rings).

So it's the **multi-tap kernel**, not the base comparison. The point-light cube soft/PCSS taps offset across the receiver tangent plane into cube texels holding the floor's own *slope-varying back-face depth*, but the cube path — unlike the 2D-atlas and cascade paths — **never widened the comparison bias by the kernel radius**. Wider kernel → more taps read "occluded" → the 16-tap average dips below 1.0 in radial (iso-distance from the light) bands.

## Fix

Add a receiver-plane slack to the cube Soft + PCSS taps, mirroring the existing 2D/cascade fix (`pcss_ref -= depth_bias * penumbra_texels * 0.5`):

```
tap_slack = ndc_gradient * kernel_world_radius * kernel_slack
```

`ndc_gradient` and `kernel_world_radius` are computed **per-fragment from real geometry**, so the slack auto-scales with the light range, receiver distance, cube face, and softness — a general-purpose fix, not a constant pinned to one scene. **Hard** (zero kernel radius) gets zero extra bias and stays crisp.

## New per-scene param: `kernel_slack`

The unitless multiplier (default **2.0**) is exposed as a per-light shadow param:

- **Editor:** "Kernel Slack" row in the Shadows panel (point-light only).
- **MCP:** reachable with no new wiring via `patch_kind` / `dispatch_command` (SetKind) for writes, `get_node_details` / `get_snapshot` for reads, and `get_kind_schema` for discovery (all serde + schemars).
- Packed into the cube descriptor's otherwise-unused `cascade_info.x` slot → **no descriptor layout/size change**.

`0` = off (rings return), `2` = clean default, high values trade acne for contact-shadow detachment — exposed so it's tunable per scene/scale.

## Verification

- Live in the editor on the reported scene: rings gone in Soft + PCSS, contact shadow preserved, Hard unchanged; the editor field and live `patch_kind` (the MCP write path) both drive it.
- `cargo test -p awsm-renderer-scene` (incl. `scene_toml_round_trips`) and `cargo test -p awsm-renderer --lib` (302 tests, incl. naga WGSL validation) pass.
- `task lint` (rustfmt + clippy `-D warnings`, all features, tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)