### PR TITLE
Shadows: edge-aware denoise blur + unified baked-Vogel sampling + per-light tap count

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,7 +187,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "askama",
@@ -214,7 +214,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-core"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "binpack2d",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-curves"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "glam 0.32.1",
  "serde",
@@ -248,7 +248,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-debugging"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-editor"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-editor-protocol"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "awsm-renderer-meshgen",
  "awsm-renderer-scene",
@@ -323,7 +323,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-geometry"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "glam 0.32.1",
  "serde",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-glb-export"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "awsm-renderer-meshgen",
  "awsm-renderer-tangents",
@@ -346,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-gltf"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-gltf-convert"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "awsm-renderer-glb-export",
  "awsm-renderer-meshgen",
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-lod-bake"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "glam 0.32.1",
  "serde",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-lod-bake-cli"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "awsm-renderer-glb-export",
@@ -410,7 +410,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-materials"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "awsm-renderer-core",
  "thiserror 2.0.18",
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-meshgen"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "awsm-renderer-curves",
  "awsm-renderer-geometry",
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-model-tests"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-multithreaded-example"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "awsm-renderer",
  "awsm-renderer-core",
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-particles"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "awsm-renderer-curves",
  "awsm-renderer-geometry",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-render-worker-example"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-scene"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "bitcode",
  "glam 0.32.1",
@@ -535,7 +535,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-scene-loader"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-scene-mcp"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "awsm-renderer-editor-protocol",
@@ -578,14 +578,14 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-tangents"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "bevy_mikktspace",
 ]
 
 [[package]]
 name = "awsm-renderer-web-shared"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ resolver = "2"
 [workspace.package]
 description = "awsm renderer"
 edition = "2021"
-version = "0.8.0"
+version = "0.9.0"
 license = "MIT OR Apache-2.0"
 authors = ["David Komer"]
 # 1.85 floor: rmcp 1.x (the MCP server SDK) is edition-2024, which requires
@@ -118,23 +118,23 @@ opt-level = 1
 # `workspace.package.version` so the published crates carry concrete
 # version requirements on each other (crates.io rejects path-only deps).
 # Bump this block together with the version above on every release.
-awsm-renderer-curves = { path = "packages/crates/curves", version = "0.8.0" }
-awsm-renderer-geometry = { path = "packages/crates/geometry", version = "0.8.0" }
-awsm-renderer-scene = { path = "packages/crates/scene", version = "0.8.0" }
-awsm-renderer-scene-loader = { path = "packages/crates/scene-loader", version = "0.8.0" }
-awsm-renderer-editor-protocol = { path = "packages/mcp/editor-protocol", version = "0.8.0" }
-awsm-renderer-core = { path = "packages/crates/renderer-core", version = "0.8.0" }
-awsm-renderer-meshgen = { path = "packages/crates/meshgen", version = "0.8.0" }
-awsm-renderer-glb-export = { path = "packages/crates/glb-export", version = "0.8.0" }
-awsm-renderer-gltf-convert = { path = "packages/crates/gltf-convert", version = "0.8.0" }
-awsm-renderer-tangents = { path = "packages/crates/tangents", version = "0.8.0" }
-awsm-renderer-lod-bake = { path = "packages/crates/lod-bake", version = "0.8.0" }
-awsm-renderer-particles = { path = "packages/crates/particles", version = "0.8.0" }
-awsm-renderer-materials = { path = "packages/crates/materials", version = "0.8.0" }
-awsm-renderer = { path = "packages/crates/renderer", version = "0.8.0" }
-awsm-renderer-gltf = { path = "packages/crates/renderer-gltf", version = "0.8.0" }
+awsm-renderer-curves = { path = "packages/crates/curves", version = "0.9.0" }
+awsm-renderer-geometry = { path = "packages/crates/geometry", version = "0.9.0" }
+awsm-renderer-scene = { path = "packages/crates/scene", version = "0.9.0" }
+awsm-renderer-scene-loader = { path = "packages/crates/scene-loader", version = "0.9.0" }
+awsm-renderer-editor-protocol = { path = "packages/mcp/editor-protocol", version = "0.9.0" }
+awsm-renderer-core = { path = "packages/crates/renderer-core", version = "0.9.0" }
+awsm-renderer-meshgen = { path = "packages/crates/meshgen", version = "0.9.0" }
+awsm-renderer-glb-export = { path = "packages/crates/glb-export", version = "0.9.0" }
+awsm-renderer-gltf-convert = { path = "packages/crates/gltf-convert", version = "0.9.0" }
+awsm-renderer-tangents = { path = "packages/crates/tangents", version = "0.9.0" }
+awsm-renderer-lod-bake = { path = "packages/crates/lod-bake", version = "0.9.0" }
+awsm-renderer-particles = { path = "packages/crates/particles", version = "0.9.0" }
+awsm-renderer-materials = { path = "packages/crates/materials", version = "0.9.0" }
+awsm-renderer = { path = "packages/crates/renderer", version = "0.9.0" }
+awsm-renderer-gltf = { path = "packages/crates/renderer-gltf", version = "0.9.0" }
 # Frontend-only (not published); workspace dep keeps consumers path-agnostic.
-awsm-renderer-web-shared = { path = "packages/frontend/web-shared", version = "0.8.0" }
+awsm-renderer-web-shared = { path = "packages/frontend/web-shared", version = "0.9.0" }
 
 # Misc
 cfg-if = "1.0.4"

--- a/docs/SHADOWS.md
+++ b/docs/SHADOWS.md
@@ -21,11 +21,14 @@ bottom for where to look.
   as opaque.
 * **Sample-site filters**: `Hard` (1-tap), `Soft` (PCF with a
   world-unit-sized kernel), `Pcss` (variable-kernel PCF with blocker
-  search — on every light kind, incl. point/cube). The point-light
-  soft/Pcss taps use a clump-free Vogel disc; an optional screen-space
-  [denoise blur](#shadow-denoise-blur) smooths the residual penumbra
-  speckle. EVSM is selected per-cascade via `evsm_cutoff` and gives a
-  single-bilinear-fetch path for the farthest cascades.
+  search — on every light kind, incl. point/cube). All kinds sample one
+  shared **baked Vogel (golden-angle) disc** — even, clump-free coverage
+  at a runtime-chosen tap count. The per-light `shadow_samples` knob sets
+  that count (the cost lever); an optional screen-space
+  [denoise blur](#shadow-denoise-blur) smooths residual penumbra speckle
+  so a modest count suffices. EVSM is selected per-cascade via
+  `evsm_cutoff` and gives a single-bilinear-fetch path for the farthest
+  cascades.
 * **Screen-space contact shadows (SSCS)** refine the dominant
   directional light's term in the opaque pass.
 
@@ -46,6 +49,7 @@ under each Light node's **Shadows** sub-panel.
 | `hardness`                  | `Hard` / `Soft` / `Pcss`                                | Sample-site filter. `Pcss` runs on every light kind; point-light Pcss is a fixed-kernel widened-Soft (see Known limits). |
 | `pcss_penumbra_scale`       | f32, default 1.0                                        | Only consulted when `hardness == Pcss`.                                                     |
 | `kernel_slack`              | f32, default 2.0 (point only)                          | Soft/Pcss self-shadow acne slack, in cube-texels of quantization to forgive (scaled per-texel, NOT by kernel radius — see Known limits). `0` = off.  |
+| `shadow_samples`            | u32, default 16, clamped `[8, 64]`                     | Soft/Pcss Vogel tap budget — the per-shadowed-pixel `textureSampleCompare` cost knob, all light kinds (PCSS blocker search uses ¾). Higher = smoother penumbra, more cost; reserve high counts for hero lights. `Hard` ignores it. |
 | `max_distance`              | f32 (m)                                                 | Camera-distance cutoff. Beyond this, the light's shadow fades.                              |
 | `cascade_count`             | 1..=4 (directional only)                                | Default 4. Lower for cheaper but coarser shadow coverage.                                   |
 | `cascade_split_lambda`      | 0.0..=1.0 (directional only)                            | PSSM split bias. `0` = uniform; `1` = logarithmic. Default `0.5`.                           |
@@ -187,17 +191,21 @@ historical reasons; new player code should prefer the From impls.
   `24 · res² · max_lights` bytes. The defaults (8 lights × 1024²) cost
   ~24 MB. Mobile-class browsers usually want `512²` × `4` lights
   (~3 MB) or smaller.
+* **`shadow_samples`** (per-light, default 16) — THE tap-count cost
+  lever. Every shadowed pixel does `shadow_samples` (Soft) or
+  `shadow_samples` + ¾·`shadow_samples` (Pcss, blocker + PCF) cube/atlas
+  `textureSampleCompare`s, so cost is ~linear in it. Lower for fill
+  lights / low-end GPUs; raise only for hero lights. The denoise blur is
+  the cheaper *global* noise lever, so 16 + denoise usually beats 48 raw.
 * **`hardness`** at the receiver site:
   * `Hard`: 1 comparison tap per fragment.
-  * `Soft`: 16-tap rotated Poisson disk PCF. Kernel half-width is
-    sized in *world units* (`soft_world_radius`, ~25 cm at default
-    light angles) divided by `world_per_texel`, clamped to
-    `[3, 20]` texels. With hardware 2×2 bilinear comparison per tap
-    that's ~64 effective samples — a clearly soft edge across the
-    full cascade chain.
-  * `Pcss`: blocker search + variable-kernel PCF. AAA quality, AAA
-    cost; reserve for hero lights. (Point lights use a clump-free Vogel
-    disc — 24 blocker + 32 PCF taps; the 2D/cascade path stays at 16.)
+  * `Soft`: `shadow_samples`-tap Vogel-disc PCF. Kernel half-width is
+    sized in *world units* (`soft_world_radius`) divided by
+    `world_per_texel`. With hardware 2×2 bilinear comparison per tap the
+    effective sample count is ~4×, a clearly soft edge.
+  * `Pcss`: blocker search + variable-kernel PCF. AAA quality, AAA cost;
+    reserve for hero lights. Tap budget is `shadow_samples` (PCF) +
+    ¾·`shadow_samples` (blocker), all light kinds.
 * **`denoise`** — one separable, light-count-independent screen-space
   blur on the shared visibility buffer (see [Shadow denoise](#shadow-denoise-blur)).
   Cheap relative to the shadow sampling it cleans up; on by default.
@@ -464,17 +472,21 @@ penumbra against a high-contrast (dark-shadow / bright-floor) receiver.
    denoise**, on by default) exists to smooth exactly this. Confirm it's
    enabled; if a player build looks noisy, check `ShadowsConfig::denoise`
    is `true`. See [Shadow denoise](#shadow-denoise-blur).
-2. **Kernel reaching off-tile (directional/spot).** On the 2D path,
+2. **Too few samples.** Raise the light's `shadow_samples` (default 16).
+   Low counts on a wide penumbra are the direct cause of speckle; with
+   denoise on, 16 is usually clean, but a very wide PCSS penumbra on a
+   hero light may want 24–48.
+3. **Kernel reaching off-tile (directional/spot).** On the 2D path,
    `pcss_penumbra_scale` can widen the variable kernel beyond the
    cascade's atlas tile, where blocker-search taps hit the tile clamp.
    Reduce `pcss_penumbra_scale` (try `1.0` and work up). Confirm with
    `debug_cascade_colors` that the receiver isn't right at a cascade
    boundary where two PCSS kernels overlap.
-3. **Underlying sampler.** The point-light soft/Pcss taps use a
-   clump-free Vogel disc (32 PCF / 24 blocker taps) — far smoother than a
-   rotated fixed-Poisson set — so the residual after denoise is minimal.
-   If you still see structure with denoise on, it's likely the MSAA
-   silhouette-edge band the blur skips (see the denoise limitation).
+4. **Underlying sampler.** All kinds sample a clump-free baked Vogel disc
+   (far smoother than a rotated fixed-Poisson set), so the residual after
+   denoise is minimal. If you still see structure with denoise on, it's
+   likely the MSAA silhouette-edge band the blur skips (see the denoise
+   limitation).
 
 #### Phantom double / mirrored shadow on point lights
 
@@ -525,8 +537,8 @@ Recipe for an unambiguous EVSM-vs-PCF demo:
   inlined at the call site (a forward-declared helper tripped a
   Dawn validation error). Penumbra width follows
   `(z_recv − z_blocker_avg) / z_blocker_avg`, mapped to a
-  world-space disc radius clamped to `[10 cm, 1 m]`. Taps use a
-  Vogel disc (24 blocker / 32 PCF) for clump-free coverage.
+  world-space disc radius clamped to `[10 cm, 1 m]`. Taps use the shared
+  baked Vogel disc at the light's `shadow_samples` count (¾ for blocker).
 * **`kernel_slack` is per-texel, not per-kernel** — the point-light
   soft/Pcss self-shadow slack (which removes "acne rings" on a flat
   floor) is scaled by the world footprint of **one** cube texel, not by
@@ -570,7 +582,8 @@ move with the code if it gets refactored. Map of where to look:
 | Atlas clear-once / cube clear      | [`shadows/render_pass.rs`](../packages/crates/renderer/src/shadows/render_pass.rs)                                                                  |
 | Cube Y-flip + CW winding           | [`shadows/mod.rs`](../packages/crates/renderer/src/shadows/mod.rs) (search for `y_flip`)                                                            |
 | EVSM moment write + blur shaders   | [`shadows/evsm.rs`](../packages/crates/renderer/src/shadows/evsm.rs)                                                                                |
-| Cascade-blend, PCF / PCSS taps, Vogel disc, `kernel_slack` | [`shared_wgsl/shadow/bind_groups.wgsl`](../packages/crates/renderer/src/render_passes/shared/shared_wgsl/shadow/bind_groups.wgsl)                   |
+| Cascade-blend, PCF/PCSS taps, baked Vogel disc (`VOGEL_BASE`), `shadow_samples`, `kernel_slack` | [`shared_wgsl/shadow/bind_groups.wgsl`](../packages/crates/renderer/src/render_passes/shared/shared_wgsl/shadow/bind_groups.wgsl)                   |
+| Per-light shadow descriptor packing (`extra_params`) | [`shadows/helpers.rs`](../packages/crates/renderer/src/shadows/helpers.rs) + [`shadows/consts.rs`](../packages/crates/renderer/src/shadows/consts.rs) |
 | Shadow denoise blur (visibility)   | [`material_prep/shader/shadow_blur_wgsl/`](../packages/crates/renderer/src/render_passes/material_prep/shader/shadow_blur_wgsl) + [`render_blur`](../packages/crates/renderer/src/render_passes/material_prep/render_pass.rs) |
 | Equal-resolution cascades          | [`shadows/cascade.rs::cascade_resolution`](../packages/crates/renderer/src/shadows/cascade.rs)                                                      |
 | Slope-scale + constant depth bias  | [`build_shadow_pipeline`](../packages/crates/renderer/src/shadows/mod.rs) (`with_depth_bias(1).with_depth_bias_slope_scale(1.5)`)                  |

--- a/docs/SHADOWS.md
+++ b/docs/SHADOWS.md
@@ -19,11 +19,13 @@ bottom for where to look.
   does (16.B landed the bind-group consolidation that unblocks this);
   transparent receivers honour the same `Mesh::receive_shadows` flag
   as opaque.
-* **Sample-site filters**: `Hard` (1-tap), `Soft` (16-tap rotated
-  Poisson PCF with a world-unit-sized kernel), `Pcss` (variable-
-  kernel PCF with blocker search — 2D only). EVSM is selected
-  per-cascade via `evsm_cutoff` and gives a single-bilinear-fetch
-  path for the farthest cascades.
+* **Sample-site filters**: `Hard` (1-tap), `Soft` (PCF with a
+  world-unit-sized kernel), `Pcss` (variable-kernel PCF with blocker
+  search — on every light kind, incl. point/cube). The point-light
+  soft/Pcss taps use a clump-free Vogel disc; an optional screen-space
+  [denoise blur](#shadow-denoise-blur) smooths the residual penumbra
+  speckle. EVSM is selected per-cascade via `evsm_cutoff` and gives a
+  single-bilinear-fetch path for the farthest cascades.
 * **Screen-space contact shadows (SSCS)** refine the dominant
   directional light's term in the opaque pass.
 
@@ -43,6 +45,7 @@ under each Light node's **Shadows** sub-panel.
 | `resolution`                | 512 / 1024 / 2048 / 4096                                | Per-cascade / per-spot map resolution. Point lights ignore this — they use the global pool. |
 | `hardness`                  | `Hard` / `Soft` / `Pcss`                                | Sample-site filter. `Pcss` runs on every light kind; point-light Pcss is a fixed-kernel widened-Soft (see Known limits). |
 | `pcss_penumbra_scale`       | f32, default 1.0                                        | Only consulted when `hardness == Pcss`.                                                     |
+| `kernel_slack`              | f32, default 2.0 (point only)                          | Soft/Pcss self-shadow acne slack, in cube-texels of quantization to forgive (scaled per-texel, NOT by kernel radius — see Known limits). `0` = off.  |
 | `max_distance`              | f32 (m)                                                 | Camera-distance cutoff. Beyond this, the light's shadow fades.                              |
 | `cascade_count`             | 1..=4 (directional only)                                | Default 4. Lower for cheaper but coarser shadow coverage.                                   |
 | `cascade_split_lambda`      | 0.0..=1.0 (directional only)                            | PSSM split bias. `0` = uniform; `1` = logarithmic. Default `0.5`.                           |
@@ -81,12 +84,51 @@ they don't expose toggles.
 | `max_point_shadows`         | 0 / 2 / 4 / 8 / 16                  | Live (tears down the cube pool).                                |
 | `point_shadow_resolution`   | 256 / 512 / 1024 / 2048             | Live (tears down the cube pool).                                |
 | `debug_cascade_colors`      | bool                                | Live.                                                           |
+| `denoise`                   | bool (default `true`)               | Live. Edge-aware denoise blur on the per-pixel shadow-visibility buffer (see [Shadow denoise](#shadow-denoise-blur)). Editor toggle: **Settings → Shadow denoise**. |
 
 The "tears down" fields recreate the underlying GPU textures + bind
 groups at the start of the next `write_gpu` — fine from the inspector
 (the user-facing latency is one frame) but don't drive them at frame
 rate. The 2D PCF atlas additionally auto-grows when the row-pack
 allocator overflows, on top of the explicit size users may set here.
+
+## Shadow denoise blur
+
+`ShadowsConfig::denoise` (editor: **Settings → Shadow denoise**, default
+**on**) enables an edge-aware blur on the per-pixel shadow-visibility
+buffer that the deferred prep pass produces.
+
+**Why it exists.** Soft/PCSS penumbras are sampled with a finite,
+per-pixel-rotated tap disc. Over a wide penumbra (point-light Pcss can
+reach a ~1 m world disc) that undersampling reads as a "furry" speckle
+fringe at the shadow edge — there is no temporal accumulation to resolve
+it. Rather than pay for more taps inside the (per-light) shadow sampler,
+the denoise blur smooths the *result* once.
+
+**How it works — one pass, all lights.** The
+[`material_prep`](../packages/crates/renderer/src/render_passes/material_prep)
+pass writes every shadowed light's per-pixel visibility into one packed
+`Rgba8unorm` array (`prep_shadow_visibility`, 4 lights per layer). The
+denoise pass blurs *that texture*, so its cost is **independent of light
+count** — 1 shadowed light and 100 cost the same. It is:
+
+* **Separable** — a horizontal then a vertical 1D pass (writes a temp,
+  then writes back into `prep_shadow_visibility` in place, so the opaque
+  reader's binding never changes).
+* **Edge-stopped by linear depth** — a neighbour whose reconstructed
+  view-z differs from the centre by more than a small *fraction* (5%)
+  falls off sharply. So the penumbra smooths on a continuous surface but
+  shadow never bleeds across a silhouette (or into sky).
+* **Skipped entirely** when the toggle is off (the dispatch is gated;
+  the bind groups + pipelines stay resident so the flip is free).
+
+**Limitation.** Under MSAA the thin silhouette-edge samples are shaded
+from a separate compact buffer (`prep_edge_shadow`) that this blur does
+not touch — only the full-screen interior is denoised. In practice the
+visible penumbra noise is interior, so this is rarely noticeable.
+
+See `render_passes/material_prep/shader/shadow_blur_wgsl/` for the
+shader and `material_prep/render_pass.rs::render_blur` for the dispatch.
 
 ## Player / runtime integration
 
@@ -153,8 +195,12 @@ historical reasons; new player code should prefer the From impls.
     `[3, 20]` texels. With hardware 2×2 bilinear comparison per tap
     that's ~64 effective samples — a clearly soft edge across the
     full cascade chain.
-  * `Pcss`: 16-tap blocker search + 16-tap variable-kernel PCF. AAA
-    quality, AAA cost. Reserve for hero lights.
+  * `Pcss`: blocker search + variable-kernel PCF. AAA quality, AAA
+    cost; reserve for hero lights. (Point lights use a clump-free Vogel
+    disc — 24 blocker + 32 PCF taps; the 2D/cascade path stays at 16.)
+* **`denoise`** — one separable, light-count-independent screen-space
+  blur on the shared visibility buffer (see [Shadow denoise](#shadow-denoise-blur)).
+  Cheap relative to the shadow sampling it cleans up; on by default.
 * **`evsm_cutoff`** — promotes one or two trailing cascades to EVSM,
   which trades a moment-write + Gaussian blur compute pass per
   cascade for a single bilinear fetch + Chebyshev visibility at the
@@ -406,18 +452,29 @@ fine.
    excess silently drops with `point-light shadow cube pool
    exhausted` in the console.
 
-#### PCSS edges look like noise / staircase
+#### PCSS / soft edges look like noise / speckle
 
-**Symptom:** the soft penumbra has a noisy or stepped texture
-instead of a smooth fall-off.
+**Symptom:** the soft penumbra has a noisy "furry" or stepped texture
+instead of a smooth fall-off — most visible on a point light's wide
+penumbra against a high-contrast (dark-shadow / bright-floor) receiver.
 
-**Cause:** `pcss_penumbra_scale` is widening the variable kernel
-beyond the cascade's atlas tile, where blocker-search taps hit the
-tile clamp.
+**Diagnosis ladder:**
 
-**Fix:** reduce `pcss_penumbra_scale` (try `1.0` and work up).
-Confirm with `debug_cascade_colors` that the receiver isn't right at
-a cascade boundary where two PCSS kernels overlap.
+1. **Denoise off.** The edge-aware denoise blur (**Settings → Shadow
+   denoise**, on by default) exists to smooth exactly this. Confirm it's
+   enabled; if a player build looks noisy, check `ShadowsConfig::denoise`
+   is `true`. See [Shadow denoise](#shadow-denoise-blur).
+2. **Kernel reaching off-tile (directional/spot).** On the 2D path,
+   `pcss_penumbra_scale` can widen the variable kernel beyond the
+   cascade's atlas tile, where blocker-search taps hit the tile clamp.
+   Reduce `pcss_penumbra_scale` (try `1.0` and work up). Confirm with
+   `debug_cascade_colors` that the receiver isn't right at a cascade
+   boundary where two PCSS kernels overlap.
+3. **Underlying sampler.** The point-light soft/Pcss taps use a
+   clump-free Vogel disc (32 PCF / 24 blocker taps) — far smoother than a
+   rotated fixed-Poisson set — so the residual after denoise is minimal.
+   If you still see structure with denoise on, it's likely the MSAA
+   silhouette-edge band the blur skips (see the denoise limitation).
 
 #### Phantom double / mirrored shadow on point lights
 
@@ -468,7 +525,18 @@ Recipe for an unambiguous EVSM-vs-PCF demo:
   inlined at the call site (a forward-declared helper tripped a
   Dawn validation error). Penumbra width follows
   `(z_recv − z_blocker_avg) / z_blocker_avg`, mapped to a
-  world-space disc radius clamped to `[10 cm, 1 m]`.
+  world-space disc radius clamped to `[10 cm, 1 m]`. Taps use a
+  Vogel disc (24 blocker / 32 PCF) for clump-free coverage.
+* **`kernel_slack` is per-texel, not per-kernel** — the point-light
+  soft/Pcss self-shadow slack (which removes "acne rings" on a flat
+  floor) is scaled by the world footprint of **one** cube texel, not by
+  the kernel radius. Scaling by the (up to ~1 m) kernel radius — the
+  original formulation — let a wide Pcss penumbra balloon the slack past
+  a genuine receiver↔occluder gap and leak light into the umbra (a lit
+  hole under a floating occluder). One-texel scale fixes the
+  quantization acne identically while staying far too small to bridge a
+  real occluder gap. `kernel_slack` therefore reads as "texels of
+  quantization to forgive" (default 2).
 * **Spot light PCSS** — supported (it's a 2D shadow), but you may
   want to tune `pcss_penumbra_scale` per-spot since the cone half-
   angle affects the apparent penumbra.
@@ -502,7 +570,8 @@ move with the code if it gets refactored. Map of where to look:
 | Atlas clear-once / cube clear      | [`shadows/render_pass.rs`](../packages/crates/renderer/src/shadows/render_pass.rs)                                                                  |
 | Cube Y-flip + CW winding           | [`shadows/mod.rs`](../packages/crates/renderer/src/shadows/mod.rs) (search for `y_flip`)                                                            |
 | EVSM moment write + blur shaders   | [`shadows/evsm.rs`](../packages/crates/renderer/src/shadows/evsm.rs)                                                                                |
-| Cascade-blend, PCF / PCSS taps     | [`shared_wgsl/shadow/bind_groups.wgsl`](../packages/crates/renderer/src/render_passes/shared/shared_wgsl/shadow/bind_groups.wgsl)                   |
+| Cascade-blend, PCF / PCSS taps, Vogel disc, `kernel_slack` | [`shared_wgsl/shadow/bind_groups.wgsl`](../packages/crates/renderer/src/render_passes/shared/shared_wgsl/shadow/bind_groups.wgsl)                   |
+| Shadow denoise blur (visibility)   | [`material_prep/shader/shadow_blur_wgsl/`](../packages/crates/renderer/src/render_passes/material_prep/shader/shadow_blur_wgsl) + [`render_blur`](../packages/crates/renderer/src/render_passes/material_prep/render_pass.rs) |
 | Equal-resolution cascades          | [`shadows/cascade.rs::cascade_resolution`](../packages/crates/renderer/src/shadows/cascade.rs)                                                      |
 | Slope-scale + constant depth bias  | [`build_shadow_pipeline`](../packages/crates/renderer/src/shadows/mod.rs) (`with_depth_bias(1).with_depth_bias_slope_scale(1.5)`)                  |
 | 16.B bind-group consolidation      | [`material_transparent/bind_group.rs`](../packages/crates/renderer/src/render_passes/material_transparent/bind_group.rs)                            |

--- a/packages/crates/renderer/src/render.rs
+++ b/packages/crates/renderer/src/render.rs
@@ -1078,6 +1078,10 @@ impl AwsmRenderer {
             // (classify → prep → opaque ordering); concurrent edge-buffer READ is
             // safe within the frame encoder.
             prep.render_edge(&ctx)?;
+            // Optional shadow-visibility denoise blur (in place on
+            // prep_shadow_visibility). Gated on ShadowsConfig::denoise; runs
+            // before opaque reads the buffer.
+            prep.render_blur(&ctx)?;
         }
 
         {

--- a/packages/crates/renderer/src/render_passes/material_prep/bind_group.rs
+++ b/packages/crates/renderer/src/render_passes/material_prep/bind_group.rs
@@ -59,9 +59,17 @@ pub struct MaterialPrepBindGroups {
     /// edge_layout (uniform) + edge_shadow_out (storage texture array, write).
     /// `None` when the renderer is not MSAA (no edges, no cs_prep_edge pipeline).
     pub edge_bind_group_layout_key: Option<BindGroupLayoutKey>,
+    /// Layouts for the optional shadow-denoise blur (`cs_blur_h` / `cs_blur_v`).
+    /// Two MSAA variants (the depth binding type follows the geometry pass).
+    pub blur_multisampled_bind_group_layout_key: BindGroupLayoutKey,
+    pub blur_singlesampled_bind_group_layout_key: BindGroupLayoutKey,
     bind_group: Option<web_sys::GpuBindGroup>,
     lights_bind_group: Option<web_sys::GpuBindGroup>,
     shadows_bind_group: Option<web_sys::GpuBindGroup>,
+    /// Blur ping-pong bind groups: H reads `prep_shadow_visibility` → writes
+    /// the temp; V reads the temp → writes back into `prep_shadow_visibility`.
+    blur_h_bind_group: Option<web_sys::GpuBindGroup>,
+    blur_v_bind_group: Option<web_sys::GpuBindGroup>,
 }
 
 impl MaterialPrepBindGroups {
@@ -90,15 +98,24 @@ impl MaterialPrepBindGroups {
         // the pipeline + texture are ready for the MSAA-on path.
         let edge_bind_group_layout_key = Some(create_edge_bind_group_layout_key(ctx)?);
 
+        let blur_multisampled_bind_group_layout_key =
+            create_blur_bind_group_layout_key(ctx, true)?;
+        let blur_singlesampled_bind_group_layout_key =
+            create_blur_bind_group_layout_key(ctx, false)?;
+
         Ok(Self {
             multisampled_bind_group_layout_key,
             singlesampled_bind_group_layout_key,
             lights_bind_group_layout_key,
             shadows_bind_group_layout_key,
             edge_bind_group_layout_key,
+            blur_multisampled_bind_group_layout_key,
+            blur_singlesampled_bind_group_layout_key,
             bind_group: None,
             lights_bind_group: None,
             shadows_bind_group: None,
+            blur_h_bind_group: None,
+            blur_v_bind_group: None,
         })
     }
 
@@ -129,6 +146,24 @@ impl MaterialPrepBindGroups {
             .ok_or_else(|| AwsmBindGroupError::NotFound("Material Prep - Shadows".to_string()))
     }
 
+    /// Blur H bind group (src = `prep_shadow_visibility`, dst = temp).
+    pub fn get_blur_h_bind_group(
+        &self,
+    ) -> std::result::Result<&web_sys::GpuBindGroup, AwsmBindGroupError> {
+        self.blur_h_bind_group
+            .as_ref()
+            .ok_or_else(|| AwsmBindGroupError::NotFound("Material Prep - Blur H".to_string()))
+    }
+
+    /// Blur V bind group (src = temp, dst = `prep_shadow_visibility`).
+    pub fn get_blur_v_bind_group(
+        &self,
+    ) -> std::result::Result<&web_sys::GpuBindGroup, AwsmBindGroupError> {
+        self.blur_v_bind_group
+            .as_ref()
+            .ok_or_else(|| AwsmBindGroupError::NotFound("Material Prep - Blur V".to_string()))
+    }
+
     /// (Re)builds all three prep bind groups. Called from
     /// [`crate::bind_groups::BindGroups`] in response to any of prep's recreate
     /// events (texture-view recreate, mesh-meta / geometry-pool resize, lights /
@@ -138,7 +173,85 @@ impl MaterialPrepBindGroups {
         self.recreate_main(ctx)?;
         self.recreate_lights(ctx)?;
         self.recreate_shadows(ctx)?;
+        self.recreate_blur(ctx)?;
         Ok(())
+    }
+
+    /// Rebuilds the two blur ping-pong bind groups (H + V) against the live
+    /// MSAA layout. Built unconditionally (cheap) so the denoise toggle can flip
+    /// at runtime without a bind-group rebuild — `render_blur` skips the
+    /// dispatch when the config disables it.
+    fn recreate_blur(&mut self, ctx: &BindGroupRecreateContext<'_>) -> Result<()> {
+        let msaa = ctx.anti_aliasing.msaa_sample_count.is_some();
+        let layout_key = if msaa {
+            self.blur_multisampled_bind_group_layout_key
+        } else {
+            self.blur_singlesampled_bind_group_layout_key
+        };
+
+        let visibility = ctx
+            .render_texture_views
+            .prep_shadow_visibility
+            .as_ref()
+            .ok_or_else(|| {
+                AwsmBindGroupError::NotFound("Material Prep - Blur visibility".to_string())
+            })?;
+        let tmp = ctx
+            .render_texture_views
+            .prep_shadow_visibility_blur_tmp
+            .as_ref()
+            .ok_or_else(|| {
+                AwsmBindGroupError::NotFound("Material Prep - Blur temp".to_string())
+            })?;
+
+        // H: src = visibility → dst = temp. V: src = temp → dst = visibility.
+        self.blur_h_bind_group = Some(self.build_blur_bind_group(
+            ctx,
+            layout_key,
+            visibility,
+            tmp,
+            "Material Prep - Blur H",
+        )?);
+        self.blur_v_bind_group = Some(self.build_blur_bind_group(
+            ctx,
+            layout_key,
+            tmp,
+            visibility,
+            "Material Prep - Blur V",
+        )?);
+        Ok(())
+    }
+
+    fn build_blur_bind_group(
+        &self,
+        ctx: &BindGroupRecreateContext<'_>,
+        layout_key: BindGroupLayoutKey,
+        src: &web_sys::GpuTextureView,
+        dst: &web_sys::GpuTextureView,
+        label: &str,
+    ) -> Result<web_sys::GpuBindGroup> {
+        let entries = vec![
+            // 0 depth_tex (edge-stopping).
+            BindGroupEntry::new(
+                0,
+                BindGroupResource::TextureView(Cow::Borrowed(&ctx.render_texture_views.depth)),
+            ),
+            // 1 camera_raw (uniform — depth → linear view-z).
+            BindGroupEntry::new(
+                1,
+                BindGroupResource::Buffer(BufferBinding::new(&ctx.camera.gpu_buffer)),
+            ),
+            // 2 src visibility (sampled).
+            BindGroupEntry::new(2, BindGroupResource::TextureView(Cow::Borrowed(src))),
+            // 3 dst visibility (storage write).
+            BindGroupEntry::new(3, BindGroupResource::TextureView(Cow::Borrowed(dst))),
+        ];
+        let descriptor = BindGroupDescriptor::new(
+            ctx.bind_group_layouts.get(layout_key)?,
+            Some(label),
+            entries,
+        );
+        Ok(ctx.gpu.create_bind_group(&descriptor.into()))
     }
 
     fn recreate_main(&mut self, ctx: &BindGroupRecreateContext<'_>) -> Result<()> {
@@ -392,6 +505,53 @@ fn create_edge_bind_group_layout_key(
             BufferBindingLayout::new().with_binding_type(BufferBindingType::Uniform),
         )),
         // 2 edge_shadow_out — storage texture array (rgba8unorm, write).
+        compute(BindGroupLayoutResource::StorageTexture(
+            StorageTextureBindingLayout::new(TextureFormat::Rgba8unorm)
+                .with_view_dimension(TextureViewDimension::N2dArray)
+                .with_access(StorageTextureAccess::WriteOnly),
+        )),
+    ];
+
+    Ok(ctx
+        .bind_group_layouts
+        .get_key(ctx.gpu, BindGroupLayoutCacheKey { entries })?)
+}
+
+/// Layout for the optional shadow-denoise blur (`cs_blur_h` / `cs_blur_v`):
+///   0 blur_depth_tex   — depth texture (edge-stop); MSAA variant multisampled.
+///   1 blur_camera_raw  — uniform (depth → linear view-z).
+///   2 blur_src         — sampled visibility array (Rgba8unorm read as f32).
+///   3 blur_dst         — storage visibility array (Rgba8unorm, write).
+fn create_blur_bind_group_layout_key(
+    ctx: &mut RenderPassInitContext<'_>,
+    multisampled_geometry: bool,
+) -> Result<BindGroupLayoutKey> {
+    let compute = |resource: BindGroupLayoutResource| BindGroupLayoutCacheKeyEntry {
+        resource,
+        visibility_vertex: false,
+        visibility_fragment: false,
+        visibility_compute: true,
+    };
+
+    let entries = vec![
+        // 0 depth_tex — MSAA variant is multisampled (matches geometry depth).
+        compute(BindGroupLayoutResource::Texture(
+            TextureBindingLayout::new()
+                .with_view_dimension(TextureViewDimension::N2d)
+                .with_sample_type(TextureSampleType::Depth)
+                .with_multisampled(multisampled_geometry),
+        )),
+        // 1 camera_raw — uniform.
+        compute(BindGroupLayoutResource::Buffer(
+            BufferBindingLayout::new().with_binding_type(BufferBindingType::Uniform),
+        )),
+        // 2 src visibility — sampled texture array (rgba8unorm → filterable f32).
+        compute(BindGroupLayoutResource::Texture(
+            TextureBindingLayout::new()
+                .with_view_dimension(TextureViewDimension::N2dArray)
+                .with_sample_type(TextureSampleType::Float),
+        )),
+        // 3 dst visibility — storage texture array (rgba8unorm, write).
         compute(BindGroupLayoutResource::StorageTexture(
             StorageTextureBindingLayout::new(TextureFormat::Rgba8unorm)
                 .with_view_dimension(TextureViewDimension::N2dArray)

--- a/packages/crates/renderer/src/render_passes/material_prep/bind_group.rs
+++ b/packages/crates/renderer/src/render_passes/material_prep/bind_group.rs
@@ -98,8 +98,7 @@ impl MaterialPrepBindGroups {
         // the pipeline + texture are ready for the MSAA-on path.
         let edge_bind_group_layout_key = Some(create_edge_bind_group_layout_key(ctx)?);
 
-        let blur_multisampled_bind_group_layout_key =
-            create_blur_bind_group_layout_key(ctx, true)?;
+        let blur_multisampled_bind_group_layout_key = create_blur_bind_group_layout_key(ctx, true)?;
         let blur_singlesampled_bind_group_layout_key =
             create_blur_bind_group_layout_key(ctx, false)?;
 
@@ -200,9 +199,7 @@ impl MaterialPrepBindGroups {
             .render_texture_views
             .prep_shadow_visibility_blur_tmp
             .as_ref()
-            .ok_or_else(|| {
-                AwsmBindGroupError::NotFound("Material Prep - Blur temp".to_string())
-            })?;
+            .ok_or_else(|| AwsmBindGroupError::NotFound("Material Prep - Blur temp".to_string()))?;
 
         // H: src = visibility → dst = temp. V: src = temp → dst = visibility.
         self.blur_h_bind_group = Some(self.build_blur_bind_group(

--- a/packages/crates/renderer/src/render_passes/material_prep/render_pass.rs
+++ b/packages/crates/renderer/src/render_passes/material_prep/render_pass.rs
@@ -25,8 +25,9 @@ use crate::{
     render_passes::{
         material_opaque::edge_buffers::MaterialEdgeBuffers,
         material_prep::{
-            bind_group::MaterialPrepBindGroups, buffers::EdgeShadowBuffer,
-            shader::cache_key::ShaderCacheKeyMaterialPrep,
+            bind_group::MaterialPrepBindGroups,
+            buffers::EdgeShadowBuffer,
+            shader::cache_key::{ShaderCacheKeyMaterialPrep, ShaderCacheKeyShadowBlur},
         },
         RenderPassInitContext,
     },
@@ -47,6 +48,13 @@ pub struct MaterialPrepRenderPass {
     /// Stage 5b-shadow: the compact per-edge-sample shadow texture cs_prep_edge
     /// writes + cs_edge reads. `None` when not MSAA.
     pub edge_shadow: Option<EdgeShadowBuffer>,
+    /// Optional shadow-denoise blur pipelines (`cs_blur_h` / `cs_blur_v`), one
+    /// per MSAA-geometry variant. Built eagerly; dispatched by `render_blur`
+    /// only when the runtime `ShadowsConfig::denoise` toggle is on.
+    blur_h_multisampled_pipeline_key: ComputePipelineKey,
+    blur_h_singlesampled_pipeline_key: ComputePipelineKey,
+    blur_v_multisampled_pipeline_key: ComputePipelineKey,
+    blur_v_singlesampled_pipeline_key: ComputePipelineKey,
 }
 
 impl MaterialPrepRenderPass {
@@ -73,12 +81,25 @@ impl MaterialPrepRenderPass {
             ctx.prep_config.shadow_visibility_layers(),
         )?);
 
+        let blur_h_multisampled_pipeline_key =
+            build_blur_pipeline(ctx, &bind_groups, true, "cs_blur_h").await?;
+        let blur_h_singlesampled_pipeline_key =
+            build_blur_pipeline(ctx, &bind_groups, false, "cs_blur_h").await?;
+        let blur_v_multisampled_pipeline_key =
+            build_blur_pipeline(ctx, &bind_groups, true, "cs_blur_v").await?;
+        let blur_v_singlesampled_pipeline_key =
+            build_blur_pipeline(ctx, &bind_groups, false, "cs_blur_v").await?;
+
         Ok(Self {
             bind_groups,
             multisampled_pipeline_key,
             singlesampled_pipeline_key,
             edge_pipeline_key,
             edge_shadow,
+            blur_h_multisampled_pipeline_key,
+            blur_h_singlesampled_pipeline_key,
+            blur_v_multisampled_pipeline_key,
+            blur_v_singlesampled_pipeline_key,
         })
     }
 
@@ -213,6 +234,67 @@ impl MaterialPrepRenderPass {
         compute_pass.end();
         Ok(())
     }
+
+    /// Optional shadow-visibility denoise blur. A single separable, edge-aware
+    /// (depth-stopped) screen-space pass over `prep_shadow_visibility`: H writes
+    /// the temp, V writes back, so the opaque reader's binding never changes.
+    /// Smooths the residual soft/PCSS penumbra speckle for ALL shadowed lights
+    /// at once (cost independent of light count). Skipped entirely when the
+    /// runtime `ShadowsConfig::denoise` toggle is off. Inserted between
+    /// `cs_prep`/`cs_prep_edge` and the opaque pass (compute passes in one
+    /// encoder are ordered, so the write→read is safe with no explicit barrier).
+    pub fn render_blur(&self, ctx: &RenderContext) -> Result<()> {
+        if !ctx.shadows.config().denoise {
+            return Ok(());
+        }
+        // Nothing casts → `prep_shadow_visibility` is all-1.0; blurring it is a
+        // no-op. Skip the two full-screen dispatches (matches how the shadow
+        // generation pass itself short-circuits on `any_active()`).
+        if !ctx.shadows.any_active() {
+            return Ok(());
+        }
+        let msaa = ctx.anti_aliasing.msaa_sample_count.is_some();
+        let (h_key, v_key) = if msaa {
+            (
+                self.blur_h_multisampled_pipeline_key,
+                self.blur_v_multisampled_pipeline_key,
+            )
+        } else {
+            (
+                self.blur_h_singlesampled_pipeline_key,
+                self.blur_v_singlesampled_pipeline_key,
+            )
+        };
+        let h_pipeline = ctx.pipelines.compute.get(h_key)?;
+        let v_pipeline = ctx.pipelines.compute.get(v_key)?;
+        let h_bind_group = self.bind_groups.get_blur_h_bind_group()?;
+        let v_bind_group = self.bind_groups.get_blur_v_bind_group()?;
+
+        let workgroups_x = ctx.render_texture_views.width.div_ceil(8);
+        let workgroups_y = ctx.render_texture_views.height.div_ceil(8);
+
+        // Horizontal: prep_shadow_visibility → temp.
+        {
+            let compute_pass = ctx.command_encoder.begin_compute_pass(Some(
+                &ComputePassDescriptor::new(Some("Shadow Denoise Blur H")).into(),
+            ));
+            compute_pass.set_pipeline(h_pipeline);
+            compute_pass.set_bind_group(0, h_bind_group, None)?;
+            compute_pass.dispatch_workgroups(workgroups_x, Some(workgroups_y), Some(1));
+            compute_pass.end();
+        }
+        // Vertical: temp → prep_shadow_visibility (back in place).
+        {
+            let compute_pass = ctx.command_encoder.begin_compute_pass(Some(
+                &ComputePassDescriptor::new(Some("Shadow Denoise Blur V")).into(),
+            ));
+            compute_pass.set_pipeline(v_pipeline);
+            compute_pass.set_bind_group(0, v_bind_group, None)?;
+            compute_pass.dispatch_workgroups(workgroups_x, Some(workgroups_y), Some(1));
+            compute_pass.end();
+        }
+        Ok(())
+    }
 }
 
 /// Builds the `cs_prep` pipeline for one MSAA-geometry variant.
@@ -299,6 +381,51 @@ async fn build_edge_pipeline(
             ctx.pipeline_layouts,
             ComputePipelineCacheKey::new(shader_key, pipeline_layout_key)
                 .with_entry_point("cs_prep_edge"),
+        )
+        .await?;
+    Ok(pipeline_key)
+}
+
+/// Builds one shadow-denoise blur pipeline (`entry_point` = `cs_blur_h` or
+/// `cs_blur_v`) for one MSAA-geometry variant. Both entry points share the one
+/// blur shader module (same `ShaderCacheKeyShadowBlur`); only the pipeline's
+/// entry point + the H/V bind group differ. Pipeline layout = the single blur
+/// bind group at group(0).
+async fn build_blur_pipeline(
+    ctx: &mut RenderPassInitContext<'_>,
+    bind_groups: &MaterialPrepBindGroups,
+    multisampled_geometry: bool,
+    entry_point: &str,
+) -> Result<ComputePipelineKey> {
+    let bgl_key = if multisampled_geometry {
+        bind_groups.blur_multisampled_bind_group_layout_key
+    } else {
+        bind_groups.blur_singlesampled_bind_group_layout_key
+    };
+    let pipeline_layout_key = ctx.pipeline_layouts.get_key(
+        ctx.gpu,
+        ctx.bind_group_layouts,
+        PipelineLayoutCacheKey::new(vec![bgl_key]),
+    )?;
+    let shader_key = ctx
+        .shaders
+        .get_key(
+            ctx.gpu,
+            ShaderCacheKeyShadowBlur {
+                msaa_sample_count: if multisampled_geometry { Some(4) } else { None },
+                max_shadow_casters: ctx.prep_config.clamped_k(),
+            },
+        )
+        .await?;
+    let pipeline_key = ctx
+        .pipelines
+        .compute
+        .get_key(
+            ctx.gpu,
+            ctx.shaders,
+            ctx.pipeline_layouts,
+            ComputePipelineCacheKey::new(shader_key, pipeline_layout_key)
+                .with_entry_point(entry_point),
         )
         .await?;
     Ok(pipeline_key)

--- a/packages/crates/renderer/src/render_passes/material_prep/shader/cache_key.rs
+++ b/packages/crates/renderer/src/render_passes/material_prep/shader/cache_key.rs
@@ -23,3 +23,19 @@ impl From<ShaderCacheKeyMaterialPrep> for ShaderCacheKey {
         ShaderCacheKey::RenderPass(ShaderCacheKeyRenderPass::MaterialPrep(key))
     }
 }
+
+/// Cache key for the OPTIONAL shadow-visibility denoise blur compute pipelines
+/// (`cs_blur_h` / `cs_blur_v`). `msaa_sample_count` selects the depth binding
+/// type (multisampled vs not); `max_shadow_casters` sets the packed-layer loop
+/// count (`ceil(K/4)`), matching the prep output it blurs.
+#[derive(Hash, Debug, Clone, PartialEq, Eq)]
+pub struct ShaderCacheKeyShadowBlur {
+    pub msaa_sample_count: Option<u32>,
+    pub max_shadow_casters: u32,
+}
+
+impl From<ShaderCacheKeyShadowBlur> for ShaderCacheKey {
+    fn from(key: ShaderCacheKeyShadowBlur) -> Self {
+        ShaderCacheKey::RenderPass(ShaderCacheKeyRenderPass::ShadowBlur(key))
+    }
+}

--- a/packages/crates/renderer/src/render_passes/material_prep/shader/shadow_blur_wgsl/bind_groups.wgsl
+++ b/packages/crates/renderer/src/render_passes/material_prep/shader/shadow_blur_wgsl/bind_groups.wgsl
@@ -1,0 +1,24 @@
+// Bind group for the OPTIONAL shadow-visibility denoise blur (separable,
+// edge-aware). Reads the packed per-pixel shadow-visibility array + the
+// geometry depth, writes a blurred copy. Two MSAA variants (the depth binding
+// type follows the geometry pass). Layout must stay in lockstep with
+// `material_prep/bind_group.rs` (`create_blur_bind_group_layout_key`).
+//
+// The pass is separable: H (src = prep_shadow_visibility → dst = tmp) then V
+// (src = tmp → dst = prep_shadow_visibility), so the opaque reader's binding
+// never changes and the whole thing is skipped when the toggle is off.
+
+// CameraRaw + camera_from_raw — depth → linear view-z for the edge-stopping
+// weight (reject silhouette / sky jumps; smooth on continuous surfaces).
+{% include "shared_wgsl/camera.wgsl" %}
+
+{% if multisampled_geometry %}
+    @group(0) @binding(0) var blur_depth_tex: texture_depth_multisampled_2d;
+{% else %}
+    @group(0) @binding(0) var blur_depth_tex: texture_depth_2d;
+{% endif %}
+@group(0) @binding(1) var<uniform> blur_camera_raw: CameraRaw;
+// Source visibility (sampled) + blurred destination (storage write). Both are
+// the Rgba8unorm `ceil(K/4)`-layer packed visibility format.
+@group(0) @binding(2) var blur_src: texture_2d_array<f32>;
+@group(0) @binding(3) var blur_dst: texture_storage_2d_array<rgba8unorm, write>;

--- a/packages/crates/renderer/src/render_passes/material_prep/shader/shadow_blur_wgsl/compute.wgsl
+++ b/packages/crates/renderer/src/render_passes/material_prep/shader/shadow_blur_wgsl/compute.wgsl
@@ -1,0 +1,95 @@
+// Separable edge-aware blur on the packed shadow-visibility array — the
+// optional shadow denoise pass. `cs_blur_h` then `cs_blur_v` run in sequence
+// (H writes the temp, V writes back into prep_shadow_visibility), each a 1D
+// Gaussian gated by a RELATIVE linear-depth similarity weight: neighbours on
+// the same continuous surface contribute (smoothing the PCSS/soft penumbra
+// speckle), while neighbours across a silhouette — or sky — fall off sharply
+// (their view-z differs by a large fraction) so shadow never bleeds across a
+// geometry edge.
+//
+// `BLUR_LAYERS` = ceil(K/4) packed visibility layers; each Rgba8unorm channel
+// is an independent light's visibility, so every channel blurs independently
+// (a plain per-component box is correct — no unpack needed).
+
+const BLUR_LAYERS: u32 = {{ shadow_visibility_layers }}u;
+// Half-width of the 1D kernel (per axis). 4 → a 9-tap separable blur ≈ 9×9.
+const BLUR_RADIUS: i32 = 4;
+// Spatial Gaussian variance (in texels²) for the kernel falloff.
+const BLUR_SPATIAL_VAR: f32 = 4.0;
+// Edge-stop: a neighbour whose linear view-z differs from the centre by this
+// FRACTION contributes ~e^-0.5. Relative (not absolute) so it is scale- and
+// distance-invariant — a grazing floor's own gradient stays under it while a
+// silhouette/sky jump blows past it.
+const BLUR_DEPTH_REL_SIGMA: f32 = 0.05;
+
+// Reconstruct linear view-space Z (metres, positive in front) from the depth
+// texture — same unprojection cs_prep uses, reduced to just the Z we need.
+// Only the Z and W of the unprojected point matter, so the caller hoists rows
+// 2 and 3 of inv_proj (one `camera_from_raw` per pixel) and we do two dot
+// products per tap instead of a full mat4x4 * vec4.
+fn blur_view_z(inv_proj_row_z: vec4<f32>, inv_proj_row_w: vec4<f32>, coords: vec2<i32>, dims: vec2<f32>) -> f32 {
+    let depth = textureLoad(blur_depth_tex, coords, 0);
+    let pix_uv = (vec2<f32>(coords) + vec2<f32>(0.5, 0.5)) / dims;
+    let p = vec4<f32>(pix_uv.x * 2.0 - 1.0, 1.0 - pix_uv.y * 2.0, depth, 1.0);
+    let view_z = dot(inv_proj_row_z, p);
+    let view_w = dot(inv_proj_row_w, p);
+    return -(view_z / max(view_w, 1e-8));
+}
+
+fn blur_axis(gid: vec2<u32>, dir: vec2<i32>) {
+    let dims_u = textureDimensions(blur_src).xy;
+    if (gid.x >= dims_u.x || gid.y >= dims_u.y) {
+        return;
+    }
+    let dims_i = vec2<i32>(dims_u);
+    let dims_f = vec2<f32>(dims_u);
+    // Rows 2 and 3 of inv_proj — the only rows view-z reconstruction needs.
+    // (inv_proj[col][row]; column-major, so row r = the r-th component of each column.)
+    let inv_proj = camera_from_raw(blur_camera_raw).inv_proj;
+    let inv_proj_row_z = vec4<f32>(inv_proj[0].z, inv_proj[1].z, inv_proj[2].z, inv_proj[3].z);
+    let inv_proj_row_w = vec4<f32>(inv_proj[0].w, inv_proj[1].w, inv_proj[2].w, inv_proj[3].w);
+    let c = vec2<i32>(gid);
+    let center_z = blur_view_z(inv_proj_row_z, inv_proj_row_w, c, dims_f);
+    let z_sigma = max(center_z, 0.05) * BLUR_DEPTH_REL_SIGMA;
+    let inv_two_z_var = 1.0 / (2.0 * z_sigma * z_sigma);
+
+    // Edge-stopping is geometry-only (depth), so the per-tap spatial × depth
+    // weight is identical for every layer — compute it ONCE, reuse across the
+    // `BLUR_LAYERS` packed-light layers.
+    var taps: array<vec2<i32>, 8>;      // up to BLUR_RADIUS*2 neighbour coords
+    var weights: array<f32, 8>;
+    var tap_count: u32 = 0u;
+    for (var k: i32 = 1; k <= BLUR_RADIUS; k = k + 1) {
+        let gw = exp(-f32(k * k) / (2.0 * BLUR_SPATIAL_VAR));
+        for (var s: i32 = -1; s <= 1; s = s + 2) {
+            let nc = clamp(c + dir * (k * s), vec2<i32>(0, 0), dims_i - vec2<i32>(1, 1));
+            let nz = blur_view_z(inv_proj_row_z, inv_proj_row_w, nc, dims_f);
+            let dz = nz - center_z;
+            let wz = exp(-(dz * dz) * inv_two_z_var);
+            taps[tap_count] = nc;
+            weights[tap_count] = gw * wz;
+            tap_count = tap_count + 1u;
+        }
+    }
+
+    for (var l: u32 = 0u; l < BLUR_LAYERS; l = l + 1u) {
+        // Centre tap (weight 1).
+        var sum = textureLoad(blur_src, c, i32(l), 0);
+        var wsum = 1.0;
+        for (var t: u32 = 0u; t < tap_count; t = t + 1u) {
+            sum = sum + textureLoad(blur_src, taps[t], i32(l), 0) * weights[t];
+            wsum = wsum + weights[t];
+        }
+        textureStore(blur_dst, c, i32(l), sum / wsum);
+    }
+}
+
+@compute @workgroup_size(8, 8)
+fn cs_blur_h(@builtin(global_invocation_id) gid: vec3<u32>) {
+    blur_axis(gid.xy, vec2<i32>(1, 0));
+}
+
+@compute @workgroup_size(8, 8)
+fn cs_blur_v(@builtin(global_invocation_id) gid: vec3<u32>) {
+    blur_axis(gid.xy, vec2<i32>(0, 1));
+}

--- a/packages/crates/renderer/src/render_passes/material_prep/shader/template.rs
+++ b/packages/crates/renderer/src/render_passes/material_prep/shader/template.rs
@@ -4,7 +4,9 @@
 use askama::Template;
 
 use crate::{
-    render_passes::material_prep::shader::cache_key::ShaderCacheKeyMaterialPrep,
+    render_passes::material_prep::shader::cache_key::{
+        ShaderCacheKeyMaterialPrep, ShaderCacheKeyShadowBlur,
+    },
     shaders::{AwsmShaderError, Result},
 };
 
@@ -105,5 +107,58 @@ impl ShaderTemplateMaterialPrep {
     /// Returns an optional debug label for shader compilation.
     pub fn debug_label(&self) -> Option<&str> {
         Some("Material Prep")
+    }
+}
+
+// ── Optional shadow-visibility denoise blur (`cs_blur_h` / `cs_blur_v`) ───────
+
+pub struct ShaderTemplateShadowBlur {
+    pub bind_groups: ShaderTemplateShadowBlurBindGroups,
+    pub compute: ShaderTemplateShadowBlurCompute,
+}
+
+/// Blur bind-group declarations — lockstep with the blur layout in
+/// `material_prep/bind_group.rs` (`create_blur_bind_group_layout_key`).
+#[derive(Template, Debug)]
+#[template(path = "shadow_blur_wgsl/bind_groups.wgsl", whitespace = "minimize")]
+pub struct ShaderTemplateShadowBlurBindGroups {
+    /// Depth binding type (true = `texture_depth_multisampled_2d`).
+    pub multisampled_geometry: bool,
+}
+
+/// Blur compute body (`cs_blur_h` / `cs_blur_v`).
+#[derive(Template, Debug)]
+#[template(path = "shadow_blur_wgsl/compute.wgsl", whitespace = "minimize")]
+pub struct ShaderTemplateShadowBlurCompute {
+    /// `ceil(K/4)` — packed shadow-visibility layers to blur (matches the prep
+    /// output this pass reads + writes).
+    pub shadow_visibility_layers: u32,
+}
+
+impl TryFrom<&ShaderCacheKeyShadowBlur> for ShaderTemplateShadowBlur {
+    type Error = AwsmShaderError;
+    fn try_from(key: &ShaderCacheKeyShadowBlur) -> Result<Self> {
+        Ok(ShaderTemplateShadowBlur {
+            bind_groups: ShaderTemplateShadowBlurBindGroups {
+                multisampled_geometry: key.msaa_sample_count.is_some(),
+            },
+            compute: ShaderTemplateShadowBlurCompute {
+                shadow_visibility_layers: key.max_shadow_casters.div_ceil(4).max(1),
+            },
+        })
+    }
+}
+
+impl ShaderTemplateShadowBlur {
+    /// Renders the blur shader into a WGSL source string.
+    pub fn into_source(self) -> Result<String> {
+        let bind_groups_source = self.bind_groups.render()?;
+        let compute_source = self.compute.render()?;
+        Ok(format!("{}\n{}", bind_groups_source, compute_source))
+    }
+
+    /// Returns an optional debug label for shader compilation.
+    pub fn debug_label(&self) -> Option<&str> {
+        Some("Shadow Denoise Blur")
     }
 }

--- a/packages/crates/renderer/src/render_passes/shader_cache_key.rs
+++ b/packages/crates/renderer/src/render_passes/shader_cache_key.rs
@@ -19,7 +19,7 @@ use crate::render_passes::{
     material_decal::shader::cache_key::ShaderCacheKeyMaterialDecal,
     material_opaque::shader::cache_key::ShaderCacheKeyMaterialOpaque,
     material_opaque::shader::edge_cache_key::ShaderCacheKeyMaterialFinalBlend,
-    material_prep::shader::cache_key::ShaderCacheKeyMaterialPrep,
+    material_prep::shader::cache_key::{ShaderCacheKeyMaterialPrep, ShaderCacheKeyShadowBlur},
     material_transparent::shader::cache_key::ShaderCacheKeyMaterialTransparent,
     occlusion::shader::cache_key::{
         ShaderCacheKeyOcclusionCompaction, ShaderCacheKeyOcclusionCull,
@@ -48,6 +48,8 @@ pub enum ShaderCacheKeyRenderPass {
     MaterialClassify(ShaderCacheKeyMaterialClassify),
     /// Plan B shared prep pass (docs/plans/deferred-shared-prep-pass.md).
     MaterialPrep(ShaderCacheKeyMaterialPrep),
+    /// Optional shadow-visibility denoise blur (`cs_blur_h` / `cs_blur_v`).
+    ShadowBlur(ShaderCacheKeyShadowBlur),
     DecalClassify(ShaderCacheKeyDecalClassify),
     MaterialDecal(ShaderCacheKeyMaterialDecal),
     MaterialOpaque(ShaderCacheKeyMaterialOpaque),

--- a/packages/crates/renderer/src/render_passes/shader_template.rs
+++ b/packages/crates/renderer/src/render_passes/shader_template.rs
@@ -20,7 +20,7 @@ use crate::{
         material_decal::shader::template::ShaderTemplateMaterialDecal,
         material_opaque::shader::edge_template::ShaderTemplateMaterialFinalBlend,
         material_opaque::shader::template::ShaderTemplateMaterialOpaque,
-        material_prep::shader::template::ShaderTemplateMaterialPrep,
+        material_prep::shader::template::{ShaderTemplateMaterialPrep, ShaderTemplateShadowBlur},
         material_transparent::shader::template::ShaderTemplateMaterialTransparent,
         occlusion::shader::template::{
             ShaderTemplateOcclusionCompaction, ShaderTemplateOcclusionCull,
@@ -42,6 +42,7 @@ pub enum ShaderTemplateRenderPass {
     LightCulling(ShaderTemplateLightCulling),
     MaterialClassify(ShaderTemplateMaterialClassify),
     MaterialPrep(ShaderTemplateMaterialPrep),
+    ShadowBlur(ShaderTemplateShadowBlur),
     DecalClassify(ShaderTemplateDecalClassify),
     MaterialDecal(ShaderTemplateMaterialDecal),
     MaterialOpaque(ShaderTemplateMaterialOpaque),
@@ -91,6 +92,9 @@ impl TryFrom<&ShaderCacheKeyRenderPass> for ShaderTemplateRenderPass {
             ),
             ShaderCacheKeyRenderPass::MaterialPrep(cache_key) => Ok(
                 ShaderTemplateRenderPass::MaterialPrep(cache_key.try_into()?),
+            ),
+            ShaderCacheKeyRenderPass::ShadowBlur(cache_key) => Ok(
+                ShaderTemplateRenderPass::ShadowBlur(cache_key.try_into()?),
             ),
             ShaderCacheKeyRenderPass::DecalClassify(cache_key) => Ok(
                 ShaderTemplateRenderPass::DecalClassify(cache_key.try_into()?),
@@ -145,6 +149,7 @@ impl ShaderTemplateRenderPass {
             ShaderTemplateRenderPass::LightCulling(tmpl) => tmpl.into_source(),
             ShaderTemplateRenderPass::MaterialClassify(tmpl) => tmpl.into_source(),
             ShaderTemplateRenderPass::MaterialPrep(tmpl) => tmpl.into_source(),
+            ShaderTemplateRenderPass::ShadowBlur(tmpl) => tmpl.into_source(),
             ShaderTemplateRenderPass::DecalClassify(tmpl) => tmpl.into_source(),
             ShaderTemplateRenderPass::MaterialDecal(tmpl) => tmpl.into_source(),
             ShaderTemplateRenderPass::MaterialOpaque(tmpl) => tmpl.into_source(),
@@ -176,6 +181,7 @@ impl ShaderTemplateRenderPass {
             ShaderTemplateRenderPass::LightCulling(tmpl) => tmpl.debug_label(),
             ShaderTemplateRenderPass::MaterialClassify(tmpl) => tmpl.debug_label(),
             ShaderTemplateRenderPass::MaterialPrep(tmpl) => tmpl.debug_label(),
+            ShaderTemplateRenderPass::ShadowBlur(tmpl) => tmpl.debug_label(),
             ShaderTemplateRenderPass::DecalClassify(tmpl) => tmpl.debug_label(),
             ShaderTemplateRenderPass::MaterialDecal(tmpl) => tmpl.debug_label(),
             ShaderTemplateRenderPass::MaterialOpaque(tmpl) => tmpl.debug_label(),

--- a/packages/crates/renderer/src/render_passes/shader_template.rs
+++ b/packages/crates/renderer/src/render_passes/shader_template.rs
@@ -93,9 +93,9 @@ impl TryFrom<&ShaderCacheKeyRenderPass> for ShaderTemplateRenderPass {
             ShaderCacheKeyRenderPass::MaterialPrep(cache_key) => Ok(
                 ShaderTemplateRenderPass::MaterialPrep(cache_key.try_into()?),
             ),
-            ShaderCacheKeyRenderPass::ShadowBlur(cache_key) => Ok(
-                ShaderTemplateRenderPass::ShadowBlur(cache_key.try_into()?),
-            ),
+            ShaderCacheKeyRenderPass::ShadowBlur(cache_key) => {
+                Ok(ShaderTemplateRenderPass::ShadowBlur(cache_key.try_into()?))
+            }
             ShaderCacheKeyRenderPass::DecalClassify(cache_key) => Ok(
                 ShaderTemplateRenderPass::DecalClassify(cache_key.try_into()?),
             ),

--- a/packages/crates/renderer/src/render_passes/shared/shared_wgsl/shadow/bind_groups.wgsl
+++ b/packages/crates/renderer/src/render_passes/shared/shared_wgsl/shadow/bind_groups.wgsl
@@ -176,6 +176,27 @@ fn vogel_tap(i: u32, rsqrt_n: f32, sin_p: f32, cos_p: f32) -> vec2<f32> {
 // Per-light Vogel tap budget (PCF / soft / final-PCSS), from the descriptor's
 // `extra_params.x`. Clamped to [VOGEL_MIN_TAPS, VOGEL_MAX_TAPS]; 0 (unset)
 // falls back to VOGEL_DEFAULT_TAPS so an un-plumbed descriptor still samples.
+//
+// PERF NOTE — `n` is a DYNAMIC loop bound below, which usually rings alarm
+// bells ("dynamic loop per texel = killer"). It isn't, here, for a specific
+// reason: `n` comes from the per-LIGHT descriptor, so it's UNIFORM across the
+// warp (every lane sampling a given light's shadow iterates the same count).
+// The killer case is a per-PIXEL-varying trip count → lane divergence (the old
+// `pcss_tap_count(ndc.z)` taper, since removed). A uniform dynamic bound has no
+// divergence; the only cost vs a compile-time constant is lost loop unrolling /
+// latency-hiding, which is small on these texture-fetch-bound loops (and may not
+// even differ — drivers often don't fully unroll a 32-tap textureSampleCompare
+// loop regardless). Unmeasured, deliberately: kept per-light because it's a
+// strict superset (set every light the same → it behaves as one global knob,
+// for free) at negligible cost.
+//
+// IF a profile ever shows this dynamic bound actually costing something: the
+// clean fast-path is shader specialization via the askama template + a cache-key
+// dimension — when Rust sees ALL active casters share a count N, key the
+// material_prep variant on `Some(N)` and emit `const` tap counts (→ unrolled);
+// key on `None` for the mixed case and fall back to exactly this dynamic path.
+// All-or-nothing per pass, recompiles when the shared N changes (debounce the
+// editor slider). Not built — premature without a measured delta.
 const VOGEL_MIN_TAPS: u32 = 8u;
 const VOGEL_DEFAULT_TAPS: u32 = 16u;
 fn shadow_tap_count(extra_x: f32) -> u32 {

--- a/packages/crates/renderer/src/render_passes/shared/shared_wgsl/shadow/bind_groups.wgsl
+++ b/packages/crates/renderer/src/render_passes/shared/shared_wgsl/shadow/bind_groups.wgsl
@@ -23,6 +23,11 @@ struct ShadowDescriptor {
     // and Gaussian blur landed alongside it. If a future tweak leaves
     // EVSM disabled the cascade falls back to PCF on `shadow_atlas`.
     cascade_info: vec4<f32>,
+    // (shadow_samples, pad, pad, pad) — per-light soft/PCSS Vogel tap budget
+    // (.x). Universal slot: kernel_slack overloads cascade_info.x and is only
+    // free on the cube path, so the tap count (read by every light kind) needs
+    // its own. Read via `shadow_tap_count(desc.extra_params.x)`.
+    extra_params: vec4<f32>,
 };
 
 struct ShadowGlobals {
@@ -65,27 +70,86 @@ const SHADOW_INDEX_NONE: u32 = 0xFFFFFFFFu;
 // (ABI — the pipeline layout always has the shadow group).
 {% if needs_shadow_sampling %}
 
-// 16 Poisson-distributed samples in `[-1, 1]^2`. Used by both the
-// PCSS blocker search and the variable-kernel PCF pass. The same
-// table doubled-up keeps the WGSL small; a per-pixel rotation breaks
-// up the regular pattern.
-const POISSON_DISK_16: array<vec2<f32>, 16> = array<vec2<f32>, 16>(
-    vec2<f32>(-0.94201624, -0.39906216),
-    vec2<f32>( 0.94558609, -0.76890725),
-    vec2<f32>(-0.09418410, -0.92938870),
-    vec2<f32>( 0.34495938,  0.29387760),
-    vec2<f32>(-0.91588581,  0.45771432),
-    vec2<f32>(-0.81544232, -0.87912464),
-    vec2<f32>(-0.38277543,  0.27676845),
-    vec2<f32>( 0.97484398,  0.75648379),
-    vec2<f32>( 0.44323325, -0.97511554),
-    vec2<f32>( 0.53742981, -0.47373420),
-    vec2<f32>(-0.26496911, -0.41893023),
-    vec2<f32>( 0.79197514,  0.19090188),
-    vec2<f32>(-0.24188840,  0.99706507),
-    vec2<f32>(-0.81409955,  0.91437590),
-    vec2<f32>( 0.19984126,  0.78641367),
-    vec2<f32>( 0.14383161, -0.14100790),
+// Baked Vogel (sunflower) disc — the single sampling pattern for ALL shadow
+// kinds (cube + cascade + spot; PCF, blocker search, and PCSS). Golden-angle
+// spiral: even coverage with no clumps at any count, so a per-pixel phase
+// rotation decorrelates neighbours WITHOUT exposing clumps as speckle (the
+// failure mode of rotating a fixed Poisson set over a wide kernel).
+//
+// VOGEL_BASE[i] = sqrt(i+0.5) * (cos(i*GA), sin(i*GA)). The runtime point for
+// an n-tap disc is `rotate(VOGEL_BASE[i], phase) * inversesqrt(n)`, which
+// equals `sqrt((i+0.5)/n)` at angle `i*GA + phase`. Splitting the radius this
+// way is the whole trick: the only n-dependent factor is `inversesqrt(n)`,
+// computed ONCE per pixel — so the tap count `n` is a free runtime parameter
+// (truncating to the first n entries × rsqrt(n) still fills the full unit disc)
+// AND there are ZERO transcendentals per tap (vs sqrt+sin+cos in the naive
+// formula). `n` may be any value up to VOGEL_MAX_TAPS.
+const VOGEL_MAX_TAPS: u32 = 64u;
+const VOGEL_BASE: array<vec2<f32>, 64> = array<vec2<f32>, 64>(
+    vec2<f32>(0.707107, 0.000000),
+    vec2<f32>(-0.903089, 0.827303),
+    vec2<f32>(0.138232, -1.575085),
+    vec2<f32>(1.138285, 1.484691),
+    vec2<f32>(-2.088893, -0.369496),
+    vec2<f32>(1.978782, -1.258739),
+    vec2<f32>(-0.661864, 2.462100),
+    vec2<f32>(-1.262246, -2.430378),
+    vec2<f32>(2.738569, 1.000121),
+    vec2<f32>(-2.849024, 1.176036),
+    vec2<f32>(1.373418, -2.934914),
+    vec2<f32>(1.014921, 3.235728),
+    vec2<f32>(-3.058984, -1.772744),
+    vec2<f32>(3.588536, -0.788930),
+    vec2<f32>(-2.190028, 3.115089),
+    vec2<f32>(-0.505947, -3.904359),
+    vec2<f32>(3.106019, 2.617756),
+    vec2<f32>(-4.179728, 0.172845),
+    vec2<f32>(3.048791, -3.033954),
+    vec2<f32>(-0.203976, 4.411167),
+    vec2<f32>(-2.900934, -3.476288),
+    vec2<f32>(4.595400, 0.618305),
+    vec2<f32>(-3.893673, 2.709116),
+    vec2<f32>(1.063975, -4.729477),
+    vec2<f32>(2.460920, 4.294633),
+    vec2<f32>(-4.810863, -1.534796),
+    vec2<f32>(4.673141, -2.159110),
+    vec2<f32>(-2.024521, 4.837490),
+    vec2<f32>(-1.806841, -5.023478),
+    vec2<f32>(4.807809, 2.526850),
+    vec2<f32>(-5.340266, 1.407677),
+    vec2<f32>(3.035444, -4.720813),
+    vec2<f32>(0.965593, 5.618508),
+    vec2<f32>(-4.576062, -3.543960),
+    vec2<f32>(5.853615, -0.484960),
+    vec2<f32>(-4.046082, 4.373696),
+    vec2<f32>(0.029472, -6.041451),
+    vec2<f32>(4.114440, 4.535569),
+    vec2<f32>(-6.178359, -0.572609),
+    vec2<f32>(5.006298, -3.799602),
+    vec2<f32>(-1.139045, 6.261196),
+    vec2<f32>(-3.431072, -5.452316),
+    vec2<f32>(6.287361, 1.723105),
+    vec2<f32>(-5.867884, 3.011301),
+    vec2<f32>(2.318893, -6.254817),
+    vec2<f32>(2.543292, 6.247533),
+    vec2<f32>(-6.162111, -2.920340),
+    vec2<f32>(6.586106, -2.030567),
+    vec2<f32>(-3.521252, 6.008393),
+    vec2<f32>(-1.477146, -6.878811),
+    vec2<f32>(5.793419, 4.115373),
+    vec2<f32>(-7.121259, 0.887509),
+    vec2<f32>(4.696434, -5.517563),
+    vec2<f32>(0.266559, 7.309511),
+    vec2<f32>(-5.181816, -5.258211),
+    vec2<f32>(7.440113, 0.380418),
+    vec2<f32>(-5.794585, 4.787775),
+    vec2<f32>(1.047803, -7.510134),
+    vec2<f32>(4.337639, 6.299594),
+    vec2<f32>(-7.517192, -1.729688),
+    vec2<f32>(6.767494, -3.834192),
+    vec2<f32>(-2.419935, 7.459485),
+    vec2<f32>(-3.280777, -7.192809),
+    vec2<f32>(7.335807, 3.112224),
 );
 
 // Inter-leaved Gradient Noise — Jorge Jimenez's hash, returns a
@@ -101,36 +165,34 @@ fn pcss_rotate(v: vec2<f32>, sin_a: f32, cos_a: f32) -> vec2<f32> {
     return vec2<f32>(v.x * cos_a - v.y * sin_a, v.x * sin_a + v.y * cos_a);
 }
 
-// Vogel (sunflower) disk: `n` points spread by the golden angle, each at
-// radius `sqrt((i+0.5)/n)`. Coverage is far more uniform than rotating a fixed
-// 16-point Poisson set — a rotated Poisson set keeps its clumps (it just spins
-// them), so a wide kernel undersamples into per-pixel speckle. The Vogel point
-// set has no clumps at any count, so the same per-pixel rotation (`phase`,
-// from the IGN hash) decorrelates neighbours WITHOUT exposing clumps as noise.
-// Scales to any `n` with no lookup table. Returns a point in the unit disk.
-fn vogel_disk(i: u32, n: u32, phase: f32) -> vec2<f32> {
-    let GOLDEN_ANGLE: f32 = 2.39996323; // π·(3−√5)
-    let r = sqrt((f32(i) + 0.5) / f32(n));
-    let theta = f32(i) * GOLDEN_ANGLE + phase;
-    return vec2<f32>(r * cos(theta), r * sin(theta));
+// The i-th tap of an n-tap Vogel disc, in the unit disk. Caller hoists the two
+// per-pixel scalars (`rsqrt_n = inversesqrt(f32(n))`, and `sin_p`/`cos_p` of
+// the IGN phase) out of the loop, so this is just a rotate + scale per tap — no
+// transcendentals. `i` must be < n <= VOGEL_MAX_TAPS.
+fn vogel_tap(i: u32, rsqrt_n: f32, sin_p: f32, cos_p: f32) -> vec2<f32> {
+    return pcss_rotate(VOGEL_BASE[i], sin_p, cos_p) * rsqrt_n;
 }
 
-// Cube soft/PCSS tap budgets. Raised from the original fixed 16 (and routed
-// through the clump-free Vogel disk above) because point-light penumbras here
-// reach a ~1 m world disc — 16 rotated-Poisson taps over that span read as the
-// "furry" speckle fringe. More taps + uniform coverage resolves the penumbra
-// smoothly. These are point-light-only; the 2D/cascade paths keep their own.
-//
-// COST: these are the per-shadowed-pixel cube `textureSampleCompare` budget and
-// are a HARD compile-time ceiling (they can't grow at runtime). The values are
-// the deliberate cost/quality knob — ~2x the old 16-tap budget. The cheaper
-// noise lever is the screen-space denoise blur (ShadowsConfig::denoise, on by
-// default), which smooths residual penumbra speckle once for ALL lights instead
-// of per-pixel-per-light here; raise the blur radius before raising these. They
-// stay this high so the denoise-OFF path is still acceptable on its own.
-const CUBE_SOFT_TAPS: u32 = 32u;
-const CUBE_BLOCKER_TAPS: u32 = 24u;
-const CUBE_PCSS_TAPS: u32 = 32u;
+// Per-light Vogel tap budget (PCF / soft / final-PCSS), from the descriptor's
+// `extra_params.x`. Clamped to [VOGEL_MIN_TAPS, VOGEL_MAX_TAPS]; 0 (unset)
+// falls back to VOGEL_DEFAULT_TAPS so an un-plumbed descriptor still samples.
+const VOGEL_MIN_TAPS: u32 = 8u;
+const VOGEL_DEFAULT_TAPS: u32 = 16u;
+fn shadow_tap_count(extra_x: f32) -> u32 {
+    let n = u32(extra_x + 0.5);
+    if n == 0u {
+        return VOGEL_DEFAULT_TAPS;
+    }
+    return clamp(n, VOGEL_MIN_TAPS, VOGEL_MAX_TAPS);
+}
+
+// Blocker-search budget: a fraction of the PCF budget (the search only
+// estimates an average blocker depth, so it needs fewer taps; the denoise
+// blur + the averaging smooth the residual width noise). Min 8.
+fn shadow_blocker_count(n: u32) -> u32 {
+    return max((n * 3u) / 4u, VOGEL_MIN_TAPS);
+}
+
 
 // Screen-space contact shadows (SSCS). Short ray-march in view space
 // from `world_pos` toward `light_dir` (the surface→light direction),
@@ -397,27 +459,36 @@ fn sample_shadow_cube(desc: ShadowDescriptor, world_pos: vec3<f32>, world_normal
     let tangent = normalize(cross(up_hint, world_normal));
     let bitangent = cross(world_normal, tangent);
 
-    // Per-pixel phase for the Vogel disk (IGN hash on world pos, so adjacent
-    // receivers sample rotated kernels and don't share a pattern).
+    // Per-pixel phase for the Vogel disc (IGN hash on world pos, so adjacent
+    // receivers sample rotated kernels and don't share a pattern). sin/cos
+    // hoisted once — `vogel_tap` only rotates + scales per tap.
     let angle = pcss_disk_angle(
         biased_pos.xz * 137.0 + vec2<f32>(biased_pos.y * 31.0, biased_pos.y * 17.0),
     );
+    let sin_p = sin(angle);
+    let cos_p = cos(angle);
 
     // Cube face resolution (square), for the per-texel kernel-slack term in
     // both branches below.
     let cube_face_res = f32(textureDimensions(shadow_cube_2d_array, 0).x);
 
+    // Per-light Vogel tap budget (descriptor extra_params.x). Soft/PCSS use `n`;
+    // the blocker search uses a smaller `n_blocker`.
+    let n = shadow_tap_count(desc.extra_params.x);
+    let n_blocker = shadow_blocker_count(n);
+
     if hardness < 1.5 {
-        // Soft — fixed-width Vogel disc, ~15 cm world radius. The tap count is
-        // `CUBE_SOFT_TAPS` (raised from 16); over a clump-free Vogel set this
+        // Soft — fixed-width Vogel disc, ~15 cm world radius, `n` taps (the
+        // per-light `shadow_samples` budget); over a clump-free Vogel set this
         // resolves the soft edge smoothly with no rotation speckle.
         // World-space disc radius. Base 0.15 m at `pcss_penumbra_scale == 1`;
         // the per-light knob (bias_params.w) is the user's softness control,
         // shared with PCSS so one slider governs both modes for point lights too.
         let SOFT_WORLD_RADIUS: f32 = 0.15 * max(desc.bias_params.w, 0.0);
+        let rsqrt_n = inverseSqrt(f32(n));
         var sum = 0.0;
-        for (var i = 0u; i < CUBE_SOFT_TAPS; i = i + 1u) {
-            let off = vogel_disk(i, CUBE_SOFT_TAPS, angle) * SOFT_WORLD_RADIUS;
+        for (var i = 0u; i < n; i = i + 1u) {
+            let off = vogel_tap(i, rsqrt_n, sin_p, cos_p) * SOFT_WORLD_RADIUS;
             let tap_pos = biased_pos + tangent * off.x + bitangent * off.y;
             let tap_to_light = tap_pos - light_pos;
             let tap_dist = length(tap_to_light);
@@ -446,7 +517,7 @@ fn sample_shadow_cube(desc: ShadowDescriptor, world_pos: vec3<f32>, world_normal
                 tap_ref,
             );
         }
-        return sum / f32(CUBE_SOFT_TAPS);
+        return sum / f32(n);
     }
 
     // PCSS — real blocker search + variable kernel.
@@ -476,14 +547,15 @@ fn sample_shadow_cube(desc: ShadowDescriptor, world_pos: vec3<f32>, world_normal
     let cube_dims = textureDimensions(shadow_cube_2d_array, 0);
     let cube_face_size = vec2<f32>(f32(cube_dims.x), f32(cube_dims.y));
 
-    // Vogel blocker search (`CUBE_BLOCKER_TAPS`). The averaged blocker depth
+    // Vogel blocker search (`n_blocker` taps). The averaged blocker depth
     // sets the penumbra WIDTH, so per-pixel variance here turns into a noisy
     // penumbra-radius field — a second noise source on top of the PCF below.
     // A clump-free Vogel set + more taps keeps the width estimate smooth.
     var blocker_sum = 0.0;
     var blocker_count = 0u;
-    for (var i = 0u; i < CUBE_BLOCKER_TAPS; i = i + 1u) {
-        let off = vogel_disk(i, CUBE_BLOCKER_TAPS, angle) * pcss_search_world_radius;
+    let blocker_rsqrt_n = inverseSqrt(f32(n_blocker));
+    for (var i = 0u; i < n_blocker; i = i + 1u) {
+        let off = vogel_tap(i, blocker_rsqrt_n, sin_p, cos_p) * pcss_search_world_radius;
         let tap_pos = biased_pos + tangent * off.x + bitangent * off.y;
         let tap_to_light = tap_pos - light_pos;
         let tap_dist = length(tap_to_light);
@@ -542,7 +614,7 @@ fn sample_shadow_cube(desc: ShadowDescriptor, world_pos: vec3<f32>, world_normal
     if blocker_count == 0u {
         return 1.0;
     }
-    if blocker_count == CUBE_BLOCKER_TAPS {
+    if blocker_count == n_blocker {
         return 0.0;
     }
     let avg_blocker = blocker_sum / f32(blocker_count);
@@ -567,8 +639,9 @@ fn sample_shadow_cube(desc: ShadowDescriptor, world_pos: vec3<f32>, world_normal
     );
 
     var sum = 0.0;
-    for (var i = 0u; i < CUBE_PCSS_TAPS; i = i + 1u) {
-        let off = vogel_disk(i, CUBE_PCSS_TAPS, angle) * penumbra_world_radius;
+    let pcss_rsqrt_n = inverseSqrt(f32(n));
+    for (var i = 0u; i < n; i = i + 1u) {
+        let off = vogel_tap(i, pcss_rsqrt_n, sin_p, cos_p) * penumbra_world_radius;
         let tap_pos = biased_pos + tangent * off.x + bitangent * off.y;
         let tap_to_light = tap_pos - light_pos;
         let tap_dist = length(tap_to_light);
@@ -596,7 +669,7 @@ fn sample_shadow_cube(desc: ShadowDescriptor, world_pos: vec3<f32>, world_normal
             tap_ref,
         );
     }
-    return sum / f32(CUBE_PCSS_TAPS);
+    return sum / f32(n);
 }
 
 
@@ -737,9 +810,11 @@ fn sample_shadow_cascade_array(
         );
         let sin_a = sin(angle);
         let cos_a = cos(angle);
+        let n = shadow_tap_count(desc.extra_params.x);
+        let rsqrt_n = inverseSqrt(f32(n));
         var sum = 0.0;
-        for (var i = 0u; i < 16u; i = i + 1u) {
-            let off = pcss_rotate(POISSON_DISK_16[i], sin_a, cos_a) * radius_texels;
+        for (var i = 0u; i < n; i = i + 1u) {
+            let off = vogel_tap(i, rsqrt_n, sin_a, cos_a) * radius_texels;
             sum += textureSampleCompareLevel(
                 shadow_cascade_array, shadow_atlas_sampler,
                 clamp(atlas_uv + off * inv_atlas, tile_min, tile_max),
@@ -747,7 +822,7 @@ fn sample_shadow_cascade_array(
                 ref_depth,
             );
         }
-        return sum / 16.0;
+        return sum / f32(n);
     }
     // PCSS — same recipe as the 2D path, with the cascade-array
     // texture and explicit `layer` arg.
@@ -763,6 +838,10 @@ fn sample_shadow_cascade_array(
     );
     let sin_a = sin(angle);
     let cos_a = cos(angle);
+    let n = shadow_tap_count(desc.extra_params.x);
+    let n_blocker = shadow_blocker_count(n);
+    let blocker_rsqrt_n = inverseSqrt(f32(n_blocker));
+    let pcf_rsqrt_n = inverseSqrt(f32(n));
     let search_radius_texels = clamp(
         pcss_light_world_radius / world_per_texel_pcss,
         4.0,
@@ -781,8 +860,8 @@ fn sample_shadow_cascade_array(
     var blocker_count = 0u;
     let tile_min_px = vec2<i32>(tile_min * atlas_uv_to_texels);
     let tile_max_px = vec2<i32>(tile_max * atlas_uv_to_texels);
-    for (var i = 0u; i < 16u; i = i + 1u) {
-        let off = pcss_rotate(POISSON_DISK_16[i], sin_a, cos_a) * search_radius_texels;
+    for (var i = 0u; i < n_blocker; i = i + 1u) {
+        let off = vogel_tap(i, blocker_rsqrt_n, sin_a, cos_a) * search_radius_texels;
         let sample_uv = atlas_uv + off * inv_atlas;
         let coord = vec2<i32>(sample_uv * atlas_uv_to_texels);
         let c = clamp(coord, tile_min_px, tile_max_px);
@@ -795,7 +874,7 @@ fn sample_shadow_cascade_array(
     if blocker_count == 0u {
         return 1.0;
     }
-    if blocker_count == 16u {
+    if blocker_count == n_blocker {
         return 0.0;
     }
     let avg_blocker = blocker_sum / f32(blocker_count);
@@ -812,8 +891,8 @@ fn sample_shadow_cascade_array(
     // peter-panning a near-contact (narrow-kernel) fragment would otherwise show.
     let pcss_ref = ref_depth - desc.bias_params.x * penumbra_texels * 0.5;
     var pcf_sum = 0.0;
-    for (var i = 0u; i < 16u; i = i + 1u) {
-        let off = pcss_rotate(POISSON_DISK_16[i], sin_a, cos_a) * penumbra_texels;
+    for (var i = 0u; i < n; i = i + 1u) {
+        let off = vogel_tap(i, pcf_rsqrt_n, sin_a, cos_a) * penumbra_texels;
         pcf_sum = pcf_sum + textureSampleCompareLevel(
             shadow_cascade_array,
             shadow_atlas_sampler,
@@ -822,7 +901,7 @@ fn sample_shadow_cascade_array(
             pcss_ref,
         );
     }
-    return pcf_sum / 16.0;
+    return pcf_sum / f32(n);
 }
 
 // Sample a single shadow descriptor (cascade / spot / face). Returns
@@ -943,20 +1022,22 @@ fn sample_shadow_descriptor(
         );
         let sin_a = sin(angle);
         let cos_a = cos(angle);
+        let n = shadow_tap_count(desc.extra_params.x);
+        let rsqrt_n = inverseSqrt(f32(n));
         // Fixed 16 taps on the Soft path — see `sample_shadow_cube`'s
         // Soft branch for the full rationale. Tapering here banded
         // large smooth receivers; the PCSS branch below still
         // tapers because its variable-kernel PCF absorbs the noise.
         var sum = 0.0;
-        for (var i = 0u; i < 16u; i = i + 1u) {
-            let off = pcss_rotate(POISSON_DISK_16[i], sin_a, cos_a) * radius_texels;
+        for (var i = 0u; i < n; i = i + 1u) {
+            let off = vogel_tap(i, rsqrt_n, sin_a, cos_a) * radius_texels;
             sum += textureSampleCompareLevel(
                 shadow_atlas, shadow_atlas_sampler,
                 clamp(atlas_uv + off * inv_atlas, tile_min, tile_max),
                 ref_depth,
             );
         }
-        return sum / 16.0;
+        return sum / f32(n);
     }
     // PCSS — blocker-search + variable-kernel PCF.
     //
@@ -988,6 +1069,10 @@ fn sample_shadow_descriptor(
     );
     let sin_a = sin(angle);
     let cos_a = cos(angle);
+    let n = shadow_tap_count(desc.extra_params.x);
+    let n_blocker = shadow_blocker_count(n);
+    let blocker_rsqrt_n = inverseSqrt(f32(n_blocker));
+    let pcf_rsqrt_n = inverseSqrt(f32(n));
     // Blocker-search radius: track the light disc directly so a wider
     // virtual light sees more potential blockers (correct PCSS
     // behaviour — small light = sharper shadow because fewer
@@ -1008,8 +1093,8 @@ fn sample_shadow_descriptor(
     var blocker_count = 0u;
     let tile_min_px = vec2<i32>(tile_min * atlas_uv_to_texels);
     let tile_max_px = vec2<i32>(tile_max * atlas_uv_to_texels);
-    for (var i = 0u; i < 16u; i = i + 1u) {
-        let off = pcss_rotate(POISSON_DISK_16[i], sin_a, cos_a) * search_radius_texels;
+    for (var i = 0u; i < n_blocker; i = i + 1u) {
+        let off = vogel_tap(i, blocker_rsqrt_n, sin_a, cos_a) * search_radius_texels;
         let sample_uv = atlas_uv + off * inv_atlas;
         let coord = vec2<i32>(sample_uv * atlas_uv_to_texels);
         // Clamp to the cascade's own tile so the blocker search
@@ -1024,7 +1109,7 @@ fn sample_shadow_descriptor(
     if blocker_count == 0u {
         return 1.0; // fully lit fast path
     }
-    if blocker_count == 16u {
+    if blocker_count == n_blocker {
         // Every blocker-search sample was below the receiver's
         // biased depth — the receiver is deep inside the umbra
         // and the second 16-tap PCF would average to ≈ 0
@@ -1052,8 +1137,8 @@ fn sample_shadow_descriptor(
     // radius, so it inherits the per-light tuning instead of a fresh constant.
     let pcss_ref = ref_depth - desc.bias_params.x * penumbra_texels * 0.5;
     var pcf_sum = 0.0;
-    for (var i = 0u; i < 16u; i = i + 1u) {
-        let off = pcss_rotate(POISSON_DISK_16[i], sin_a, cos_a) * penumbra_texels;
+    for (var i = 0u; i < n; i = i + 1u) {
+        let off = vogel_tap(i, pcf_rsqrt_n, sin_a, cos_a) * penumbra_texels;
         pcf_sum = pcf_sum + textureSampleCompareLevel(
             shadow_atlas,
             shadow_atlas_sampler,
@@ -1061,7 +1146,7 @@ fn sample_shadow_descriptor(
             pcss_ref,
         );
     }
-    return pcf_sum / 16.0;
+    return pcf_sum / f32(n);
 }
 
 // Per-light cascade selection with smooth blending across split

--- a/packages/crates/renderer/src/render_passes/shared/shared_wgsl/shadow/bind_groups.wgsl
+++ b/packages/crates/renderer/src/render_passes/shared/shared_wgsl/shadow/bind_groups.wgsl
@@ -101,6 +101,37 @@ fn pcss_rotate(v: vec2<f32>, sin_a: f32, cos_a: f32) -> vec2<f32> {
     return vec2<f32>(v.x * cos_a - v.y * sin_a, v.x * sin_a + v.y * cos_a);
 }
 
+// Vogel (sunflower) disk: `n` points spread by the golden angle, each at
+// radius `sqrt((i+0.5)/n)`. Coverage is far more uniform than rotating a fixed
+// 16-point Poisson set — a rotated Poisson set keeps its clumps (it just spins
+// them), so a wide kernel undersamples into per-pixel speckle. The Vogel point
+// set has no clumps at any count, so the same per-pixel rotation (`phase`,
+// from the IGN hash) decorrelates neighbours WITHOUT exposing clumps as noise.
+// Scales to any `n` with no lookup table. Returns a point in the unit disk.
+fn vogel_disk(i: u32, n: u32, phase: f32) -> vec2<f32> {
+    let GOLDEN_ANGLE: f32 = 2.39996323; // π·(3−√5)
+    let r = sqrt((f32(i) + 0.5) / f32(n));
+    let theta = f32(i) * GOLDEN_ANGLE + phase;
+    return vec2<f32>(r * cos(theta), r * sin(theta));
+}
+
+// Cube soft/PCSS tap budgets. Raised from the original fixed 16 (and routed
+// through the clump-free Vogel disk above) because point-light penumbras here
+// reach a ~1 m world disc — 16 rotated-Poisson taps over that span read as the
+// "furry" speckle fringe. More taps + uniform coverage resolves the penumbra
+// smoothly. These are point-light-only; the 2D/cascade paths keep their own.
+//
+// COST: these are the per-shadowed-pixel cube `textureSampleCompare` budget and
+// are a HARD compile-time ceiling (they can't grow at runtime). The values are
+// the deliberate cost/quality knob — ~2x the old 16-tap budget. The cheaper
+// noise lever is the screen-space denoise blur (ShadowsConfig::denoise, on by
+// default), which smooths residual penumbra speckle once for ALL lights instead
+// of per-pixel-per-light here; raise the blur radius before raising these. They
+// stay this high so the denoise-OFF path is still acceptable on its own.
+const CUBE_SOFT_TAPS: u32 = 32u;
+const CUBE_BLOCKER_TAPS: u32 = 24u;
+const CUBE_PCSS_TAPS: u32 = 32u;
+
 // Screen-space contact shadows (SSCS). Short ray-march in view space
 // from `world_pos` toward `light_dir` (the surface→light direction),
 // using the already-bound depth buffer (`depth_tex`). Returns `[0, 1]`
@@ -251,20 +282,38 @@ fn apply_sscs(world_pos: vec3<f32>, light_dir: vec3<f32>) -> f32 {
 // for cube face generation in `Shadows::write_gpu`.
 const POINT_SHADOW_NEAR: f32 = 0.05;
 
-// Kernel-width receiver-plane slack for the point-light soft/PCSS taps
-// is the per-light `kernel_slack` shadow param, delivered in the
+// Texel-quantization receiver-plane slack for the point-light soft/PCSS
+// taps is the per-light `kernel_slack` shadow param, delivered in the
 // otherwise-unused `cascade_info.x` descriptor slot (see
-// `shadows::state` cube packing). A wide disc on the receiver tangent
-// plane reaches taps whose light-direction lands in cube texels storing
-// the floor's own (quantized, slope-varying) back-face depth; the
-// constant per-tap `depth_bias` can't cover that growing mismatch, so
-// the 16-tap average dips below 1.0 in radial bands → the "acne rings"
-// on a flat floor under a point light. Mirrors the 2D/cascade fix
-// (`pcss_ref -= depth_bias * penumbra_texels * 0.5`): widen the
-// comparison bias with the kernel radius so wider penumbras get
-// proportional slack. Scaled below by the local NDC.z gradient so the
-// slack is in the same units as `ref_depth` at every distance/face.
-// Hard (kernel radius 0) gets zero extra bias and stays crisp.
+// `shadows::state` cube packing). A tap whose light-direction lands in a
+// cube texel storing the floor's own back-face depth self-shadows by the
+// depth quantization across that texel; the constant per-tap `depth_bias`
+// can't cover it, so the average dips below 1.0 in radial bands → the
+// "acne rings" on a flat floor under a point light.
+//
+// The slack widens the comparison bias by exactly that quantization gap:
+// `tap_grad × world_per_texel × kernel_slack`, where `world_per_texel =
+// 2·view_depth / cube_resolution` is the world footprint of ONE cube
+// texel at the tap's distance. `kernel_slack` therefore reads as "how
+// many texels of quantization to forgive" (default 2).
+//
+// CRITICAL: the slack scales with ONE TEXEL, not the kernel radius. The
+// earlier formula used the kernel *radius* (`SOFT_WORLD_RADIUS` /
+// `penumbra_world_radius`), so a ~1 m PCSS penumbra demanded ~100× the
+// slack a genuine receiver↔occluder gap provides, and the umbra leaked
+// to lit — worst directly under a floating occluder, where the gap is
+// smallest. One-texel scale fixes the quantization acne identically
+// (it IS a one-texel effect) while staying far too small to ever bridge
+// a real occluder gap, so the umbra can't leak. Hard (no kernel) gets
+// zero extra bias and stays crisp.
+//
+// The stored `kernel_slack` value (default 2) is reinterpreted by this
+// change: under the old kernel-radius formula the same number meant a
+// far larger world slack. No migration is provided — the kernel-radius
+// formula only ever shipped in the immediately-prior point-light commit,
+// so a project with a non-default value tuned against it is not expected
+// in practice, and the default reads correctly here. If an old project
+// shows faint acne rings, nudge its per-light `kernel_slack` up a texel.
 
 // Point-light cube shadow sample.
 //
@@ -348,30 +397,27 @@ fn sample_shadow_cube(desc: ShadowDescriptor, world_pos: vec3<f32>, world_normal
     let tangent = normalize(cross(up_hint, world_normal));
     let bitangent = cross(world_normal, tangent);
 
+    // Per-pixel phase for the Vogel disk (IGN hash on world pos, so adjacent
+    // receivers sample rotated kernels and don't share a pattern).
     let angle = pcss_disk_angle(
         biased_pos.xz * 137.0 + vec2<f32>(biased_pos.y * 31.0, biased_pos.y * 17.0),
     );
-    let sin_a = sin(angle);
-    let cos_a = cos(angle);
+
+    // Cube face resolution (square), for the per-texel kernel-slack term in
+    // both branches below.
+    let cube_face_res = f32(textureDimensions(shadow_cube_2d_array, 0).x);
 
     if hardness < 1.5 {
-        // Soft — fixed 16-tap rotated Poisson, ~15 cm world disc.
-        // Distance tapering applies ONLY to the PCSS branch below
-        // (where the variable-kernel PCF can absorb the noise floor
-        // a smaller sample count introduces). The Soft path is the
-        // user's "I want a clean smooth shadow, no contact hardening"
-        // setting; dropping its tap count introduces visible Poisson-
-        // rotation banding on large smooth receivers (the floor in
-        // the canonical "directional light + character on a plane"
-        // test). 16 fixed = visually clean; the tap-count knob exists
-        // for the PCSS branch's wide-kernel pass.
+        // Soft — fixed-width Vogel disc, ~15 cm world radius. The tap count is
+        // `CUBE_SOFT_TAPS` (raised from 16); over a clump-free Vogel set this
+        // resolves the soft edge smoothly with no rotation speckle.
         // World-space disc radius. Base 0.15 m at `pcss_penumbra_scale == 1`;
         // the per-light knob (bias_params.w) is the user's softness control,
         // shared with PCSS so one slider governs both modes for point lights too.
         let SOFT_WORLD_RADIUS: f32 = 0.15 * max(desc.bias_params.w, 0.0);
         var sum = 0.0;
-        for (var i = 0u; i < 16u; i = i + 1u) {
-            let off = pcss_rotate(POISSON_DISK_16[i], sin_a, cos_a) * SOFT_WORLD_RADIUS;
+        for (var i = 0u; i < CUBE_SOFT_TAPS; i = i + 1u) {
+            let off = vogel_disk(i, CUBE_SOFT_TAPS, angle) * SOFT_WORLD_RADIUS;
             let tap_pos = biased_pos + tangent * off.x + bitangent * off.y;
             let tap_to_light = tap_pos - light_pos;
             let tap_dist = length(tap_to_light);
@@ -383,11 +429,14 @@ fn sample_shadow_cube(desc: ShadowDescriptor, world_pos: vec3<f32>, world_normal
                 (range / (range - near)) * (1.0 - near / max(tap_view_depth, near));
             let tap_n_dot_dir = abs(dot(tap_dir, world_normal));
             let tap_bias = desc.bias_params.x / max(tap_n_dot_dir, 0.05);
-            // Kernel-width slack: depth a tap-radius displacement can span
-            // on this receiver, in NDC.z units (gradient × world radius).
+            // Per-texel quantization slack (NOT kernel-radius — see the block
+            // comment above the cube fn). `world_per_texel = 2·view_depth /
+            // res`; one texel of depth can't bridge a real occluder gap, so
+            // no umbra leak.
             let tap_grad = (range / (range - near)) * near
                 / max(tap_view_depth * tap_view_depth, near * near);
-            let tap_slack = tap_grad * SOFT_WORLD_RADIUS * desc.cascade_info.x;
+            let texel_world = 2.0 * tap_view_depth / cube_face_res;
+            let tap_slack = tap_grad * texel_world * desc.cascade_info.x;
             let tap_ref = clamp(tap_ndc_z, 0.0, 1.0) - tap_bias - tap_slack;
             sum += textureSampleCompareLevel(
                 shadow_cube_array,
@@ -397,7 +446,7 @@ fn sample_shadow_cube(desc: ShadowDescriptor, world_pos: vec3<f32>, world_normal
                 tap_ref,
             );
         }
-        return sum / 16.0;
+        return sum / f32(CUBE_SOFT_TAPS);
     }
 
     // PCSS — real blocker search + variable kernel.
@@ -427,18 +476,14 @@ fn sample_shadow_cube(desc: ShadowDescriptor, world_pos: vec3<f32>, world_normal
     let cube_dims = textureDimensions(shadow_cube_2d_array, 0);
     let cube_face_size = vec2<f32>(f32(cube_dims.x), f32(cube_dims.y));
 
-    // Fixed 16-tap blocker search. We previously tapered this by
-    // `dist / range` to save fragment cost on distant receivers,
-    // but the variable-kernel PCF below needs all 16 samples to
-    // resolve smoothly — undersampled wide penumbras showed
-    // visible Poisson-rotation banding (cube version less obvious
-    // than directional, but present). The unused helper
-    // `pcss_tap_count` is kept above for future re-introduction
-    // once a quality-preserving tap budget is worked out.
+    // Vogel blocker search (`CUBE_BLOCKER_TAPS`). The averaged blocker depth
+    // sets the penumbra WIDTH, so per-pixel variance here turns into a noisy
+    // penumbra-radius field — a second noise source on top of the PCF below.
+    // A clump-free Vogel set + more taps keeps the width estimate smooth.
     var blocker_sum = 0.0;
     var blocker_count = 0u;
-    for (var i = 0u; i < 16u; i = i + 1u) {
-        let off = pcss_rotate(POISSON_DISK_16[i], sin_a, cos_a) * pcss_search_world_radius;
+    for (var i = 0u; i < CUBE_BLOCKER_TAPS; i = i + 1u) {
+        let off = vogel_disk(i, CUBE_BLOCKER_TAPS, angle) * pcss_search_world_radius;
         let tap_pos = biased_pos + tangent * off.x + bitangent * off.y;
         let tap_to_light = tap_pos - light_pos;
         let tap_dist = length(tap_to_light);
@@ -497,7 +542,7 @@ fn sample_shadow_cube(desc: ShadowDescriptor, world_pos: vec3<f32>, world_normal
     if blocker_count == 0u {
         return 1.0;
     }
-    if blocker_count == 16u {
+    if blocker_count == CUBE_BLOCKER_TAPS {
         return 0.0;
     }
     let avg_blocker = blocker_sum / f32(blocker_count);
@@ -522,8 +567,8 @@ fn sample_shadow_cube(desc: ShadowDescriptor, world_pos: vec3<f32>, world_normal
     );
 
     var sum = 0.0;
-    for (var i = 0u; i < 16u; i = i + 1u) {
-        let off = pcss_rotate(POISSON_DISK_16[i], sin_a, cos_a) * penumbra_world_radius;
+    for (var i = 0u; i < CUBE_PCSS_TAPS; i = i + 1u) {
+        let off = vogel_disk(i, CUBE_PCSS_TAPS, angle) * penumbra_world_radius;
         let tap_pos = biased_pos + tangent * off.x + bitangent * off.y;
         let tap_to_light = tap_pos - light_pos;
         let tap_dist = length(tap_to_light);
@@ -535,11 +580,13 @@ fn sample_shadow_cube(desc: ShadowDescriptor, world_pos: vec3<f32>, world_normal
             (range / (range - near)) * (1.0 - near / max(tap_view_depth, near));
         let tap_n_dot_dir = abs(dot(tap_dir, world_normal));
         let tap_bias = desc.bias_params.x / max(tap_n_dot_dir, 0.05);
-        // Kernel-width slack (see soft path) — scaled by the PCSS
-        // penumbra radius so wide variable kernels don't self-shadow.
+        // Per-texel quantization slack (see soft path + the block comment
+        // above the cube fn): ONE-texel footprint, independent of the (up to
+        // ~1 m) penumbra radius, so a wide kernel no longer leaks the umbra.
         let tap_grad = (range / (range - near)) * near
             / max(tap_view_depth * tap_view_depth, near * near);
-        let tap_slack = tap_grad * penumbra_world_radius * desc.cascade_info.x;
+        let texel_world = 2.0 * tap_view_depth / cube_face_res;
+        let tap_slack = tap_grad * texel_world * desc.cascade_info.x;
         let tap_ref = clamp(tap_ndc_z, 0.0, 1.0) - tap_bias - tap_slack;
         sum += textureSampleCompareLevel(
             shadow_cube_array,
@@ -549,7 +596,7 @@ fn sample_shadow_cube(desc: ShadowDescriptor, world_pos: vec3<f32>, world_normal
             tap_ref,
         );
     }
-    return sum / 16.0;
+    return sum / f32(CUBE_PCSS_TAPS);
 }
 
 

--- a/packages/crates/renderer/src/render_textures.rs
+++ b/packages/crates/renderer/src/render_textures.rs
@@ -327,6 +327,9 @@ pub struct RenderTextureViews {
     pub prep_vcolor: Option<web_sys::GpuTextureView>,
     /// Plan B Stage 3: per-pixel shadow-visibility view (Rgba8unorm array).
     pub prep_shadow_visibility: Option<web_sys::GpuTextureView>,
+    /// Ping-pong temp for the optional separable shadow-denoise blur (same
+    /// descriptor as `prep_shadow_visibility`). H writes here, V writes back.
+    pub prep_shadow_visibility_blur_tmp: Option<web_sys::GpuTextureView>,
     /// U0: per-pixel edge-id view (R32Uint). `None` when MSAA is off.
     /// Written by classify (storage texture); read by nobody in U0.
     pub edge_id: Option<web_sys::GpuTextureView>,
@@ -396,6 +399,9 @@ impl RenderTextureViews {
             prep_uv: inner.prep_uv_view.clone(),
             prep_vcolor: inner.prep_vcolor_view.clone(),
             prep_shadow_visibility: inner.prep_shadow_visibility_view.clone(),
+            prep_shadow_visibility_blur_tmp: inner
+                .prep_shadow_visibility_blur_tmp_view
+                .clone(),
             edge_id: inner.edge_id_view.clone(),
             depth: inner.depth_view.clone(),
             hud_depth: inner.hud_depth_view.clone(),
@@ -470,6 +476,10 @@ pub struct RenderTexturesInner {
     /// slots/texel). Always allocated (prep is unconditional).
     pub prep_shadow_visibility: Option<web_sys::GpuTexture>,
     pub prep_shadow_visibility_view: Option<web_sys::GpuTextureView>,
+    /// Ping-pong temp for the optional separable shadow-denoise blur (same
+    /// descriptor as `prep_shadow_visibility`).
+    pub prep_shadow_visibility_blur_tmp: Option<web_sys::GpuTexture>,
+    pub prep_shadow_visibility_blur_tmp_view: Option<web_sys::GpuTextureView>,
 
     /// U0 (`docs/plans/unified-edge-shading.md`): per-pixel edge-id texture
     /// (R32Uint, one word/pixel). Classify writes the compact edge_pixel_id /
@@ -928,6 +938,46 @@ impl RenderTexturesInner {
             ),
             None => None,
         };
+        // Ping-pong temp for the optional separable shadow-denoise blur. Same
+        // descriptor as `prep_shadow_visibility` (storage write + sampled read).
+        // DELIBERATELY always allocated (it shares prep_shadow_visibility's exact
+        // lifecycle: resize/AA rebuild only). Denoise defaults ON, so the temp is
+        // needed in the common case; making it conditional would couple the cheap
+        // live `denoise` toggle to a full render-texture rebuild for no benefit
+        // when on. Standing cost when denoise is OFF: 4 bytes/px × ceil(K/4)
+        // layers (~8 MB @1080p K≤4, ~133 MB @4K K=16) — revisit only if a
+        // high-K, denoise-off configuration proves common.
+        let prep_shadow_visibility_blur_tmp = Some(
+            gpu.create_texture(
+                &TextureDescriptor::new(
+                    TextureFormat::Rgba8unorm,
+                    Extent3d::new(width, Some(height), Some(prep_shadow_layers.max(1))),
+                    TextureUsage::new()
+                        .with_storage_binding()
+                        .with_texture_binding(),
+                )
+                .with_label("PrepShadowVisibilityBlurTmp")
+                .into(),
+            )
+            .map_err(AwsmRenderTextureError::CreateTexture)?,
+        );
+        let prep_shadow_visibility_blur_tmp_view =
+            match prep_shadow_visibility_blur_tmp.as_ref() {
+                Some(tex) => Some(
+                    tex.create_view_with_descriptor(
+                        &TextureViewDescriptor::new(Some("PrepShadowVisibilityBlurTmp"))
+                            .with_dimension(TextureViewDimension::N2dArray)
+                            .with_array_layer_count(prep_shadow_layers.max(1))
+                            .into(),
+                    )
+                    .map_err(|e| {
+                        AwsmRenderTextureError::CreateTextureView(format!(
+                            "prep_shadow_visibility_blur_tmp: {e:?}"
+                        ))
+                    })?,
+                ),
+                None => None,
+            };
 
         // U0 (`docs/plans/unified-edge-shading.md`): per-pixel edge-id texture
         // — R32Uint, one word/pixel, NEVER multisampled (one value per pixel,
@@ -1049,6 +1099,8 @@ impl RenderTexturesInner {
             prep_vcolor_view,
             prep_shadow_visibility,
             prep_shadow_visibility_view,
+            prep_shadow_visibility_blur_tmp,
+            prep_shadow_visibility_blur_tmp_view,
 
             edge_id,
             edge_id_view,
@@ -1097,6 +1149,9 @@ impl RenderTexturesInner {
             tex.destroy();
         }
         if let Some(tex) = self.prep_shadow_visibility {
+            tex.destroy();
+        }
+        if let Some(tex) = self.prep_shadow_visibility_blur_tmp {
             tex.destroy();
         }
         if let Some(tex) = self.edge_id {

--- a/packages/crates/renderer/src/render_textures.rs
+++ b/packages/crates/renderer/src/render_textures.rs
@@ -399,9 +399,7 @@ impl RenderTextureViews {
             prep_uv: inner.prep_uv_view.clone(),
             prep_vcolor: inner.prep_vcolor_view.clone(),
             prep_shadow_visibility: inner.prep_shadow_visibility_view.clone(),
-            prep_shadow_visibility_blur_tmp: inner
-                .prep_shadow_visibility_blur_tmp_view
-                .clone(),
+            prep_shadow_visibility_blur_tmp: inner.prep_shadow_visibility_blur_tmp_view.clone(),
             edge_id: inner.edge_id_view.clone(),
             depth: inner.depth_view.clone(),
             hud_depth: inner.hud_depth_view.clone(),
@@ -961,23 +959,22 @@ impl RenderTexturesInner {
             )
             .map_err(AwsmRenderTextureError::CreateTexture)?,
         );
-        let prep_shadow_visibility_blur_tmp_view =
-            match prep_shadow_visibility_blur_tmp.as_ref() {
-                Some(tex) => Some(
-                    tex.create_view_with_descriptor(
-                        &TextureViewDescriptor::new(Some("PrepShadowVisibilityBlurTmp"))
-                            .with_dimension(TextureViewDimension::N2dArray)
-                            .with_array_layer_count(prep_shadow_layers.max(1))
-                            .into(),
-                    )
-                    .map_err(|e| {
-                        AwsmRenderTextureError::CreateTextureView(format!(
-                            "prep_shadow_visibility_blur_tmp: {e:?}"
-                        ))
-                    })?,
-                ),
-                None => None,
-            };
+        let prep_shadow_visibility_blur_tmp_view = match prep_shadow_visibility_blur_tmp.as_ref() {
+            Some(tex) => Some(
+                tex.create_view_with_descriptor(
+                    &TextureViewDescriptor::new(Some("PrepShadowVisibilityBlurTmp"))
+                        .with_dimension(TextureViewDimension::N2dArray)
+                        .with_array_layer_count(prep_shadow_layers.max(1))
+                        .into(),
+                )
+                .map_err(|e| {
+                    AwsmRenderTextureError::CreateTextureView(format!(
+                        "prep_shadow_visibility_blur_tmp: {e:?}"
+                    ))
+                })?,
+            ),
+            None => None,
+        };
 
         // U0 (`docs/plans/unified-edge-shading.md`): per-pixel edge-id texture
         // — R32Uint, one word/pixel, NEVER multisampled (one value per pixel,

--- a/packages/crates/renderer/src/shadows/config.rs
+++ b/packages/crates/renderer/src/shadows/config.rs
@@ -57,6 +57,14 @@ pub struct ShadowsConfig {
     /// Tints each directional cascade range so the splits are visible
     /// in the editor. Drives a debug bitmask flag in the opaque pass.
     pub debug_cascade_colors: bool,
+    /// Optional edge-aware denoise blur on the packed per-pixel
+    /// shadow-visibility buffer (`prep_shadow_visibility`). A single
+    /// separable, depth-stopped screen-space pass that smooths the
+    /// residual soft/PCSS penumbra speckle for ALL shadowed lights at
+    /// once (cost is independent of light count). Skipped entirely when
+    /// `false`. Does not cover MSAA silhouette-edge samples (those read a
+    /// separate compact buffer).
+    pub denoise: bool,
 }
 
 impl Default for ShadowsConfig {
@@ -82,6 +90,10 @@ impl Default for ShadowsConfig {
             max_point_shadows: 8,
             point_shadow_resolution: 1024,
             debug_cascade_colors: false,
+            // On by default: it fixes the residual point-light penumbra
+            // speckle out of the box and is cheap (one separable pass,
+            // light-count-independent). Toggleable off in the editor.
+            denoise: true,
         }
     }
 }

--- a/packages/crates/renderer/src/shadows/consts.rs
+++ b/packages/crates/renderer/src/shadows/consts.rs
@@ -22,7 +22,8 @@ pub const MAX_SHADOW_VIEWS: u32 = 96;
 /// - `atlas_rect: vec4<f32>` (16 B)
 /// - `bias_params: vec4<f32>` (16 B)
 /// - `cascade_info: vec4<f32>` (16 B)
-pub const SHADOW_DESCRIPTOR_BYTES: usize = 112;
+/// - `extra_params: vec4<f32>` (16 B) — `(shadow_samples, _, _, _)`
+pub const SHADOW_DESCRIPTOR_BYTES: usize = 128;
 
 /// Size in bytes of the `ShadowGlobals` uniform block. Layout:
 /// - `atlas_sizes: vec4<f32>` (16 B) — `(pcf.w, pcf.h, evsm.w, evsm.h)`

--- a/packages/crates/renderer/src/shadows/helpers.rs
+++ b/packages/crates/renderer/src/shadows/helpers.rs
@@ -65,6 +65,7 @@ pub(super) fn write_shadow_descriptor(
     cascade_y_param: f32,
     cascade_count: u32,
     split_far: f32,
+    shadow_samples: u32,
 ) {
     debug_assert!(dest.len() >= SHADOW_DESCRIPTOR_BYTES);
     let cols = view_projection.to_cols_array();
@@ -101,6 +102,11 @@ pub(super) fn write_shadow_descriptor(
     dest[100..104].copy_from_slice(&cascade_y_param.to_ne_bytes());
     dest[104..108].copy_from_slice(&(cascade_count as f32).to_ne_bytes());
     dest[108..112].copy_from_slice(&0.0_f32.to_ne_bytes());
+    // extra_params: (shadow_samples, pad, pad, pad).
+    dest[112..116].copy_from_slice(&(shadow_samples as f32).to_ne_bytes());
+    dest[116..120].copy_from_slice(&0.0_f32.to_ne_bytes());
+    dest[120..124].copy_from_slice(&0.0_f32.to_ne_bytes());
+    dest[124..128].copy_from_slice(&0.0_f32.to_ne_bytes());
 }
 
 /// Writes a directional-cascade descriptor (kind = 3) whose depth
@@ -125,6 +131,7 @@ pub(super) fn write_shadow_cascade_array_descriptor(
     world_per_texel: f32,
     cascade_count: u32,
     split_far: f32,
+    shadow_samples: u32,
 ) {
     debug_assert!(dest.len() >= SHADOW_DESCRIPTOR_BYTES);
     let cols = view_projection.to_cols_array();
@@ -161,6 +168,11 @@ pub(super) fn write_shadow_cascade_array_descriptor(
     dest[104..108].copy_from_slice(&(cascade_count as f32).to_ne_bytes());
     // cascade_info.w = 3.0 → cascade-array PCF.
     dest[108..112].copy_from_slice(&3.0_f32.to_ne_bytes());
+    // extra_params: (shadow_samples, pad, pad, pad).
+    dest[112..116].copy_from_slice(&(shadow_samples as f32).to_ne_bytes());
+    dest[116..120].copy_from_slice(&0.0_f32.to_ne_bytes());
+    dest[120..124].copy_from_slice(&0.0_f32.to_ne_bytes());
+    dest[124..128].copy_from_slice(&0.0_f32.to_ne_bytes());
 }
 
 pub(super) fn build_evsm_moment_write_bind_group(

--- a/packages/crates/renderer/src/shadows/light_shadow.rs
+++ b/packages/crates/renderer/src/shadows/light_shadow.rs
@@ -38,6 +38,13 @@ pub struct LightShadowParams {
     /// (otherwise-unused) `cascade_info.x` descriptor slot. `0.0` = off,
     /// `2.0` = neutral default; larger trades acne for contact leak.
     pub kernel_slack: f32,
+    /// Soft/PCSS Vogel tap budget for this light — the per-shadowed-pixel
+    /// `textureSampleCompare` cost knob, applied to ALL light kinds (the PCSS
+    /// blocker search uses ¾ of it). Higher = smoother penumbra, more cost;
+    /// reserve high counts for hero lights. Clamped to `[8, 64]` by the shader;
+    /// the screen-space denoise blur is the cheaper global noise lever, so a
+    /// modest count here usually suffices. `Hard` ignores it (1 tap).
+    pub shadow_samples: u32,
     /// Camera-distance fadeout cutoff for this light's shadow.
     /// Camera-distance cutoff for the cascade span. `<= 0` = AUTO
     /// (follow the camera far plane) — the scale-safe default; a
@@ -75,6 +82,7 @@ impl Default for LightShadowParams {
             hardness: LightShadowHardness::Soft,
             pcss_penumbra_scale: 1.0,
             kernel_slack: 2.0,
+            shadow_samples: 16,
             max_distance: 0.0,
             cascade_count: 4,
             cascade_split_lambda: 0.5,

--- a/packages/crates/renderer/src/shadows/schema_convert.rs
+++ b/packages/crates/renderer/src/shadows/schema_convert.rs
@@ -45,9 +45,10 @@ impl From<schema::ShadowsConfig> for ShadowsConfig {
             max_point_shadows: s.max_point_shadows,
             point_shadow_resolution: s.point_shadow_resolution,
             debug_cascade_colors: s.debug_cascade_colors,
-            // Cascade-array fields aren't authored in the on-disk
-            // schema yet — fall back to defaults. Once the editor
-            // exposes them they can be threaded through here.
+            // `denoise` is not in the on-disk schema (it's a runtime/editor
+            // quality knob); it falls back to the renderer default (on) here.
+            // Cascade-array fields likewise aren't authored yet — fall back to
+            // defaults. Once the editor exposes them, thread them through here.
             ..ShadowsConfig::default()
         }
     }

--- a/packages/crates/renderer/src/shadows/schema_convert.rs
+++ b/packages/crates/renderer/src/shadows/schema_convert.rs
@@ -64,6 +64,7 @@ impl From<schema::LightShadowConfig> for LightShadowParams {
             hardness: s.hardness.into(),
             pcss_penumbra_scale: s.pcss_penumbra_scale,
             kernel_slack: s.kernel_slack,
+            shadow_samples: s.shadow_samples,
             max_distance: s.max_distance,
             cascade_count: s.cascade_count,
             cascade_split_lambda: s.cascade_split_lambda,

--- a/packages/crates/renderer/src/shadows/state.rs
+++ b/packages/crates/renderer/src/shadows/state.rs
@@ -1980,6 +1980,7 @@ impl Shadows {
                                 cascade.world_per_texel,
                                 cascade_count,
                                 *split_far,
+                                params.shadow_samples,
                             );
                             // cascade_info.w = 1.0 → EVSM 2D sample.
                             descriptor_bytes[off + 108..off + 112]
@@ -2033,6 +2034,7 @@ impl Shadows {
                                 cascade.world_per_texel,
                                 cascade_count,
                                 *split_far,
+                                params.shadow_samples,
                             );
                         }
 
@@ -2200,6 +2202,7 @@ impl Shadows {
                         // `split_far` to +infinity-ish makes the shader's
                         // walk pick this descriptor unconditionally.
                         f32::MAX,
+                        params.shadow_samples,
                     );
 
                     let view_slot = alloc.view_base;
@@ -2387,6 +2390,7 @@ impl Shadows {
                         0.0,
                         1,
                         f32::MAX,
+                        params.shadow_samples,
                     );
                     // Patch in the cube-specific atlas_rect (light_pos +
                     // range) and the "kind = cube + slice index" in

--- a/packages/crates/scene-loader/src/light.rs
+++ b/packages/crates/scene-loader/src/light.rs
@@ -68,6 +68,7 @@ pub fn light_shadow_params_from_config(
         },
         pcss_penumbra_scale: cfg.pcss_penumbra_scale,
         kernel_slack: cfg.kernel_slack,
+        shadow_samples: cfg.shadow_samples,
         max_distance: cfg.max_distance,
         cascade_count: cfg.cascade_count,
         cascade_split_lambda: cfg.cascade_split_lambda,

--- a/packages/crates/scene/src/light.rs
+++ b/packages/crates/scene/src/light.rs
@@ -61,12 +61,15 @@ pub struct LightShadowConfig {
     #[serde(default = "default_pcss_scale")]
     pub pcss_penumbra_scale: f32,
     /// Point-light only. Receiver-plane slack added to the soft/PCSS
-    /// comparison bias, scaled by the kernel radius — counteracts the
-    /// self-shadow "acne rings" a wide disc produces on a flat floor
-    /// under a point light (the cube faces store slope-varying
-    /// back-face depth that a constant `depth_bias` can't cover as the
-    /// kernel widens). 0 = off (acne returns at large softness); larger
-    /// = more slack (eventually light-leak / peter-panning at contacts).
+    /// comparison bias, in units of ONE cube-shadow texel's depth footprint
+    /// (`tap_grad * world_per_texel`) — i.e. "how many texels of self-shadow
+    /// quantization to forgive". Counteracts the "acne rings" a soft/PCSS disc
+    /// produces on a flat floor under a point light (the cube faces store
+    /// slope-varying back-face depth a constant `depth_bias` can't cover).
+    /// Scaled per-texel, NOT by the kernel radius, so a wide PCSS penumbra
+    /// can't balloon the slack past a real occluder gap and leak the umbra.
+    /// 0 = off (acne returns at large softness); ~2 = default; larger only
+    /// risks minor peter-panning right at contacts.
     #[serde(default = "default_kernel_slack")]
     pub kernel_slack: f32,
     /// Beyond this distance from the camera the shadow fades and the

--- a/packages/crates/scene/src/light.rs
+++ b/packages/crates/scene/src/light.rs
@@ -72,6 +72,12 @@ pub struct LightShadowConfig {
     /// risks minor peter-panning right at contacts.
     #[serde(default = "default_kernel_slack")]
     pub kernel_slack: f32,
+    /// Soft/PCSS Vogel tap budget — the per-shadowed-pixel sample cost for this
+    /// light, all kinds (the PCSS blocker search uses ¾ of it). Higher =
+    /// smoother penumbra, more cost; reserve high counts for hero lights.
+    /// Clamped to `[8, 64]` by the renderer. `Hard` ignores it.
+    #[serde(default = "default_shadow_samples")]
+    pub shadow_samples: u32,
     /// Beyond this distance from the camera the shadow fades and the
     /// light skips its shadow pass that frame.
     #[serde(default = "default_max_distance")]
@@ -105,6 +111,7 @@ impl Default for LightShadowConfig {
             hardness: LightShadowHardness::Soft,
             pcss_penumbra_scale: 1.0,
             kernel_slack: 2.0,
+            shadow_samples: default_shadow_samples(),
             max_distance: 0.0,
             cascade_count: 4,
             cascade_split_lambda: 0.5,
@@ -199,6 +206,9 @@ fn default_pcss_scale() -> f32 {
 }
 fn default_kernel_slack() -> f32 {
     2.0
+}
+fn default_shadow_samples() -> u32 {
+    16
 }
 fn default_max_distance() -> f32 {
     // <= 0 = AUTO (follow the camera far plane) — scale-safe; see the

--- a/packages/crates/scene/src/shadows.rs
+++ b/packages/crates/scene/src/shadows.rs
@@ -59,6 +59,12 @@ pub struct ShadowsConfig {
     /// visible during authoring.
     #[serde(default)]
     pub debug_cascade_colors: bool,
+    // NOTE: the shadow-denoise blur is intentionally NOT persisted here.
+    // It's a renderer-runtime quality knob (`renderer::ShadowsConfig::denoise`,
+    // default on) toggled live in the editor's Settings drawer, exactly like
+    // MSAA — none of the renderer-wide shadow config is wired scene→renderer in
+    // the editor yet. If/when that subsystem lands, add `denoise` back alongside
+    // its siblings with real round-tripping rather than as a dangling field.
 }
 
 impl Default for ShadowsConfig {

--- a/packages/frontend/editor/src/app.rs
+++ b/packages/frontend/editor/src/app.rs
@@ -507,6 +507,7 @@ fn settings_drawer() -> Dom {
                 .child(row("Light gizmos", toggle(s.light_gizmos.clone())))
                 .child(row("Skeleton overlay", toggle(s.skeleton_viz.clone())))
                 .child(row("MSAA", toggle(s.msaa.clone())))
+                .child(row("Shadow denoise", toggle(s.shadow_denoise.clone())))
                 .child(row("Light heatmap", toggle(s.heatmap.clone())))
                 .child(row(
                     "Follow agent activity",

--- a/packages/frontend/editor/src/controller/state.rs
+++ b/packages/frontend/editor/src/controller/state.rs
@@ -182,6 +182,9 @@ pub struct Settings {
     pub auto_key: Mutable<bool>,
     pub msaa: Mutable<bool>,
     pub heatmap: Mutable<bool>,
+    /// Edge-aware shadow denoise blur (global). Drives the renderer's
+    /// `ShadowsConfig::denoise` via `settings_sync`.
+    pub shadow_denoise: Mutable<bool>,
     pub snap: Mutable<bool>,
     pub units: Mutable<String>,
     /// Built-in editor view camera projection: `true` = orthographic, `false` =
@@ -200,6 +203,9 @@ impl Default for Settings {
             auto_key: Mutable::new(true),
             msaa: Mutable::new(true),
             heatmap: Mutable::new(false),
+            // On by default — matches the renderer's `ShadowsConfig::denoise`
+            // default; keeps point-light soft/PCSS penumbras clean out of box.
+            shadow_denoise: Mutable::new(true),
             snap: Mutable::new(false),
             units: Mutable::new("meters".to_string()),
             editor_ortho: Mutable::new(false),

--- a/packages/frontend/editor/src/engine/settings_sync.rs
+++ b/packages/frontend/editor/src/engine/settings_sync.rs
@@ -29,6 +29,33 @@ pub fn start() {
             .await;
     });
 
+    // Shadow denoise blur (cheap, synchronous — no pipeline recompile, just a
+    // per-frame dispatch gate in ShadowsConfig).
+    spawn_local(async {
+        let mut first = true;
+        controller()
+            .settings
+            .shadow_denoise
+            .signal()
+            .for_each(move |on| {
+                let skip = first;
+                first = false;
+                async move {
+                    if !skip {
+                        with_renderer_mut(move |r| {
+                            let mut cfg = r.shadows_config().clone();
+                            if cfg.denoise != on {
+                                cfg.denoise = on;
+                                r.set_shadows_config(cfg);
+                            }
+                        })
+                        .await;
+                    }
+                }
+            })
+            .await;
+    });
+
     // MSAA on/off — recompiles the affected pipelines, so it's async + guarded
     // against redundant re-applies.
     spawn_local(async {

--- a/packages/frontend/editor/src/scene_mode/inspector.rs
+++ b/packages/frontend/editor/src/scene_mode/inspector.rs
@@ -3605,6 +3605,20 @@ fn light_shadow_editor(node: &Arc<Node>, cfg: &LightConfig) -> Dom {
             .render(),
     ));
 
+    // Soft/PCSS Vogel tap budget — per-shadowed-pixel sample cost. Higher =
+    // smoother penumbra, more cost; reserve high counts for hero lights. No
+    // effect in Hard mode. Clamped to [8, 64].
+    let n = node.clone();
+    sec = sec.child(row(
+        "Samples",
+        NumField::new(shadow.shadow_samples as f64)
+            .min(8.0)
+            .max(64.0)
+            .step(4.0)
+            .on_change(move |v| update_shadow(&n, |s| s.shadow_samples = (v as u32).clamp(8, 64)))
+            .render(),
+    ));
+
     let n = node.clone();
     sec = sec.child(row(
         "Resolution",


### PR DESCRIPTION
Cleans up point-light soft/PCSS shadow quality and makes the sample-site cost configurable. Stacked, each commit independently reviewable.

## What & why

**1. Edge-aware denoise blur (optional, default on).** Point-light soft/PCSS penumbras showed a "furry" speckle fringe (penumbra undersampling, no temporal accumulation to resolve it). New separable, depth-edge-stopped screen-space pass over the packed `prep_shadow_visibility` buffer — smooths residual penumbra speckle for **all** shadowed lights at once, cost independent of light count. Editor: **Settings → Shadow denoise**, wired live like MSAA (a renderer-runtime quality knob; not persisted in the scene schema since the renderer-wide shadow config isn't wired scene→renderer in the editor yet).

**2. `kernel_slack` hardening.** The prior kernel-slack fix scaled the receiver-plane slack by the (up to ~1 m) PCSS kernel radius, which could bridge a real occluder gap and leak a lit hole into the umbra. Now scaled by **one cube texel's** world footprint — kills the self-shadow "acne rings" identically while staying far too small to leak.

**3. Unified baked Vogel disc (Poisson removed).** Cube + cascade + spot now sample one shared golden-angle disc. It's **baked**: `VOGEL_BASE[i] = sqrt(i+0.5)·(cos,sin)(i·GA)`, and a tap is `rotate(VOGEL_BASE[i], phase) · rsqrt(n)`. Splitting the radius that way means the only `n`-dependent factor (`rsqrt(n)`) hoists per-pixel, giving **zero transcendentals per tap** (the naive form did sqrt+sin+cos every tap) *and* making the tap count a free runtime parameter.

**4. Per-light `shadow_samples` (default 16, `[8,64]`).** The tap-count cost lever, all light kinds (PCSS blocker search uses ¾). Delivered via a new `extra_params: vec4` on `ShadowDescriptor` (112→128 B) — `kernel_slack` already squats on the only cube-free slot, so the universal count needed its own. Wired schema → renderer → descriptor → shader, plus a **"Samples" inspector knob**.

## Net effect
Point lights default to **16 PCF taps instead of 32** (≈half the cube-shadow cost) with denoise keeping quality; directional/spot stay at 16; everything is now tunable per-light (raise for hero lights). The per-light dynamic loop bound is warp-uniform (not the per-pixel-divergent "dynamic loop = killer" case), so the only cost vs a compile-time constant is small/unmeasured lost unrolling — documented in-shader, with an askama+cache-key specialization fast-path noted as the escape hatch if a profile ever justifies it.

## Hardening (from a workflow-backed code review)
- Blur dispatch gated on `shadows.any_active()` (skips both full-screen passes in no-caster scenes)
- Blur view-z reconstructed with 2 dot products (inv_proj rows 2/3), per-tap depth weights reused across packed layers
- Removed a dangling persisted `scene.shadows.denoise` field; documented the always-resident blur temp tradeoff

## Verification
Browser-verified across **point (PCSS), directional (Soft+PCSS), spot (Soft+PCSS)** — clean after the Poisson→Vogel swap, no new artifacts. Denoise on vs off confirmed (smooth vs grain). Per-light count confirmed live: samples 8 → speckled, 48 → smooth (denoise off); default 16 + denoise clean; descriptor byte-layout renders correctly. `cargo fmt` + `task lint` clean.

## Docs
`docs/SHADOWS.md` updated throughout (config tables, new denoise section, troubleshooting, perf notes, known limits, `kernel_slack`/`shadow_samples` semantics, impl-notes map).

🤖 Generated with [Claude Code](https://claude.com/claude-code)