### PR TITLE
Player bundle: carry the environment through export + load, + HttpAssets asset source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -549,6 +549,7 @@ dependencies = [
  "awsm-renderer-particles",
  "awsm-renderer-scene",
  "glam 0.32.1",
+ "gloo-net",
  "serde_json",
  "toml",
  "tracing",

--- a/packages/crates/renderer-core/src/cubemap.rs
+++ b/packages/crates/renderer-core/src/cubemap.rs
@@ -114,6 +114,14 @@ impl CubemapImage {
                 Ok(CubemapImage::Ktx(Arc::new(reader)))
             }
 
+            /// Loads a KTX2 cubemap from already-fetched bytes (no network) — e.g.
+            /// a `.ktx2` pulled from a player-bundle asset map or an in-memory stash.
+            pub fn load_ktx_bytes(bytes: Vec<u8>) -> anyhow::Result<Self> {
+                let reader = ktx::load_bytes(bytes)?;
+
+                Ok(CubemapImage::Ktx(Arc::new(reader)))
+            }
+
             // returns mip count as well
             /// Creates a GPU cubemap texture and view.
             pub async fn create_texture_and_view(

--- a/packages/crates/renderer-core/src/cubemap/ktx.rs
+++ b/packages/crates/renderer-core/src/cubemap/ktx.rs
@@ -31,6 +31,13 @@ pub async fn load_url(url: &str) -> anyhow::Result<ktx2::Reader<Vec<u8>>> {
     Ok(ktx2::Reader::new(bytes).map_err(|e| AwsmCoreError::Ktx(e.to_string()))?)
 }
 
+/// Parses a KTX2 file from already-fetched bytes (no network). The bytes-in
+/// counterpart of [`load_url`] — used when the `.ktx2` comes from a player-bundle
+/// asset map (or any in-memory source) rather than a URL.
+pub fn load_bytes(bytes: Vec<u8>) -> anyhow::Result<ktx2::Reader<Vec<u8>>> {
+    Ok(ktx2::Reader::new(bytes).map_err(|e| AwsmCoreError::Ktx(e.to_string()))?)
+}
+
 /// Creates a cubemap texture from a KTX2 reader.
 pub async fn create_texture(
     reader: &ktx2::Reader<Vec<u8>>,

--- a/packages/crates/scene-loader/Cargo.toml
+++ b/packages/crates/scene-loader/Cargo.toml
@@ -15,6 +15,11 @@ default = ["lod"]
 # dependency are compiled out, matching `awsm-renderer/lod` — a player built without
 # LOD pulls in none of it.
 lod = ["awsm-renderer/lod", "dep:awsm-renderer-lod-bake"]
+# A ready-made HTTP `SceneAssets` (`assets::HttpAssets`) that fetches a bundle's
+# files (`scene.toml`'s `assets/…`) from a base origin — what a shipped web player
+# wants. Pulls a web-only `gloo-net`, so it's opt-in; the loader core stays
+# transport-agnostic without it (a game can still supply its own `SceneAssets`).
+http = ["dep:gloo-net"]
 
 [dependencies]
 # The core renderer (GPU) + the glTF loader we reuse for the per-mesh glbs.
@@ -42,6 +47,9 @@ awsm-renderer-lod-bake = { workspace = true, features = ["serde"], optional = tr
 awsm-renderer-glb-export = { workspace = true }
 glam = { workspace = true }
 anyhow = { workspace = true }
+# HTTP client for the optional `http` feature's `OriginAssets` (web-only). Opt-in
+# so the transport-agnostic loader core doesn't pull it unless a player wants it.
+gloo-net = { workspace = true, optional = true }
 serde_json = { workspace = true }
 # Parse the `.lod.toml` LOD manifests baked into the bundle.
 toml = "0.8"

--- a/packages/crates/scene-loader/Cargo.toml
+++ b/packages/crates/scene-loader/Cargo.toml
@@ -22,7 +22,7 @@ lod = ["awsm-renderer/lod", "dep:awsm-renderer-lod-bake"]
 # (`animation::scene_loader::lower_stored_clip` / `lower_stored_mixer`) we feed
 # the bundle's clips + mixer through.
 awsm-renderer = { workspace = true, features = ["scene-schema"] }
-awsm-renderer-core = { workspace = true }
+awsm-renderer-core = { workspace = true, features = ["ktx"] }
 awsm-renderer-gltf = { workspace = true }
 # Dynamic-material types (custom-WGSL registration: layout, registration, shader id).
 awsm-renderer-materials = { workspace = true }

--- a/packages/crates/scene-loader/src/assets.rs
+++ b/packages/crates/scene-loader/src/assets.rs
@@ -50,3 +50,52 @@ impl SceneAssets for HashMap<String, Vec<u8>> {
             .ok_or_else(|| anyhow::anyhow!("asset not found: {path}"))
     }
 }
+
+/// An HTTP [`SceneAssets`] that fetches bundle bytes from a base origin — the
+/// player counterpart of the model-test's in-memory [`HashMap`] source, and the
+/// impl a shipped web player almost always wants.
+///
+/// A player bundle ships as static files (`scene.toml` + `assets/…`) served at
+/// some origin; the loader asks for bundle-relative paths and this GETs
+/// `<origin>/<path>`. This is why fetching is *not* baked into
+/// `load_scene_for_player`: the loader stays transport-agnostic (a game might
+/// stream from a CDN, a content-addressed store, or a preloaded map), and the
+/// common same-origin-HTTP case is just this ready-made impl. Enable the `http`
+/// feature to pull it in (it adds a web-only `gloo-net` dependency), and a
+/// template needs no bespoke fetching glue:
+///
+/// ```ignore
+/// let assets = HttpAssets::new(page_origin); // window.location.origin
+/// load_scene_for_player(&mut renderer, &scene, &assets, |_| {}).await?;
+/// ```
+#[cfg(feature = "http")]
+pub struct HttpAssets {
+    base: String,
+}
+
+#[cfg(feature = "http")]
+impl HttpAssets {
+    /// Fetch bundle files relative to `origin` (a trailing `/` is trimmed, so
+    /// `https://host` and `https://host/` behave identically). For a same-origin
+    /// web player pass the page origin (`window.location.origin`).
+    pub fn new(origin: impl Into<String>) -> Self {
+        Self {
+            base: origin.into().trim_end_matches('/').to_string(),
+        }
+    }
+}
+
+#[cfg(feature = "http")]
+impl SceneAssets for HttpAssets {
+    async fn fetch(&self, path: &str) -> anyhow::Result<Vec<u8>> {
+        let url = format!("{}/{}", self.base, path);
+        let bytes = gloo_net::http::Request::get(&url)
+            .send()
+            .await
+            .map_err(|e| anyhow::anyhow!("fetch {url}: {e}"))?
+            .binary()
+            .await
+            .map_err(|e| anyhow::anyhow!("fetch {url} body: {e}"))?;
+        Ok(bytes)
+    }
+}

--- a/packages/crates/scene-loader/src/environment.rs
+++ b/packages/crates/scene-loader/src/environment.rs
@@ -1,0 +1,156 @@
+//! Player-side environment (skybox + IBL) application — the player counterpart of
+//! the editor's `env_sync`.
+//!
+//! The bundle's `scene.toml` carries `scene.environment`; this module pushes it
+//! onto the renderer at load, so a scene looks the same played as authored.
+//! Both environment kinds the editor can set are supported:
+//! - **procedural** — the built-in default and agent-authored two-color
+//!   sky-gradient (§18), generated on the fly (`CubemapSkyGradient`);
+//! - **file-based** — a KTX2 cubemap, read from the bundle by the convention
+//!   `assets/<id>.ktx2` (the same name the editor bake emits).
+//!
+//! Applied BEFORE the load's single pipeline compile so IBL-sampling materials
+//! compile against the final environment (mirroring the editor's boot order).
+
+use anyhow::{anyhow, Result};
+use awsm_renderer::environment::Skybox;
+use awsm_renderer::lights::ibl::{Ibl, IblTexture};
+use awsm_renderer::AwsmRenderer;
+use awsm_renderer_core::command::color::Color;
+use awsm_renderer_core::cubemap::images::CubemapSkyGradient;
+use awsm_renderer_core::cubemap::CubemapImage;
+use awsm_renderer_scene::{AssetId, EnvironmentConfig, IblConfig, SkyboxConfig, ASSETS_DIR};
+
+use crate::assets::SceneAssets;
+
+/// Apply a scene's `EnvironmentConfig` (skybox + IBL) to the renderer. KTX
+/// cubemaps are read from the bundle by the `assets/<id>.ktx2` convention.
+pub async fn apply_environment(
+    renderer: &mut AwsmRenderer,
+    env: &EnvironmentConfig,
+    assets: &impl SceneAssets,
+) -> Result<()> {
+    let skybox = skybox_image(&env.skybox, assets).await?;
+    set_skybox(renderer, skybox).await?;
+
+    let (prefiltered, irradiance) = ibl_images(&env.ibl, assets).await?;
+    set_ibl(renderer, prefiltered, irradiance).await?;
+    Ok(())
+}
+
+/// A `CubemapSkyGradient` from linear-RGB zenith/nadir (§18).
+fn sky_gradient(zenith: [f32; 3], nadir: [f32; 3]) -> CubemapSkyGradient {
+    let c = |v: [f32; 3]| Color::new_values(v[0] as f64, v[1] as f64, v[2] as f64, 1.0);
+    CubemapSkyGradient::new(c(zenith), c(nadir))
+}
+
+async fn skybox_image(cfg: &SkyboxConfig, assets: &impl SceneAssets) -> Result<CubemapImage> {
+    match cfg {
+        SkyboxConfig::BuiltInDefault => {
+            CubemapImage::new_sky_gradient(CubemapSkyGradient::default(), 1024, 1024)
+                .await
+                .map_err(|e| anyhow!("sky gradient: {e}"))
+        }
+        SkyboxConfig::SkyGradient { zenith, nadir } => {
+            CubemapImage::new_sky_gradient(sky_gradient(*zenith, *nadir), 1024, 1024)
+                .await
+                .map_err(|e| anyhow!("sky gradient: {e}"))
+        }
+        SkyboxConfig::Ktx { asset_id } => load_ktx(*asset_id, assets).await,
+    }
+}
+
+async fn ibl_images(
+    cfg: &IblConfig,
+    assets: &impl SceneAssets,
+) -> Result<(CubemapImage, CubemapImage)> {
+    match cfg {
+        IblConfig::BuiltInDefault => gradient_ibl(CubemapSkyGradient::default()).await,
+        IblConfig::SkyGradient { zenith, nadir } => {
+            gradient_ibl(sky_gradient(*zenith, *nadir)).await
+        }
+        IblConfig::Ktx {
+            prefiltered_asset_id,
+            irradiance_asset_id,
+        } => {
+            let p = load_ktx(*prefiltered_asset_id, assets).await?;
+            let i = load_ktx(*irradiance_asset_id, assets).await?;
+            Ok((p, i))
+        }
+    }
+}
+
+/// Prefiltered (1024²) + irradiance (32²) env from a sky gradient — matches
+/// `env_sync::gradient_ibl`.
+async fn gradient_ibl(gradient: CubemapSkyGradient) -> Result<(CubemapImage, CubemapImage)> {
+    let p = CubemapImage::new_sky_gradient(gradient.clone(), 1024, 1024)
+        .await
+        .map_err(|e| anyhow!("prefiltered: {e}"))?;
+    let i = CubemapImage::new_sky_gradient(gradient, 32, 32)
+        .await
+        .map_err(|e| anyhow!("irradiance: {e}"))?;
+    Ok((p, i))
+}
+
+/// Read + parse a KTX2 cubemap from the bundle (`assets/<id>.ktx2`).
+async fn load_ktx(asset_id: AssetId, assets: &impl SceneAssets) -> Result<CubemapImage> {
+    let path = format!("{ASSETS_DIR}/{}.ktx2", asset_id.0);
+    let bytes = assets
+        .fetch(&path)
+        .await
+        .map_err(|e| anyhow!("fetch env ktx {path}: {e}"))?;
+    CubemapImage::load_ktx_bytes(bytes).map_err(|e| anyhow!("parse {path}: {e}"))
+}
+
+async fn set_skybox(renderer: &mut AwsmRenderer, image: CubemapImage) -> Result<()> {
+    let (texture, view, mip_count) = image
+        .create_texture_and_view(&renderer.gpu, Some("Skybox"))
+        .await
+        .map_err(|e| anyhow!("create skybox texture: {e}"))?;
+    let texture_key = renderer.textures.insert_cubemap(texture);
+    let sampler_key = renderer
+        .textures
+        .get_sampler_key(&renderer.gpu, Skybox::sampler_cache_key())
+        .map_err(|e| anyhow!("skybox sampler: {e}"))?;
+    let sampler = renderer
+        .textures
+        .get_sampler(sampler_key)
+        .map_err(|e| anyhow!("get skybox sampler: {e}"))?
+        .clone();
+    renderer.set_skybox(Skybox::new(texture_key, view, sampler, mip_count));
+    Ok(())
+}
+
+async fn set_ibl(
+    renderer: &mut AwsmRenderer,
+    prefiltered: CubemapImage,
+    irradiance: CubemapImage,
+) -> Result<()> {
+    let prefiltered_texture =
+        ibl_texture(renderer, prefiltered, "IBL Prefiltered Env Cubemap").await?;
+    let irradiance_texture = ibl_texture(renderer, irradiance, "IBL Irradiance Cubemap").await?;
+    renderer.set_ibl(Ibl::new(prefiltered_texture, irradiance_texture));
+    Ok(())
+}
+
+async fn ibl_texture(
+    renderer: &mut AwsmRenderer,
+    image: CubemapImage,
+    label: &str,
+) -> Result<IblTexture> {
+    let (texture, view, mip_count) = image
+        .create_texture_and_view(&renderer.gpu, Some(label))
+        .await
+        .map_err(|e| anyhow!("create {label}: {e}"))?;
+    let texture_key = renderer.textures.insert_cubemap(texture);
+    let sampler_key = renderer
+        .textures
+        .get_sampler_key(&renderer.gpu, IblTexture::sampler_cache_key())
+        .map_err(|e| anyhow!("ibl sampler: {e}"))?;
+    let sampler = renderer
+        .textures
+        .get_sampler(sampler_key)
+        .map_err(|e| anyhow!("get ibl sampler: {e}"))?
+        .clone();
+    Ok(IblTexture::new(texture_key, view, sampler, mip_count))
+}

--- a/packages/crates/scene-loader/src/lib.rs
+++ b/packages/crates/scene-loader/src/lib.rs
@@ -94,6 +94,7 @@ pub mod animation;
 pub mod assets;
 pub mod camera;
 pub mod dynamic;
+pub mod environment;
 pub mod light;
 pub mod material;
 pub mod particles;
@@ -818,6 +819,15 @@ pub async fn load_scene_for_player(
     // renderer. The loader only LOADS animation; the consumer drives the clock
     // (`update_animations` each frame, or the editor round-trip's playhead pin).
     loaded.clips = animation::load_animations(renderer, scene, &maps);
+
+    // ── Environment: apply skybox + IBL BEFORE the Phase-4 compile so
+    //    IBL-sampling materials compile against the final environment (mirrors
+    //    the editor's `env_sync::apply_initial` running before the first paint).
+    //    Non-fatal: a missing/bad cubemap falls back to the renderer's built-in
+    //    default rather than sinking the whole load.
+    if let Err(err) = environment::apply_environment(renderer, &scene.environment, assets).await {
+        tracing::warn!("environment apply failed, using renderer default: {err}");
+    }
 
     // ── Phase 4: THE commit — finalize the texture pool ONCE + compile every
     //    pipeline the scene needs, against the now-final content. This is the

--- a/packages/frontend/editor/src/controller/export.rs
+++ b/packages/frontend/editor/src/controller/export.rs
@@ -216,6 +216,15 @@ pub async fn bake_player_bundle(
         files.push(BundleFile::new(path, bytes));
     }
 
+    // 6. Environment skybox / IBL KTX2 cubemaps → assets/<id>.ktx2. The runtime
+    //    `scene.environment` (in scene.toml) references these by id; the player's
+    //    `scene_loader::environment` fetches them by the same convention. `ktx_files`
+    //    returns paths already rooted at `assets/`, so push verbatim (a gradient /
+    //    built-in environment references no KTX and emits nothing here).
+    for (path, bytes) in crate::controller::persistence::ktx_files(ctrl) {
+        files.push(BundleFile::new(path, bytes));
+    }
+
     assemble_bundle(&scene, files).map_err(|e| e.to_string())
 }
 

--- a/packages/frontend/editor/src/engine/bridge/env_sync.rs
+++ b/packages/frontend/editor/src/engine/bridge/env_sync.rs
@@ -209,20 +209,9 @@ async fn load_ktx_by_id(asset_id: AssetId) -> anyhow::Result<CubemapImage> {
         _ => anyhow::bail!("KTX skybox / IBL must reference a Filename or Url asset"),
     };
 
-    let array = js_sys::Uint8Array::from(bytes.as_slice());
-    let parts = js_sys::Array::new();
-    parts.push(&array);
-    let options = web_sys::BlobPropertyBag::new();
-    options.set_type("application/octet-stream");
-    let blob = web_sys::Blob::new_with_u8_array_sequence_and_options(&parts, &options)
-        .map_err(|e| anyhow::anyhow!("blob: {e:?}"))?;
-    let url_for_loader = web_sys::Url::create_object_url_with_blob(&blob)
-        .map_err(|e| anyhow::anyhow!("object url: {e:?}"))?;
-    let result = CubemapImage::load_url_ktx(&url_for_loader)
-        .await
-        .map_err(|e| anyhow::anyhow!("load_url_ktx {label}: {e}"));
-    let _ = web_sys::Url::revoke_object_url(&url_for_loader);
-    result
+    // Parse the KTX2 straight from bytes (same path the player's `scene_loader`
+    // uses) — no browser blob / object-URL round-trip.
+    CubemapImage::load_ktx_bytes(bytes).map_err(|e| anyhow::anyhow!("load ktx {label}: {e}"))
 }
 
 async fn set_skybox_on_renderer(


### PR DESCRIPTION
## Summary

Follow-up to #170. The exported **player bundle** dropped the scene's
**environment**: the bake never emitted the skybox/IBL KTX bytes, and the player
loader (`load_scene_for_player`) never applied `scene.environment` at all — so a
played bundle showed the renderer's built-in default environment instead of the
authored gradient / studio KTX. This fixes both ends, for **both** environment
kinds the editor can set: procedural sky-gradient **and** file-based KTX2 cubemap.

## Changes

- **renderer-core**: `CubemapImage::load_ktx_bytes` (+ `ktx::load_bytes`) — parse
  a KTX2 cubemap from already-fetched bytes, no URL/blob round-trip.
- **scene-loader**: new `environment` module, applied in `load_scene_for_player`
  **before** the pipeline compile (so IBL-sampling materials compile against the
  final environment — mirrors the editor's boot order). Procedural gradients are
  generated on the fly; KTX cubemaps are read from the bundle by the
  `assets/<id>.ktx2` convention. Non-fatal: a missing/bad cubemap falls back to
  the built-in default rather than sinking the load. Enables
  `awsm-renderer-core/ktx` so the KTX path exists in a standalone player build
  (not only under the editor's feature unification).
- **editor bake** (`bake_player_bundle`): emit the env KTX side files into the
  bundle, reusing the save-path helper `persistence::ktx_files`.
- **editor `env_sync`**: load KTX straight from bytes via the new `load_ktx_bytes`,
  dropping the browser `Blob`/object-URL glue (the editor and player now share one
  KTX-from-bytes path).

## Testing

`cargo fmt` + `task lint` clean; scene-loader compiles standalone with `ktx`
(feature addition self-sufficient, not masked by editor unification).

Verified **end-to-end** with `task mcp-dev` + browser automation: loaded the
physics pool project, set the split studio KTX environment (`set_environment` by
URL) + the felt PBR textures on the tabletop, confirmed the authoring render
(chrome ball reflecting the studio IBL, tiled felt), then baked and reloaded
through the **player path** (`load_player_bundle` → `populate_awsm_scene` →
`load_scene_for_player`). The runtime reload rendered the environment + felt with
**no environment-apply error** in the loader logs — i.e. the loader fetched the
env KTX from the baked bundle and applied it.

Note: the loader consumes an environment only if the host provides the bundle's
`assets/` to `load_scene_for_player`. A player that passes an empty asset map
(e.g. the physics-multithreaded template today) still gets procedural gradients
for free but needs to fetch `assets/` to pick up KTX cubemaps + textures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018vk1ioVqUWLjUdBXf42pc5
