### PR TITLE
shadows: fix contact-shadow holes under lowered meshes (point + spot + directional)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,7 +187,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "askama",
@@ -214,7 +214,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-core"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "binpack2d",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-curves"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "glam 0.32.1",
  "serde",
@@ -248,7 +248,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-debugging"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-editor"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-editor-protocol"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "awsm-renderer-meshgen",
  "awsm-renderer-scene",
@@ -323,7 +323,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-geometry"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "glam 0.32.1",
  "serde",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-glb-export"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "awsm-renderer-meshgen",
  "awsm-renderer-tangents",
@@ -346,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-gltf"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-gltf-convert"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "awsm-renderer-glb-export",
  "awsm-renderer-meshgen",
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-lod-bake"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "glam 0.32.1",
  "serde",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-lod-bake-cli"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "awsm-renderer-glb-export",
@@ -410,7 +410,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-materials"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "awsm-renderer-core",
  "thiserror 2.0.18",
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-meshgen"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "awsm-renderer-curves",
  "awsm-renderer-geometry",
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-model-tests"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-multithreaded-example"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "awsm-renderer",
  "awsm-renderer-core",
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-particles"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "awsm-renderer-curves",
  "awsm-renderer-geometry",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-render-worker-example"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-scene"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bitcode",
  "glam 0.32.1",
@@ -535,7 +535,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-scene-loader"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-scene-mcp"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "awsm-renderer-editor-protocol",
@@ -578,14 +578,14 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-tangents"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bevy_mikktspace",
 ]
 
 [[package]]
 name = "awsm-renderer-web-shared"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ resolver = "2"
 [workspace.package]
 description = "awsm renderer"
 edition = "2021"
-version = "0.9.0"
+version = "0.10.0"
 license = "MIT OR Apache-2.0"
 authors = ["David Komer"]
 # 1.85 floor: rmcp 1.x (the MCP server SDK) is edition-2024, which requires
@@ -118,23 +118,23 @@ opt-level = 1
 # `workspace.package.version` so the published crates carry concrete
 # version requirements on each other (crates.io rejects path-only deps).
 # Bump this block together with the version above on every release.
-awsm-renderer-curves = { path = "packages/crates/curves", version = "0.9.0" }
-awsm-renderer-geometry = { path = "packages/crates/geometry", version = "0.9.0" }
-awsm-renderer-scene = { path = "packages/crates/scene", version = "0.9.0" }
-awsm-renderer-scene-loader = { path = "packages/crates/scene-loader", version = "0.9.0" }
-awsm-renderer-editor-protocol = { path = "packages/mcp/editor-protocol", version = "0.9.0" }
-awsm-renderer-core = { path = "packages/crates/renderer-core", version = "0.9.0" }
-awsm-renderer-meshgen = { path = "packages/crates/meshgen", version = "0.9.0" }
-awsm-renderer-glb-export = { path = "packages/crates/glb-export", version = "0.9.0" }
-awsm-renderer-gltf-convert = { path = "packages/crates/gltf-convert", version = "0.9.0" }
-awsm-renderer-tangents = { path = "packages/crates/tangents", version = "0.9.0" }
-awsm-renderer-lod-bake = { path = "packages/crates/lod-bake", version = "0.9.0" }
-awsm-renderer-particles = { path = "packages/crates/particles", version = "0.9.0" }
-awsm-renderer-materials = { path = "packages/crates/materials", version = "0.9.0" }
-awsm-renderer = { path = "packages/crates/renderer", version = "0.9.0" }
-awsm-renderer-gltf = { path = "packages/crates/renderer-gltf", version = "0.9.0" }
+awsm-renderer-curves = { path = "packages/crates/curves", version = "0.10.0" }
+awsm-renderer-geometry = { path = "packages/crates/geometry", version = "0.10.0" }
+awsm-renderer-scene = { path = "packages/crates/scene", version = "0.10.0" }
+awsm-renderer-scene-loader = { path = "packages/crates/scene-loader", version = "0.10.0" }
+awsm-renderer-editor-protocol = { path = "packages/mcp/editor-protocol", version = "0.10.0" }
+awsm-renderer-core = { path = "packages/crates/renderer-core", version = "0.10.0" }
+awsm-renderer-meshgen = { path = "packages/crates/meshgen", version = "0.10.0" }
+awsm-renderer-glb-export = { path = "packages/crates/glb-export", version = "0.10.0" }
+awsm-renderer-gltf-convert = { path = "packages/crates/gltf-convert", version = "0.10.0" }
+awsm-renderer-tangents = { path = "packages/crates/tangents", version = "0.10.0" }
+awsm-renderer-lod-bake = { path = "packages/crates/lod-bake", version = "0.10.0" }
+awsm-renderer-particles = { path = "packages/crates/particles", version = "0.10.0" }
+awsm-renderer-materials = { path = "packages/crates/materials", version = "0.10.0" }
+awsm-renderer = { path = "packages/crates/renderer", version = "0.10.0" }
+awsm-renderer-gltf = { path = "packages/crates/renderer-gltf", version = "0.10.0" }
 # Frontend-only (not published); workspace dep keeps consumers path-agnostic.
-awsm-renderer-web-shared = { path = "packages/frontend/web-shared", version = "0.9.0" }
+awsm-renderer-web-shared = { path = "packages/frontend/web-shared", version = "0.10.0" }
 
 # Misc
 cfg-if = "1.0.4"

--- a/packages/crates/renderer/src/render_passes/shared/shared_wgsl/shadow/bind_groups.wgsl
+++ b/packages/crates/renderer/src/render_passes/shared/shared_wgsl/shadow/bind_groups.wgsl
@@ -439,20 +439,31 @@ fn sample_shadow_cube(desc: ShadowDescriptor, world_pos: vec3<f32>, world_normal
     let near = POINT_SHADOW_NEAR;
     let ndc_z = (range / (range - near)) * (1.0 - near / max(view_depth, near));
 
-    // Slope-aware constant bias. `n_dot_dir` floor at 0.05 keeps
-    // grazing surfaces from running away to huge bias values
-    // (`bias → ∞` as `n_dot_dir → 0`); the user-authored
-    // `desc.bias_params.x` (the per-light `depth_bias`) is trusted
-    // as-is. An earlier floor of `max(..., 0.001)` here silently
-    // overrode any inspector value smaller than 0.001 — that was
-    // ~10× the NDC gap between a receiver and a box's back face at
-    // a typical 4 m point-light distance, so contacts could never
-    // close even after lowering `depth_bias`. If you DO want a
-    // global floor for some project, gate it on
-    // `ShadowsConfig::min_point_depth_bias` (not present today).
+    // Cube face resolution (square). World-size of one texel uses this both
+    // here (central receiver bias) and in the Soft/PCSS tap loops.
+    let cube_face_res = f32(textureDimensions(shadow_cube_2d_array, 0).x);
+
+    // Receiver depth bias, expressed in WORLD space and converted to NDC.z
+    // through the local perspective depth gradient `grad = d(ndc_z)/d(view_depth)`.
+    //
+    // Why world-space: NDC.z is nonlinear under perspective, so a *constant*
+    // NDC subtraction (what this used to do) maps to a world offset that grows
+    // with distance — at a few metres the authored `depth_bias` ballooned to
+    // ~10+ cm and lifted the receiver clean off its caster, punching the lit
+    // "hole" out of the contact shadow directly under a mesh. Multiplying a
+    // world-space push-back by `grad` keeps it a fixed small offset at any
+    // light distance. `desc.bias_params.x` (`depth_bias`) is therefore in
+    // METRES on this path; the `n_dot_dir` floor at 0.05 slope-scales it
+    // (grazing surfaces need more) without running away as `n_dot_dir → 0`.
+    // The per-texel quantization slack (`texel_world * kernel_slack`) is folded
+    // into the same world push-back — both are world distances through one `grad`.
+    let grad = (range / (range - near)) * near
+        / max(view_depth * view_depth, near * near);
+    let texel_world = 2.0 * view_depth / cube_face_res;
     let n_dot_dir = abs(dot(dir, world_normal));
-    let bias = desc.bias_params.x / max(n_dot_dir, 0.05);
-    let ref_depth = clamp(ndc_z, 0.0, 1.0) - bias;
+    let world_bias = desc.bias_params.x / max(n_dot_dir, 0.05)
+        + texel_world * desc.cascade_info.x;
+    let ref_depth = clamp(ndc_z, 0.0, 1.0) - world_bias * grad;
     let hardness = desc.bias_params.z;
 
     if hardness < 0.5 {
@@ -489,10 +500,6 @@ fn sample_shadow_cube(desc: ShadowDescriptor, world_pos: vec3<f32>, world_normal
     let sin_p = sin(angle);
     let cos_p = cos(angle);
 
-    // Cube face resolution (square), for the per-texel kernel-slack term in
-    // both branches below.
-    let cube_face_res = f32(textureDimensions(shadow_cube_2d_array, 0).x);
-
     // Per-light Vogel tap budget (descriptor extra_params.x). Soft/PCSS use `n`;
     // the blocker search uses a smaller `n_blocker`.
     let n = shadow_tap_count(desc.extra_params.x);
@@ -520,16 +527,17 @@ fn sample_shadow_cube(desc: ShadowDescriptor, world_pos: vec3<f32>, world_normal
             let tap_ndc_z =
                 (range / (range - near)) * (1.0 - near / max(tap_view_depth, near));
             let tap_n_dot_dir = abs(dot(tap_dir, world_normal));
-            let tap_bias = desc.bias_params.x / max(tap_n_dot_dir, 0.05);
-            // Per-texel quantization slack (NOT kernel-radius — see the block
-            // comment above the cube fn). `world_per_texel = 2·view_depth /
-            // res`; one texel of depth can't bridge a real occluder gap, so
-            // no umbra leak.
+            // World-space receiver push-back → NDC.z via the local perspective
+            // gradient (see the central block above). `depth_bias` is metres and
+            // slope-scaled; the per-texel quantization slack (`world_per_texel =
+            // 2·view_depth / res`, one texel can't bridge a real occluder gap)
+            // rides the same `tap_grad`, so neither term explodes with distance.
             let tap_grad = (range / (range - near)) * near
                 / max(tap_view_depth * tap_view_depth, near * near);
-            let texel_world = 2.0 * tap_view_depth / cube_face_res;
-            let tap_slack = tap_grad * texel_world * desc.cascade_info.x;
-            let tap_ref = clamp(tap_ndc_z, 0.0, 1.0) - tap_bias - tap_slack;
+            let tap_texel_world = 2.0 * tap_view_depth / cube_face_res;
+            let tap_world_bias = desc.bias_params.x / max(tap_n_dot_dir, 0.05)
+                + tap_texel_world * desc.cascade_info.x;
+            let tap_ref = clamp(tap_ndc_z, 0.0, 1.0) - tap_world_bias * tap_grad;
             sum += textureSampleCompareLevel(
                 shadow_cube_array,
                 shadow_cube_sampler,
@@ -673,15 +681,17 @@ fn sample_shadow_cube(desc: ShadowDescriptor, world_pos: vec3<f32>, world_normal
         let tap_ndc_z =
             (range / (range - near)) * (1.0 - near / max(tap_view_depth, near));
         let tap_n_dot_dir = abs(dot(tap_dir, world_normal));
-        let tap_bias = desc.bias_params.x / max(tap_n_dot_dir, 0.05);
-        // Per-texel quantization slack (see soft path + the block comment
-        // above the cube fn): ONE-texel footprint, independent of the (up to
-        // ~1 m) penumbra radius, so a wide kernel no longer leaks the umbra.
+        // World-space receiver push-back → NDC.z via the local perspective
+        // gradient (see the central block + Soft path). `depth_bias` is metres
+        // and slope-scaled; the per-texel quantization slack is a ONE-texel
+        // footprint, independent of the (up to ~1 m) penumbra radius, so a wide
+        // kernel no longer leaks the umbra and neither term grows with distance.
         let tap_grad = (range / (range - near)) * near
             / max(tap_view_depth * tap_view_depth, near * near);
-        let texel_world = 2.0 * tap_view_depth / cube_face_res;
-        let tap_slack = tap_grad * texel_world * desc.cascade_info.x;
-        let tap_ref = clamp(tap_ndc_z, 0.0, 1.0) - tap_bias - tap_slack;
+        let tap_texel_world = 2.0 * tap_view_depth / cube_face_res;
+        let tap_world_bias = desc.bias_params.x / max(tap_n_dot_dir, 0.05)
+            + tap_texel_world * desc.cascade_info.x;
+        let tap_ref = clamp(tap_ndc_z, 0.0, 1.0) - tap_world_bias * tap_grad;
         sum += textureSampleCompareLevel(
             shadow_cube_array,
             shadow_cube_sampler,

--- a/packages/crates/renderer/src/render_passes/shared/shared_wgsl/shadow/bind_groups.wgsl
+++ b/packages/crates/renderer/src/render_passes/shared/shared_wgsl/shadow/bind_groups.wgsl
@@ -398,6 +398,33 @@ const POINT_SHADOW_NEAR: f32 = 0.05;
 // in practice, and the default reads correctly here. If an old project
 // shows faint acne rings, nudge its per-light `kernel_slack` up a texel.
 
+// World-space → NDC.z depth gradient at a projected point, for ANY projection.
+//
+//   ndc.z = clip.z / clip.w,   clip = view_projection · world_pos
+//   d(ndc.z)/d(world_pos) = (row2·clip.w − row3·clip.z) / clip.w²   (a vec3)
+//
+// where row2 / row3 are the z- and w-rows of `view_projection`. The returned
+// scalar is the magnitude — how much ndc.z moves per world metre along the
+// steepest (≈ light-ray) direction. Multiply a WORLD-space depth bias by it to
+// get the NDC.z offset to subtract.
+//
+// Why this matters: a *constant* NDC.z bias (`ref_depth = ndc.z − depth_bias`)
+// is only distance-invariant under an orthographic projection, where ndc.z is
+// linear in world depth. Under perspective (spot + point) ndc.z is nonlinear,
+// so a fixed NDC bias balloons into a world offset that grows with distance —
+// at a few metres it lifts the receiver clean off its caster and punches a lit
+// "hole"/donut out of the contact shadow directly under a mesh. Referencing the
+// bias through this gradient keeps it a fixed small world offset at any range.
+// For an orthographic projection (w-row = 0, clip.w constant) it collapses to a
+// constant, so the directional path keeps its existing distance-invariant
+// behaviour — now expressed, like every other path, in world metres.
+fn ndc_depth_gradient(vp: mat4x4<f32>, clip_z: f32, clip_w: f32) -> f32 {
+    let row2 = vec3<f32>(vp[0][2], vp[1][2], vp[2][2]);
+    let row3 = vec3<f32>(vp[0][3], vp[1][3], vp[2][3]);
+    let g = (row2 * clip_w - row3 * clip_z) / max(clip_w * clip_w, 1e-8);
+    return length(g);
+}
+
 // Point-light cube shadow sample.
 //
 // Each cube face stores perspective NDC.z written by the rasterizer
@@ -802,7 +829,12 @@ fn sample_shadow_cascade_array(
     // sub-rect size in normalised UV so smaller cascades don't read
     // outside their valid region.
     let atlas_uv = uv_local * desc.atlas_rect.zw;
-    let ref_depth = ndc.z - desc.bias_params.x;
+    // World-referenced depth bias (metres → NDC.z via the projection gradient).
+    // For the orthographic cascade projection this gradient is constant, so this
+    // is the same distance-invariant bias as before, just in world units — see
+    // `ndc_depth_gradient`.
+    let depth_grad = ndc_depth_gradient(desc.view_projection, clip.z, clip.w);
+    let ref_depth = ndc.z - desc.bias_params.x * depth_grad;
     let hardness = desc.bias_params.z;
 
     let inv_atlas = vec2<f32>(
@@ -897,7 +929,14 @@ fn sample_shadow_cascade_array(
         let coord = vec2<i32>(sample_uv * atlas_uv_to_texels);
         let c = clamp(coord, tile_min_px, tile_max_px);
         let d = textureLoad(shadow_cascade_array, c, layer, 0);
-        if d < ref_depth - 0.0005 {
+        // Skip-self epsilon in WORLD space (~2 receiver texels) converted to
+        // NDC.z via depth_grad. The old constant 0.0005 NDC is the same
+        // perspective trap as the depth bias: harmless under the orthographic
+        // cascade, but on the perspective spot path it grows to ~10 cm at a few
+        // metres and rejects genuine near-contact occluders, collapsing
+        // `blocker_count` so the PCSS early-out holes the contact shadow out to
+        // fully lit. (For the ortho cascade this evaluates to ≈ the old value.)
+        if d < ref_depth - 2.0 * world_per_texel_pcss * depth_grad {
             blocker_sum = blocker_sum + d;
             blocker_count = blocker_count + 1u;
         }
@@ -920,7 +959,8 @@ fn sample_shadow_cascade_array(
     // self-shadows into acne. Scale the comparison bias with the kernel width so
     // wider penumbras get proportional slack — the softness hides the extra
     // peter-panning a near-contact (narrow-kernel) fragment would otherwise show.
-    let pcss_ref = ref_depth - desc.bias_params.x * penumbra_texels * 0.5;
+    // World-referenced (× depth_grad) for the same reason as the base bias.
+    let pcss_ref = ref_depth - desc.bias_params.x * penumbra_texels * 0.5 * depth_grad;
     var pcf_sum = 0.0;
     for (var i = 0u; i < n; i = i + 1u) {
         let off = vogel_tap(i, pcf_rsqrt_n, sin_a, cos_a) * penumbra_texels;
@@ -986,7 +1026,12 @@ fn sample_shadow_descriptor(
     }
     let uv_local = vec2<f32>(ndc.x * 0.5 + 0.5, -ndc.y * 0.5 + 0.5);
     let atlas_uv = desc.atlas_rect.xy + uv_local * desc.atlas_rect.zw;
-    let ref_depth = ndc.z - desc.bias_params.x;
+    // World-referenced depth bias (metres → NDC.z via the projection gradient).
+    // The spot projection is perspective, so this is what stops the authored
+    // depth_bias from ballooning with distance and holing out contact shadows —
+    // see `ndc_depth_gradient`.
+    let depth_grad = ndc_depth_gradient(desc.view_projection, clip.z, clip.w);
+    let ref_depth = ndc.z - desc.bias_params.x * depth_grad;
     let hardness = desc.bias_params.z;
 
     // PCF / PCSS taps must stay inside this cascade's tile of the
@@ -1132,7 +1177,11 @@ fn sample_shadow_descriptor(
         // doesn't read from an adjacent cascade's depth values.
         let c = clamp(coord, tile_min_px, tile_max_px);
         let d = textureLoad(shadow_atlas, c, 0);
-        if d < ref_depth - 0.0005 {
+        // Skip-self epsilon in WORLD space (~2 receiver texels) via depth_grad —
+        // see the matching cascade-array note. The old constant 0.0005 NDC grows
+        // to ~10 cm of world depth at a few metres on this perspective path and
+        // rejected near-contact occluders, holing the contact shadow.
+        if d < ref_depth - 2.0 * world_per_texel_pcss * depth_grad {
             blocker_sum = blocker_sum + d;
             blocker_count = blocker_count + 1u;
         }
@@ -1166,7 +1215,8 @@ fn sample_shadow_descriptor(
     // peter-panning a near-contact (narrow-kernel) fragment would otherwise show.
     // The slack is the user's own `depth_bias` (bias_params.x) times the kernel
     // radius, so it inherits the per-light tuning instead of a fresh constant.
-    let pcss_ref = ref_depth - desc.bias_params.x * penumbra_texels * 0.5;
+    // World-referenced (× depth_grad) for the same reason as the base bias.
+    let pcss_ref = ref_depth - desc.bias_params.x * penumbra_texels * 0.5 * depth_grad;
     var pcf_sum = 0.0;
     for (var i = 0u; i < n; i = i + 1u) {
         let off = vogel_tap(i, pcf_rsqrt_n, sin_a, cos_a) * penumbra_texels;

--- a/packages/crates/renderer/src/shadows/light_shadow.rs
+++ b/packages/crates/renderer/src/shadows/light_shadow.rs
@@ -14,9 +14,16 @@ pub struct LightShadowParams {
     /// Constant depth offset added at sample time. Pushes the
     /// comparison reference closer to the light to suppress acne.
     pub depth_bias: f32,
-    /// Receiver-position offset along the surface normal applied before
-    /// the shadow lookup. Cures grazing-angle acne without the Peter
-    /// Panning that slope-scale bias produces.
+    /// Receiver-position offset along the surface normal (world metres)
+    /// applied before the shadow lookup. Cures grazing-angle acne without
+    /// the Peter Panning that slope-scale bias produces — but being a fixed
+    /// world push toward the light, an over-large value *is* itself a
+    /// Peter-Pan source: it lifts the receiver off a caster it nearly
+    /// touches, holing the contact shadow directly under a resting mesh.
+    /// The default is deliberately modest (~2-3 shadow texels at typical
+    /// resolutions); acne is carried mostly by the slope-scaled hardware
+    /// bias + the world-referenced `depth_bias`/per-texel slack, so this
+    /// only needs to cover the residual.
     pub normal_bias: f32,
     /// Per-cascade / per-face shadow map resolution. Directional
     /// lights use this as the base; deeper cascades downscale via
@@ -77,7 +84,11 @@ impl Default for LightShadowParams {
         Self {
             cast: false,
             depth_bias: 0.0005,
-            normal_bias: 0.05,
+            // ~2-3 shadow texels of world push-back. Was 0.05 (≈7 texels),
+            // which visibly Peter-Panned a hole into contact shadows under a
+            // resting/settling mesh; lowered once depth_bias went world-
+            // referenced and stopped over-biasing on its own. See the field doc.
+            normal_bias: 0.02,
             resolution: 1024,
             hardness: LightShadowHardness::Soft,
             pcss_penumbra_scale: 1.0,

--- a/packages/crates/scene/src/light.rs
+++ b/packages/crates/scene/src/light.rs
@@ -106,7 +106,11 @@ impl Default for LightShadowConfig {
         Self {
             cast: true,
             depth_bias: 0.0005,
-            normal_bias: 0.05,
+            // Modest normal-offset (~2-3 shadow texels). Was 0.05, which
+            // Peter-Panned a hole into contact shadows under a resting mesh;
+            // lowered once depth_bias became world-referenced. Keep in sync with
+            // `default_normal_bias()` + renderer `LightShadowParams::default`.
+            normal_bias: 0.02,
             resolution: 1024,
             hardness: LightShadowHardness::Soft,
             pcss_penumbra_scale: 1.0,
@@ -196,7 +200,7 @@ fn default_depth_bias() -> f32 {
     0.0005
 }
 fn default_normal_bias() -> f32 {
-    0.05
+    0.02
 }
 fn default_shadow_res() -> u32 {
     1024


### PR DESCRIPTION
## Problem

Shadows develop an empty/lit **hole** (a donut) directly beneath a mesh as it lowers toward — or sinks into — the ground. Reported on `templates/physics-multithreaded` (ball + tabletop, overhead **point** light); the same class of bug also affects **spot** and **directional** lights.

## Root cause — one universal bug, three sites

A **constant NDC.z value** is only distance-invariant under an *orthographic* projection (NDC.z linear in world depth). Under **perspective** (point + spot) NDC.z is nonlinear, so a fixed NDC constant balloons into a world-space offset that **grows with distance** — at a few metres it becomes ~10+ cm, lifting the receiver off its caster and holing the contact shadow. This bug appears in three places:

1. **Receiver depth bias** `ref_depth = ndc.z - depth_bias` (point/spot/directional) — at the scene's ~3.7 m point light the default `depth_bias = 0.0005` became **~13 cm** of world bias.
2. **PCSS kernel-width slack** `pcss_ref` (spot/directional).
3. **PCSS blocker-search skip-self epsilon** `d < ref_depth - 0.0005` (spot/directional) — on the perspective spot path this hardcoded constant grows to ~10 cm and **rejects genuine near-contact occluders**, collapsing `blocker_count` so the PCSS early-out declares the contact fully lit. This was the dominant cause of the *spot* PCSS donut.

## Fix

World-reference every one of those terms: express the quantity in **world metres** and convert to NDC.z through the **local perspective depth gradient**.

- **Cube (point)**: uses the analytic cube-projection gradient, folding `depth_bias` + per-texel slack into one world push-back.
- **Spot + directional (matrix paths)**: a shared `ndc_depth_gradient(view_projection, clip.z, clip.w)` helper derives `d(ndc.z)/d(world_pos)` straight from the projection matrix — correct for perspective **and** orthographic (for ortho the w-row is 0, so it collapses to the correct constant, and directional bias also becomes *consistent across cascades*, which it wasn't before).

`depth_bias` is now interpreted in **metres** on every path. EVSM and SSCS paths are untouched.

## Also: `normal_bias` default lowered 0.05 → 0.02

Investigating the deep-interpenetration residual on the spot revealed a *second* Peter-Pan source: the **5 cm normal-offset** itself. A fixed world push toward the light lifts the receiver off a caster it nearly touches, holing the contact shadow under a resting mesh (`normal_bias = 0.05` → donut; `0.01` → fully solid). The 5 cm value made sense as an aggressive acne guard when `depth_bias` over-biased on its own — but now that `depth_bias` is world-referenced, acne is carried by the slope-scaled hardware bias + world-referenced `depth_bias` + per-texel slack. On this scene the point light is clean down to `normal_bias = 0`; **`0.02`** (~2–3 shadow texels) is verified acne-free across point/spot/directional (incl. grazing sun) while tightening contact. Lowered in all three defaults (`LightShadowParams`, `LightShadowConfig`, `default_normal_bias`); existing scenes bake their own value so only new lights are affected. The physics-multithreaded scene's `project.toml` is updated to match (separate repo).

## Verification (browser, MCP + chrome-devtools)

Swept **point / spot / directional** across floating → resting → slightly sunk → deeply sunk, plus grazing-sun and 2.4× light distance:

- Contact hole/donut gone at realistic resting/contact positions; soft PCSS penumbra + contact-hardening preserved (ideal for the bouncing ball — soft when airborne, tight when it lands).
- **Distance robustness**: point light contact stays solid from 3.7 m out to 9 m.
- **No new acne**: smooth ball self-shadow terminators, clean floor, clean walls, clean grazing-sun floor (verified at the reduced biases).
- `cargo fmt` + `task lint` (rustfmt + clippy `-D warnings` + tests) pass.

Known residual: a faint hole remains only at deep (>30%) mesh interpenetration on the **wide-search spot PCSS** path — inherent to that regime; realistic resting contact is solid. `normal_bias = 0.01` closes it fully if a project wants it per-light.

## Performance

No regression on any path. Changes are confined inside the shadow sample functions — **identical** `textureSampleCompareLevel` / blocker-load counts, only a few extra scalar ALU ops (one `length()` for the matrix gradient), and **no new pipelines/shaders/variants**.

## Commits
1. `world-referencing the cube depth bias` — point light (the reported bug).
2. `extend the world-referenced bias fix to spot + directional (universal)` — matrix-gradient helper + blocker epsilon.
3. `lower default normal_bias 0.05 -> 0.02` — remove the second (normal-offset) Peter-Pan source; tighter contact, no acne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)