### PR TITLE
Shadow quality fixes + SSCS as a persisted, tunable global

### DIFF
--- a/packages/crates/renderer/src/pipeline_scheduler/launch.rs
+++ b/packages/crates/renderer/src/pipeline_scheduler/launch.rs
@@ -488,6 +488,8 @@ impl crate::AwsmRenderer {
                     msaa_sample_count: active_msaa,
                     mipmaps: active_mipmaps,
                     max_shadow_casters: self.prep_config.clamped_k(),
+                    sscs_enabled: self.prep_config.sscs_enabled,
+                    sscs_step_count: self.prep_config.sscs_step_count,
                     shader_id,
                     base,
                     owns_skybox,
@@ -730,6 +732,8 @@ impl crate::AwsmRenderer {
                 color_wgsl,
                 Some(&self.dynamic_materials),
                 self.prep_config.clamped_k(),
+                self.prep_config.sscs_enabled,
+                self.prep_config.sscs_step_count,
             )? {
             Some(d) => d,
             None => return Ok(()),

--- a/packages/crates/renderer/src/render_passes/material_opaque/edge_pipeline.rs
+++ b/packages/crates/renderer/src/render_passes/material_opaque/edge_pipeline.rs
@@ -265,6 +265,8 @@ impl MaterialEdgePipelines {
         color_wgsl_format: &str,
         dynamic_registry: Option<&DynamicMaterials>,
         max_shadow_casters: u32,
+        sscs_enabled: bool,
+        sscs_step_count: u32,
     ) -> Result<Option<MaterialEdgePipelineDescriptors>> {
         // No MSAA → no edges → no compile.
         if anti_aliasing.msaa_sample_count.is_none() {
@@ -378,6 +380,8 @@ impl MaterialEdgePipelines {
                     msaa_sample_count: anti_aliasing.msaa_sample_count,
                     mipmaps,
                     max_shadow_casters,
+                    sscs_enabled,
+                    sscs_step_count,
                     shader_id: entry.shader_id,
                     base: entry.base,
                     owns_skybox,
@@ -445,6 +449,8 @@ impl MaterialEdgePipelines {
         color_wgsl_format: &str,
         dynamic_registry: Option<&DynamicMaterials>,
         max_shadow_casters: u32,
+        sscs_enabled: bool,
+        sscs_step_count: u32,
     ) -> Result<()> {
         let Some(descs) = self.build_descriptors(
             gpu,
@@ -457,6 +463,8 @@ impl MaterialEdgePipelines {
             color_wgsl_format,
             dynamic_registry,
             max_shadow_casters,
+            sscs_enabled,
+            sscs_step_count,
         )?
         else {
             return Ok(());

--- a/packages/crates/renderer/src/render_passes/material_opaque/pipeline.rs
+++ b/packages/crates/renderer/src/render_passes/material_opaque/pipeline.rs
@@ -175,6 +175,8 @@ impl MaterialOpaquePipelines {
             &bucket_entries,
             false,
             max_shadow_casters,
+            ctx.prep_config.sscs_enabled,
+            ctx.prep_config.sscs_step_count,
         )
     }
 
@@ -195,6 +197,8 @@ impl MaterialOpaquePipelines {
         bucket_entries: &[crate::dynamic_materials::BucketEntry],
         include_first_party: bool,
         max_shadow_casters: u32,
+        sscs_enabled: bool,
+        sscs_step_count: u32,
     ) -> Result<Vec<OpaqueShaderDesc>> {
         // Which (main_bgl, slot) is active? Only emit the descriptors
         // for the live MSAA branch — the other half stays uncompiled
@@ -246,6 +250,8 @@ impl MaterialOpaquePipelines {
                         msaa_sample_count: active_msaa,
                         mipmaps: active_mipmaps,
                         max_shadow_casters,
+                        sscs_enabled,
+                        sscs_step_count,
                         shader_id,
                         base: crate::dynamic_materials::ShadingBase::for_shader_id(shader_id),
                         owns_skybox: shader_id == MaterialShaderId::SKYBOX,

--- a/packages/crates/renderer/src/render_passes/material_opaque/shader/cache_key.rs
+++ b/packages/crates/renderer/src/render_passes/material_opaque/shader/cache_key.rs
@@ -28,6 +28,15 @@ pub struct ShaderCacheKeyMaterialOpaque {
     /// renders), but carried on the key so a K change still re-keys the
     /// pipeline. Default 4.
     pub max_shadow_casters: u32,
+    /// Global SSCS enable (from `ShadowsConfig::sscs_enabled`). Folded into the
+    /// shadow module's compile-time `sscs_available` gate — when `false` the
+    /// `apply_sscs` body is compiled out entirely (zero cost, the default), so
+    /// toggling SSCS re-keys + recompiles the opaque pipelines like MSAA does.
+    pub sscs_enabled: bool,
+    /// Global SSCS ray-march step count (`ShadowsConfig::sscs_step_count`, ≥1).
+    /// Baked as the `apply_sscs` loop bound so it's a compile-time constant
+    /// (unroll-friendly, no per-fragment counter). Changing it recompiles.
+    pub sscs_step_count: u32,
     pub shader_id: MaterialShaderId,
     /// Which built-in shading family this bucket's template body comes
     /// from. Decoupled from `shader_id` so a per-feature-set PBR variant

--- a/packages/crates/renderer/src/render_passes/material_opaque/shader/template.rs
+++ b/packages/crates/renderer/src/render_passes/material_opaque/shader/template.rs
@@ -41,11 +41,13 @@ pub struct ShaderTemplateMaterialOpaqueBindGroups {
     /// Trailing alignment-pad u32 indices for `ClassifyBuckets`,
     /// mirrors the classify-pass template's `pad_words_iter`.
     pub pad_words_iter: Vec<u32>,
-    /// Whether `apply_sscs` should compile its real body (true on the
-    /// opaque pass — it has `depth_tex` bound) or short-circuit to
-    /// `return 1.0` (true on the transparent pass — sampling its own
-    /// depth target would be a feedback loop, so SSCS is disabled).
+    /// Effective SSCS gate = pass-capability (the opaque pass has `depth_tex`
+    /// bound) AND the global `ShadowsConfig::sscs_enabled`. When `false`,
+    /// `apply_sscs` short-circuits to `return 1.0` at compile time (zero cost).
     pub sscs_available: bool,
+    /// SSCS ray-march step count baked as the `apply_sscs` loop bound
+    /// (compile-time constant). Only read when `sscs_available`.
+    pub sscs_step_count: u32,
     /// Whether the ~50 KB shadow SAMPLING block in
     /// `shared_wgsl/shadow/bind_groups.wgsl` is emitted. Set from
     /// `inc.apply_lighting` (the only caller of `sample_shadow_*`), so
@@ -410,7 +412,10 @@ impl TryFrom<&ShaderCacheKeyMaterialOpaque> for ShaderTemplateMaterialOpaque {
                 msaa_sample_count,
                 debug,
                 shadow_group_index: 3,
-                sscs_available: true,
+                // Opaque is SSCS-capable; effective gate is the global enable.
+                // step_count clamped ≥1 (safe loop bound + f32(steps) divisor).
+                sscs_available: value.sscs_enabled,
+                sscs_step_count: value.sscs_step_count.max(1),
                 // Plan B (stage 5a): drop the inline `sample_shadow_*` block
                 // only in no-MSAA+prep (cs_opaque=PRIMARY reads the buffer).
                 // Under MSAA+prep cs_edge=RECOMPUTE still inline-samples, so it
@@ -700,6 +705,8 @@ mod empty_registry_tests {
             msaa_sample_count: msaa,
             mipmaps: true,
             max_shadow_casters: 4,
+            sscs_enabled: false,
+            sscs_step_count: 16,
             shader_id,
             base: crate::dynamic_materials::ShadingBase::for_shader_id(shader_id),
             owns_skybox: shader_id == MaterialShaderId::SKYBOX,
@@ -1030,6 +1037,8 @@ mod size_regression {
             msaa_sample_count: msaa,
             mipmaps,
             max_shadow_casters: 4,
+            sscs_enabled: false,
+            sscs_step_count: 16,
             shader_id: dyn_id,
             base: crate::dynamic_materials::ShadingBase::Custom,
             owns_skybox: false,

--- a/packages/crates/renderer/src/render_passes/material_prep/mod.rs
+++ b/packages/crates/renderer/src/render_passes/material_prep/mod.rs
@@ -46,12 +46,31 @@ pub struct PrepPassConfig {
     // always reconstructs it from depth (`get_standard_coordinates`). The former
     // `reconstruct_world_pos` tunable was therefore obsolete and removed (Stage 6
     // cleanup).
+    /// SSCS shader-variant inputs, mirrored from `ShadowsConfig` (kept in sync by
+    /// `AwsmRenderer::set_shadows_config`). They live here — not read from the
+    /// shadow uniform — because both drive the shadow module's COMPILE-TIME
+    /// template: `sscs_enabled` folds into the `apply_sscs` capability gate
+    /// (`sscs_available`) so a disabled config emits zero SSCS code, and
+    /// `sscs_step_count` is baked as the ray-march loop bound (unroll-friendly,
+    /// no per-fragment counter). `PrepPassConfig` is already the shadow-shader
+    /// config threaded to every shadow-consuming pipeline build (opaque, prep,
+    /// edge-resolve), so co-locating them here reaches all cache-key sites
+    /// without new plumbing. Changing either re-keys + recompiles those pipelines
+    /// (via `mark_variants_dirty` + `commit_load`); the SSCS *scalar* tuning
+    /// params stay live uniforms in `ShadowsConfig` / `ShadowGlobals`.
+    pub sscs_enabled: bool,
+    pub sscs_step_count: u32,
 }
 
 impl Default for PrepPassConfig {
     fn default() -> Self {
         Self {
             max_shadow_casters_per_pixel: 4,
+            // Match `ShadowsConfig::default()` (SSCS off; 16-step march) so the
+            // initial pipeline build and the shadow config agree before any
+            // `set_shadows_config` sync runs.
+            sscs_enabled: false,
+            sscs_step_count: 16,
         }
     }
 }

--- a/packages/crates/renderer/src/render_passes/material_prep/render_pass.rs
+++ b/packages/crates/renderer/src/render_passes/material_prep/render_pass.rs
@@ -324,6 +324,8 @@ async fn build_pipeline(
             ShaderCacheKeyMaterialPrep {
                 msaa_sample_count: if multisampled_geometry { Some(4) } else { None },
                 max_shadow_casters: ctx.prep_config.clamped_k(),
+                sscs_enabled: ctx.prep_config.sscs_enabled,
+                sscs_step_count: ctx.prep_config.sscs_step_count,
             },
         )
         .await?;
@@ -369,6 +371,8 @@ async fn build_edge_pipeline(
             ShaderCacheKeyMaterialPrep {
                 msaa_sample_count: Some(4),
                 max_shadow_casters: ctx.prep_config.clamped_k(),
+                sscs_enabled: ctx.prep_config.sscs_enabled,
+                sscs_step_count: ctx.prep_config.sscs_step_count,
             },
         )
         .await?;

--- a/packages/crates/renderer/src/render_passes/material_prep/shader/cache_key.rs
+++ b/packages/crates/renderer/src/render_passes/material_prep/shader/cache_key.rs
@@ -16,6 +16,13 @@ pub struct ShaderCacheKeyMaterialPrep {
     /// Threaded into the key so the prep pipeline varies with K (the shadow
     /// loop's slot clamp + the packed-layer count derive from it).
     pub max_shadow_casters: u32,
+    /// Global SSCS enable (`ShadowsConfig::sscs_enabled`). Folded into the shadow
+    /// module's compile-time `sscs_available` gate — when `false` the `apply_sscs`
+    /// body is compiled out (zero cost, the default). Re-keys on toggle.
+    pub sscs_enabled: bool,
+    /// Global SSCS ray-march step count (`ShadowsConfig::sscs_step_count`, ≥1),
+    /// baked as the `apply_sscs` loop bound (compile-time constant). Re-keys on change.
+    pub sscs_step_count: u32,
 }
 
 impl From<ShaderCacheKeyMaterialPrep> for ShaderCacheKey {

--- a/packages/crates/renderer/src/render_passes/material_prep/shader/material_prep_wgsl/compute.wgsl
+++ b/packages/crates/renderer/src/render_passes/material_prep/shader/material_prep_wgsl/compute.wgsl
@@ -18,8 +18,9 @@
 // Returns the K shadow factors packed into `ceil(K/4)` vec4 layers (slot j ->
 // layer j/4, channel j%4) — the caller textureStores each layer to its own
 // target. Walks the canonical froxel order (froxel_walk.wgsl SSOT) and samples
-// EXACTLY as `apply_lighting_per_froxel` does: directional incl. `* apply_sscs`,
-// punctual WITHOUT sscs. `receive_shadows` is NOT applied here (the lighting loop
+// EXACTLY as `apply_lighting_per_froxel` does: directional incl. `* apply_sscs`
+// (0.35 cap), punctual incl. `* apply_sscs` (0.9 cap — fills the cube map's
+// contact "Peter Pan" donut). `receive_shadows` is NOT applied here (the lighting loop
 // applies it at read time so the slot model stays material-independent). The
 // caller passes the world position (sample-0 depth reconstruction in both kernels
 // — see shade_sample's NOTE) + view_z + the per-pixel/per-sample surface normal.
@@ -56,7 +57,7 @@ fn compute_shadow_visibility_packed(
                 shadow_normal_toward_light(normal, ls.light_dir),
                 view_z,
             );
-            v = v * apply_sscs(world_pos, normalize(-light.direction));
+            v = v * apply_sscs(world_pos, normalize(-light.direction), shadow_globals.sscs_params.z);
             layers[slot / 4u][slot % 4u] = v;
             slot = slot + 1u;
         }
@@ -72,12 +73,18 @@ fn compute_shadow_visibility_packed(
         if (light.kind == 1u) { continue; }
         if (light.shadow_index != SHADOW_INDEX_NONE) {
             let ls = light_sample(light, normal, world_pos);
-            let v = sample_shadow_directional(
+            var v = sample_shadow_directional(
                 light.shadow_index,
                 world_pos,
                 shadow_normal_toward_light(normal, ls.light_dir),
                 view_z,
             );
+            // Punctual SSCS: bake the contact-shadow refinement into the prep
+            // buffer so PRIMARY/EDGE reads include it, matching the inline
+            // RECOMPUTE / no-prep paths in apply_lighting. Higher cap (0.9) than
+            // directional's 0.35 — the cube map leaves a fully-lit "Peter Pan"
+            // donut at ball-on-floor contacts that SSCS must fill, not just nudge.
+            v = v * apply_sscs(world_pos, normalize(light.position - world_pos), shadow_globals.sscs_params.w);
             layers[slot / 4u][slot % 4u] = v;
             slot = slot + 1u;
         }
@@ -249,25 +256,34 @@ fn cs_prep_edge(@builtin(global_invocation_id) gid: vec3<u32>) {
     let cam = camera_from_raw(camera_raw);
     let dims = textureDimensions(normal_tangent_tex);
 
-    // Sample-0 world position (matches shade_sample's get_standard_coordinates).
-    let depth0 = textureLoad(depth_tex, coords, 0);
     let pix_uv = (vec2<f32>(coords) + vec2<f32>(0.5, 0.5))
         / vec2<f32>(f32(dims.x), f32(dims.y));
-    let ndc = vec3<f32>(pix_uv.x * 2.0 - 1.0, 1.0 - pix_uv.y * 2.0, depth0);
-    let view_h = cam.inv_proj * vec4<f32>(ndc, 1.0);
-    let world_pos = (cam.inv_view * vec4<f32>(view_h.xyz / max(view_h.w, 1e-8), 1.0)).xyz;
-    let view_z = -(cam.view * vec4<f32>(world_pos, 1.0)).z;
 
     for (var s: u32 = 0u; s < {{ msaa_sample_count }}u; s = s + 1u) {
-        // Per-sample normal (shade_sample reads vis/bary/normal per-sample).
+        // Per-sample normal AND per-sample depth. Multisampled textureLoad needs a
+        // CONSTANT sample index, so both come from one constant-index switch.
         var packed_nt: vec4<f32>;
+        var depth_s: f32;
         switch (s) {
-            case 0u: { packed_nt = textureLoad(normal_tangent_tex, coords, 0); }
-            case 1u: { packed_nt = textureLoad(normal_tangent_tex, coords, 1); }
-            case 2u: { packed_nt = textureLoad(normal_tangent_tex, coords, 2); }
-            case 3u, default: { packed_nt = textureLoad(normal_tangent_tex, coords, 3); }
+            case 0u: { packed_nt = textureLoad(normal_tangent_tex, coords, 0); depth_s = textureLoad(depth_tex, coords, 0); }
+            case 1u: { packed_nt = textureLoad(normal_tangent_tex, coords, 1); depth_s = textureLoad(depth_tex, coords, 1); }
+            case 2u: { packed_nt = textureLoad(normal_tangent_tex, coords, 2); depth_s = textureLoad(depth_tex, coords, 2); }
+            case 3u, default: { packed_nt = textureLoad(normal_tangent_tex, coords, 3); depth_s = textureLoad(depth_tex, coords, 3); }
         }
         let normal = unpack_normal_tangent(packed_nt).N;
+
+        // Per-sample world position — reconstruct from THIS sample's depth so the
+        // receiver bias matches the surface the sample actually lies on. Reusing
+        // sample-0's world_pos for every sample (the old behaviour) mismatches
+        // position vs normal at a silhouette straddling a depth discontinuity (a
+        // ball resting on the floor): a floor sub-sample gets the BALL's position
+        // with the FLOOR's normal, so the normal-offset + `inc_tan` bias are sized
+        // for a surface that doesn't exist and the contact shadow flips lit/
+        // shadowed along the edge — the crawling "green fringe" at resting contacts.
+        let ndc = vec3<f32>(pix_uv.x * 2.0 - 1.0, 1.0 - pix_uv.y * 2.0, depth_s);
+        let view_h = cam.inv_proj * vec4<f32>(ndc, 1.0);
+        let world_pos = (cam.inv_view * vec4<f32>(view_h.xyz / max(view_h.w, 1e-8), 1.0)).xyz;
+        let view_z = -(cam.view * vec4<f32>(world_pos, 1.0)).z;
 
         let packed = compute_shadow_visibility_packed(pixel_xy, world_pos, view_z, normal);
 

--- a/packages/crates/renderer/src/render_passes/material_prep/shader/template.rs
+++ b/packages/crates/renderer/src/render_passes/material_prep/shader/template.rs
@@ -30,9 +30,13 @@ pub struct ShaderTemplateMaterialPrepBindGroups {
     /// Compile the shadow-SAMPLING bodies (`{% if needs_shadow_sampling %}` in
     /// `shadow/bind_groups.wgsl`). `true` — prep is a shadow sampler.
     pub needs_shadow_sampling: bool,
-    /// SSCS availability (`apply_sscs` reads `depth_tex` + `camera_raw`). Prep
-    /// binds both, so `true` (matches the opaque pass for parity).
+    /// SSCS effective gate = pass-capability (prep binds `depth_tex` +
+    /// `camera_raw`) AND the global `ShadowsConfig::sscs_enabled`. When `false`
+    /// the shared `apply_sscs` body is compiled out to `return 1.0` (zero cost).
     pub sscs_available: bool,
+    /// SSCS ray-march step count baked as the `apply_sscs` loop bound
+    /// (compile-time constant). Only read when `sscs_available`.
+    pub sscs_step_count: u32,
     /// Bind-group slot the shadow bindings live at (group 2 for prep).
     pub shadow_group_index: u32,
     /// Z-slice count for `froxel_walk.wgsl` (`FROXEL_SLICE_COUNT`).
@@ -77,7 +81,11 @@ impl TryFrom<&ShaderCacheKeyMaterialPrep> for ShaderTemplateMaterialPrep {
                 multisampled_geometry,
                 shadows: true,
                 needs_shadow_sampling: true,
-                sscs_available: true,
+                // Prep is SSCS-capable (binds depth_tex + camera_raw); the
+                // effective gate is the global enable. `sscs_step_count` is
+                // clamped ≥1 so the loop bound and `f32(steps)` divisor are safe.
+                sscs_available: key.sscs_enabled,
+                sscs_step_count: key.sscs_step_count.max(1),
                 shadow_group_index: 2,
                 froxel_slice_count,
             },

--- a/packages/crates/renderer/src/render_passes/material_transparent/shader/template.rs
+++ b/packages/crates/renderer/src/render_passes/material_transparent/shader/template.rs
@@ -206,6 +206,10 @@ pub struct ShaderTemplateTransparentMaterialBindGroups {
     /// to a depth texture it can sample on the same frame without a
     /// feedback loop. `false` here makes `apply_sscs` short-circuit.
     pub sscs_available: bool,
+    /// SSCS loop bound — inert on the transparent pass (`sscs_available` is
+    /// always `false` so `apply_sscs`'s body is never emitted), but the shared
+    /// shadow template references the field, so it must exist. Dummy `1`.
+    pub sscs_step_count: u32,
     /// Emit the shadow SAMPLING block only when this material runs
     /// first-party lighting (`inc.apply_lighting`) — the only caller of
     /// `sample_shadow_*`. Custom materials force it off. The shadow bind
@@ -229,6 +233,7 @@ impl ShaderTemplateTransparentMaterialBindGroups {
             multisampled_geometry: cache_key.msaa_sample_count.is_some(),
             shadow_group_index: 1,
             sscs_available: false,
+            sscs_step_count: 1,
             needs_shadow_sampling: inc.apply_lighting,
         }
     }

--- a/packages/crates/renderer/src/render_passes/shared/shared_wgsl/lighting/apply_lighting.wgsl
+++ b/packages/crates/renderer/src/render_passes/shared/shared_wgsl/lighting/apply_lighting.wgsl
@@ -72,7 +72,7 @@ fn apply_lighting(
                     // would double-cost them for no win.
                     if light.kind == 1u && light.shadow_index != SHADOW_INDEX_NONE {
                         let sscs_dir = normalize(-light.direction);
-                        visibility = visibility * apply_sscs(world_position, sscs_dir);
+                        visibility = visibility * apply_sscs(world_position, sscs_dir, shadow_globals.sscs_params.z);
                     }
                 }
                 color += direct * visibility;
@@ -242,7 +242,7 @@ fn apply_lighting_per_froxel(
                         );
                         if light.shadow_index != SHADOW_INDEX_NONE {
                             let sscs_dir = normalize(-light.direction);
-                            visibility = visibility * apply_sscs(world_position, sscs_dir);
+                            visibility = visibility * apply_sscs(world_position, sscs_dir, shadow_globals.sscs_params.z);
                         }
                     }
                 }
@@ -259,7 +259,7 @@ fn apply_lighting_per_froxel(
                     );
                     if light.shadow_index != SHADOW_INDEX_NONE {
                         let sscs_dir = normalize(-light.direction);
-                        visibility = visibility * apply_sscs(world_position, sscs_dir);
+                        visibility = visibility * apply_sscs(world_position, sscs_dir, shadow_globals.sscs_params.z);
                     }
                 }
                 color += direct * visibility;
@@ -318,6 +318,9 @@ fn apply_lighting_per_froxel(
                                 shadow_normal_toward_light(material_color.normal, light_brdf.light_dir),
                                 view_z_for_shadow,
                             );
+                            if light.shadow_index != SHADOW_INDEX_NONE {
+                                visibility = visibility * apply_sscs(world_position, normalize(to_light), shadow_globals.sscs_params.w);
+                            }
                         }
                         {% endif %}
                         color += direct * visibility;
@@ -342,6 +345,9 @@ fn apply_lighting_per_froxel(
                                 shadow_normal_toward_light(material_color.normal, light_brdf.light_dir),
                                 view_z_for_shadow,
                             );
+                            if light.shadow_index != SHADOW_INDEX_NONE {
+                                visibility = visibility * apply_sscs(world_position, normalize(to_light), shadow_globals.sscs_params.w);
+                            }
                         }
                         color += direct * visibility;
                     {% else %}
@@ -448,7 +454,7 @@ fn apply_lighting_per_froxel_with_transmission(
                         );
                         if light.shadow_index != SHADOW_INDEX_NONE {
                             let sscs_dir = normalize(-light.direction);
-                            visibility = visibility * apply_sscs(world_position, sscs_dir);
+                            visibility = visibility * apply_sscs(world_position, sscs_dir, shadow_globals.sscs_params.z);
                         }
                     }
                 }
@@ -465,7 +471,7 @@ fn apply_lighting_per_froxel_with_transmission(
                     );
                     if light.shadow_index != SHADOW_INDEX_NONE {
                         let sscs_dir = normalize(-light.direction);
-                        visibility = visibility * apply_sscs(world_position, sscs_dir);
+                        visibility = visibility * apply_sscs(world_position, sscs_dir, shadow_globals.sscs_params.z);
                     }
                 }
                 color += direct * visibility;
@@ -512,6 +518,9 @@ fn apply_lighting_per_froxel_with_transmission(
                                 shadow_normal_toward_light(material_color.normal, light_brdf.light_dir),
                                 view_z_for_shadow,
                             );
+                            if light.shadow_index != SHADOW_INDEX_NONE {
+                                visibility = visibility * apply_sscs(world_position, normalize(to_light), shadow_globals.sscs_params.w);
+                            }
                         }
                         {% endif %}
                         color += direct * visibility;
@@ -536,6 +545,9 @@ fn apply_lighting_per_froxel_with_transmission(
                                 shadow_normal_toward_light(material_color.normal, light_brdf.light_dir),
                                 view_z_for_shadow,
                             );
+                            if light.shadow_index != SHADOW_INDEX_NONE {
+                                visibility = visibility * apply_sscs(world_position, normalize(to_light), shadow_globals.sscs_params.w);
+                            }
                         }
                         color += direct * visibility;
                     {% else %}

--- a/packages/crates/renderer/src/render_passes/shared/shared_wgsl/shadow/bind_groups.wgsl
+++ b/packages/crates/renderer/src/render_passes/shared/shared_wgsl/shadow/bind_groups.wgsl
@@ -33,13 +33,20 @@ struct ShadowDescriptor {
 struct ShadowGlobals {
     // (atlas.w, atlas.h, evsm.w, evsm.h)
     atlas_sizes: vec4<f32>,
-    // (evsm_exponent, evsm_blur_radius, sscs_step_count, sscs_enabled)
+    // (evsm_exponent, evsm_blur_radius, _reserved, _reserved) — SSCS
+    // step_count + enabled moved to compile-time template constants (the
+    // `sscs_step_count` cache-key field folded into `sscs_available`), so
+    // .z / .w are now reserved padding.
     evsm_sscs: vec4<f32>,
     // (debug_cascade_colors, max_point_shadows, pad, pad)
     flags: vec4<u32>,
     // (cascade_array.w, cascade_array.h, max_layers, _) — per-layer
     // dimensions of the directional cascade texture array.
     cascade_array: vec4<f32>,
+    // (sscs_step_world, sscs_thickness, sscs_directional_darkening,
+    // sscs_punctual_darkening) — live-tunable SSCS scalar params (metres,
+    // metres, 0..1, 0..1). Loop-invariant in `apply_sscs`.
+    sscs_params: vec4<f32>,
 };
 
 struct ShadowDescriptorArray {
@@ -221,24 +228,23 @@ fn shadow_blocker_count(n: u32) -> u32 {
 // visibility — multiplied into the main shadow term to darken micro-
 // occluders that the shadow map misses (gaps under feet, hair, etc.).
 //
-// `shadow_globals.evsm_sscs.w` is the master enable; `.z` is the step
-// count. Uses single-sample depth reads even when the geometry pass
-// was rendered with MSAA (we read sample 0).
+// SSCS enable + step count are compile-time template constants now (folded
+// into `sscs_available` + baked as the loop bound; see `PrepPassConfig`).
+// Uses single-sample depth reads even when the geometry pass was rendered
+// with MSAA (we read sample 0).
 //
 // The transparent pass doesn't bind a `depth_tex` (sampling the
 // in-progress depth target on the same pass would be a feedback loop),
 // so its shader template sets `sscs_available = false` and this
 // function short-circuits to "fully lit" before any depth fetch.
-fn apply_sscs(world_pos: vec3<f32>, light_dir: vec3<f32>) -> f32 {
+fn apply_sscs(world_pos: vec3<f32>, light_dir: vec3<f32>, max_darkening: f32) -> f32 {
 {% if sscs_available %}
-    let enabled = shadow_globals.evsm_sscs.w;
-    if enabled < 0.5 {
-        return 1.0;
-    }
-    let steps = u32(max(shadow_globals.evsm_sscs.z, 1.0));
-    if steps == 0u {
-        return 1.0;
-    }
+    // `sscs_available` folds in the global `ShadowsConfig::sscs_enabled` at
+    // compile time, so a disabled config compiles this entire body out to the
+    // else-arm's `return 1.0` — SSCS off (the default) costs nothing.
+    // The step count is a baked compile-time constant (clamped >= 1 Rust-side),
+    // so the march bound is unroll-friendly with no per-fragment loop counter.
+    let steps: u32 = {{ sscs_step_count }}u;
 
     // SSCS — Screen-Space Contact Shadows. A short ray-march from
     // each receiver toward the light, sampling the geometry-pass
@@ -278,10 +284,20 @@ fn apply_sscs(world_pos: vec3<f32>, light_dir: vec3<f32>) -> f32 {
     // pixel-per-world ratio changes as the camera zooms, so a
     // fixed-pixel march samples different world positions every
     // frame even for the same surface).
-    let SSCS_STEP_WORLD: f32 = 0.04;          // 4 cm per step → 64 cm reach @ 16 steps
-    let SSCS_THICKNESS: f32 = 0.05;           // 5 cm slab counts as occluder
+    // Step length + occluder thickness are live-tunable global uniforms
+    // (`ShadowsConfig::sscs_step_world` / `sscs_thickness`, packed into
+    // `ShadowGlobals.sscs_params` by `Shadows::write_gpu`). They're
+    // loop-invariant, so the compiler hoists these reads out of the march —
+    // making them uniforms (vs. baked constants) costs nothing but buys
+    // recompile-free editor tuning. Total reach = step_world · step_count.
+    let SSCS_STEP_WORLD: f32 = shadow_globals.sscs_params.x;  // metres per step
+    let SSCS_THICKNESS: f32 = shadow_globals.sscs_params.y;   // occluder slab (m)
     let SSCS_SELF_OCCLUSION_EPS: f32 = 0.002; // 2 mm self-occlusion guard
-    let MAX_DARKENING: f32 = 0.35;            // SSCS is refinement, not shadow
+    // Darkening cap is a per-call parameter (`max_darkening`) sourced from the
+    // same uniform at the call sites: directional passes the conservative
+    // `sscs_params.z` refinement; punctual contacts (ball-on-floor "Peter Pan"
+    // donut) pass the higher `sscs_params.w` since there the cube map leaves a
+    // fully-lit hole SSCS must actually fill, not just nudge.
 
     let viewport_size = camera_raw.viewport.zw;
     let depth_dim = vec2<i32>(viewport_size);
@@ -355,7 +371,7 @@ fn apply_sscs(world_pos: vec3<f32>, light_dir: vec3<f32>) -> f32 {
     }
 
     let occluded = hits / f32(steps);
-    return 1.0 - occluded * MAX_DARKENING;
+    return 1.0 - occluded * max_darkening;
 {% else %}
     return 1.0;
 {% endif %}
@@ -449,7 +465,18 @@ fn sample_shadow_cube(desc: ShadowDescriptor, world_pos: vec3<f32>, world_normal
     let range = max(desc.atlas_rect.w, 0.01);
     let slot = i32(desc.cascade_info.y);
 
-    let biased_pos = world_pos + world_normal * desc.bias_params.y;
+    // Incidence-scaled normal offset. The normal-offset bias only fights acne
+    // through its component PERPENDICULAR to the light ray; its along-ray
+    // component is pure peter-panning. On a light-facing receiver (n·d → 1) that
+    // along-ray part is the WHOLE offset AND there's ~no acne to fight, so a
+    // fixed normal offset lifts the receiver clean off a resting caster into a
+    // lit "donut" under the mesh. Scale by the incidence slope from the UNbiased
+    // surface point (`min(tan, 1)`: 0 when facing → no donut, full by 45° so
+    // grazing acne stays covered, never exceeds the authored `normal_bias`).
+    let dir0 = normalize(world_pos - light_pos);
+    let ndd0 = abs(dot(dir0, world_normal));
+    let nbias_slope = min(sqrt(max(1.0 - ndd0 * ndd0, 0.0)) / max(ndd0, 0.05), 1.0);
+    let biased_pos = world_pos + world_normal * desc.bias_params.y * nbias_slope;
     let light_to_surface = biased_pos - light_pos;
     let dist = length(light_to_surface);
     if dist >= range {
@@ -488,8 +515,21 @@ fn sample_shadow_cube(desc: ShadowDescriptor, world_pos: vec3<f32>, world_normal
         / max(view_depth * view_depth, near * near);
     let texel_world = 2.0 * view_depth / cube_face_res;
     let n_dot_dir = abs(dot(dir, world_normal));
-    let world_bias = desc.bias_params.x / max(n_dot_dir, 0.05)
-        + texel_world * desc.cascade_info.x;
+    // Receiver-plane slope factor for the quantization slack. The depth error
+    // from a 1-texel lateral misplacement is `texel_world · tan(incidence)`, so
+    // the slack must VANISH where the receiver faces the light (tan → 0) — that
+    // flat-contact case is exactly where a constant slack lifts the receiver off
+    // its caster into a lit "donut" under the mesh. `tan = √(1−n·d²)/(n·d)`,
+    // clamped to ≤1 so it never EXCEEDS the old constant: grazing keeps full
+    // flat-floor-acne protection, only near-facing receivers relax. (The authored
+    // `depth_bias` term keeps its own separate `1/n·d` slope-scaling.)
+    // Incidence tangent (receiver-plane). `depth_bias` grows with it (as its old
+    // `1/n·d` did) but now VANISHES on a light-facing contact instead of flooring
+    // at the authored value → no donut; the fixed-distance texel slack rides the
+    // same tangent, clamped to ≤1× so grazing flat-floor acne stays covered.
+    let inc_tan = sqrt(max(1.0 - n_dot_dir * n_dot_dir, 0.0)) / max(n_dot_dir, 0.05);
+    let world_bias = desc.bias_params.x * inc_tan
+        + texel_world * desc.cascade_info.x * min(inc_tan, 1.0);
     let ref_depth = clamp(ndc_z, 0.0, 1.0) - world_bias * grad;
     let hardness = desc.bias_params.z;
 
@@ -562,8 +602,12 @@ fn sample_shadow_cube(desc: ShadowDescriptor, world_pos: vec3<f32>, world_normal
             let tap_grad = (range / (range - near)) * near
                 / max(tap_view_depth * tap_view_depth, near * near);
             let tap_texel_world = 2.0 * tap_view_depth / cube_face_res;
-            let tap_world_bias = desc.bias_params.x / max(tap_n_dot_dir, 0.05)
-                + tap_texel_world * desc.cascade_info.x;
+            // Receiver-plane slope factor (see the central block) — the slack
+            // vanishes on light-facing taps and never exceeds the old constant.
+            let tap_inc_tan = sqrt(max(1.0 - tap_n_dot_dir * tap_n_dot_dir, 0.0))
+                / max(tap_n_dot_dir, 0.05);
+            let tap_world_bias = desc.bias_params.x * tap_inc_tan
+                + tap_texel_world * desc.cascade_info.x * min(tap_inc_tan, 1.0);
             let tap_ref = clamp(tap_ndc_z, 0.0, 1.0) - tap_world_bias * tap_grad;
             sum += textureSampleCompareLevel(
                 shadow_cube_array,
@@ -659,10 +703,17 @@ fn sample_shadow_cube(desc: ShadowDescriptor, world_pos: vec3<f32>, world_normal
             vec2<i32>(cube_dims.xy) - vec2<i32>(1, 1),
         );
         let d = textureLoad(shadow_cube_2d_array, tex_xy, layer, 0);
-        // Bias-free blocker test — we want a clean estimate of how
-        // many genuine occluders sit in front of the receiver. The
-        // 0.0005 epsilon matches the directional PCSS path.
-        if d < tap_ndc_z - 0.0005 {
+        // Skip-self epsilon in WORLD space (~2 receiver texels) converted to
+        // NDC.z through the same `texel_world`/`grad` framework as the receiver
+        // bias above. A hardcoded NDC epsilon is the perspective trap `a9cd12dd`
+        // world-referenced on the cascade path but LEFT here: on the perspective
+        // cube path a constant `0.0005` NDC balloons into a large world depth at
+        // a few-metre light (~3.7 m in the physics template), so the search
+        // rejects the genuine near-contact occluder, `blocker_count` collapses,
+        // and the `blocker_count == 0` early-out below returns 1.0 (fully lit) —
+        // a lit "donut"/hole in the contact shadow directly under a mesh.
+        // World-referencing keeps it a fixed small offset at any light distance.
+        if d < tap_ndc_z - 2.0 * texel_world * grad {
             blocker_sum = blocker_sum + d;
             blocker_count = blocker_count + 1u;
         }
@@ -716,8 +767,12 @@ fn sample_shadow_cube(desc: ShadowDescriptor, world_pos: vec3<f32>, world_normal
         let tap_grad = (range / (range - near)) * near
             / max(tap_view_depth * tap_view_depth, near * near);
         let tap_texel_world = 2.0 * tap_view_depth / cube_face_res;
-        let tap_world_bias = desc.bias_params.x / max(tap_n_dot_dir, 0.05)
-            + tap_texel_world * desc.cascade_info.x;
+        // Receiver-plane slope factor (see the central block) — the slack
+        // vanishes on light-facing taps and never exceeds the old constant.
+        let tap_inc_tan = sqrt(max(1.0 - tap_n_dot_dir * tap_n_dot_dir, 0.0))
+            / max(tap_n_dot_dir, 0.05);
+        let tap_world_bias = desc.bias_params.x * tap_inc_tan
+            + tap_texel_world * desc.cascade_info.x * min(tap_inc_tan, 1.0);
         let tap_ref = clamp(tap_ndc_z, 0.0, 1.0) - tap_world_bias * tap_grad;
         sum += textureSampleCompareLevel(
             shadow_cube_array,

--- a/packages/crates/renderer/src/renderer.rs
+++ b/packages/crates/renderer/src/renderer.rs
@@ -2107,6 +2107,8 @@ impl AwsmRendererBuilder {
                     color_wgsl,
                     None,
                     prep_config.clamped_k(),
+                    prep_config.sscs_enabled,
+                    prep_config.sscs_step_count,
                 )
                 .await?;
         }
@@ -2586,6 +2588,8 @@ impl AwsmRenderer {
                     msaa_sample_count: None,
                     mipmaps: false,
                     max_shadow_casters: 4,
+                    sscs_enabled: self.prep_config.sscs_enabled,
+                    sscs_step_count: self.prep_config.sscs_step_count,
                     shader_id,
                     base: ShadingBase::Custom,
                     owns_skybox: false,

--- a/packages/crates/renderer/src/shader_completeness.rs
+++ b/packages/crates/renderer/src/shader_completeness.rs
@@ -127,6 +127,8 @@ fn opaque_compute_defines_every_called_loader_per_base() {
             msaa_sample_count: Some(4),
             mipmaps: true,
             max_shadow_casters: 4,
+            sscs_enabled: false,
+            sscs_step_count: 16,
             shader_id,
             base,
             owns_skybox: false,

--- a/packages/crates/renderer/src/shadows/api.rs
+++ b/packages/crates/renderer/src/shadows/api.rs
@@ -65,6 +65,23 @@ impl AwsmRenderer {
     /// (SSCS toggle, blur radius, exponent, debug overlay) take
     /// effect on the next `render()` call.
     pub fn set_shadows_config(&mut self, config: ShadowsConfig) {
+        // SSCS `enabled` + `step_count` drive the shadow module's COMPILE-TIME
+        // template (see `PrepPassConfig`'s SSCS fields), so a change to either
+        // must re-key + recompile the material pipelines — exactly like
+        // `set_anti_aliasing`. Mirror the two into `prep_config` (the carrier
+        // threaded to every shadow-consuming pipeline build); when they change,
+        // flag the material-variant reconcile so the caller's next `commit_load`
+        // recompiles (prep rebuilds lazily from its per-frame key). The SSCS
+        // *scalar* params ride `ShadowGlobals` and just re-upload via the
+        // `set_config` dirty flag below — no recompile.
+        let recompile = self.prep_config.sscs_enabled != config.sscs_enabled
+            || self.prep_config.sscs_step_count != config.sscs_step_count;
+        self.prep_config.sscs_enabled = config.sscs_enabled;
+        self.prep_config.sscs_step_count = config.sscs_step_count;
+        if recompile {
+            self.last_ensured_bucket_layout = None;
+            self.materials.mark_variants_dirty();
+        }
         self.shadows.set_config(config);
     }
 

--- a/packages/crates/renderer/src/shadows/config.rs
+++ b/packages/crates/renderer/src/shadows/config.rs
@@ -15,6 +15,16 @@ pub struct ShadowsConfig {
     pub sscs_enabled: bool,
     /// Number of screen-space ray-march steps for SSCS.
     pub sscs_step_count: u32,
+    /// World-space length of each SSCS ray-march step, in metres. Total
+    /// reach = `sscs_step_world · sscs_step_count`.
+    pub sscs_step_world: f32,
+    /// SSCS occluder-slab thickness in metres — a scene texel this far or
+    /// less in front of the ray counts as an occluder.
+    pub sscs_thickness: f32,
+    /// Max SSCS darkening for the directional shadow term (0..1).
+    pub sscs_directional_darkening: f32,
+    /// Max SSCS darkening for punctual (point/spot) shadow terms (0..1).
+    pub sscs_punctual_darkening: f32,
     /// Width / height (square) of the 2D PCF/PCSS shadow atlas in
     /// texels. Must be a power of two.
     pub atlas_size: u32,
@@ -72,6 +82,10 @@ impl Default for ShadowsConfig {
         Self {
             sscs_enabled: false,
             sscs_step_count: 16,
+            sscs_step_world: 0.04,
+            sscs_thickness: 0.05,
+            sscs_directional_darkening: 0.35,
+            sscs_punctual_darkening: 0.9,
             atlas_size: 4096,
             evsm_atlas_size: 2048,
             cascade_resolution: 2048,

--- a/packages/crates/renderer/src/shadows/consts.rs
+++ b/packages/crates/renderer/src/shadows/consts.rs
@@ -27,10 +27,14 @@ pub const SHADOW_DESCRIPTOR_BYTES: usize = 128;
 
 /// Size in bytes of the `ShadowGlobals` uniform block. Layout:
 /// - `atlas_sizes: vec4<f32>` (16 B) — `(pcf.w, pcf.h, evsm.w, evsm.h)`
-/// - `evsm_sscs: vec4<f32>` (16 B)
+/// - `evsm_sscs: vec4<f32>` (16 B) — `(evsm_exponent, evsm_blur_radius, _, _)`;
+///   SSCS step_count + enabled are now compile-time template constants, so
+///   `.z` / `.w` are reserved padding.
 /// - `flags: vec4<u32>` (16 B)
 /// - `cascade_array: vec4<f32>` (16 B) — `(layer.w, layer.h, max_layers, _)`
-pub const SHADOW_GLOBALS_BYTES: usize = 64;
+/// - `sscs_params: vec4<f32>` (16 B) — `(step_world, thickness,
+///   directional_darkening, punctual_darkening)`, live-tunable SSCS scalars.
+pub const SHADOW_GLOBALS_BYTES: usize = 80;
 
 /// Logical size of a single per-view shadow uniform entry: a
 /// `mat4x4` view-projection (64 B) and a `vec4` of bias parameters

--- a/packages/crates/renderer/src/shadows/light_shadow.rs
+++ b/packages/crates/renderer/src/shadows/light_shadow.rs
@@ -83,16 +83,23 @@ impl Default for LightShadowParams {
     fn default() -> Self {
         Self {
             cast: false,
-            depth_bias: 0.0005,
-            // ~2-3 shadow texels of world push-back. Was 0.05 (≈7 texels),
-            // which visibly Peter-Panned a hole into contact shadows under a
-            // resting/settling mesh; lowered once depth_bias went world-
-            // referenced and stopped over-biasing on its own. See the field doc.
-            normal_bias: 0.02,
+            // Slope-scaled by the shadow shader's receiver-plane `inc_tan`
+            // (→ 0 on light-facing receivers); cleans contact-edge acne without
+            // Peter-Panning. Keep in sync with scene `LightShadowConfig::default`.
+            depth_bias: 0.0015,
+            // Small normal-offset. Was 0.05 → 0.02 → 0.01: each step Peter-Panned
+            // a lit "donut" into the contact shadow under a resting/settling mesh
+            // (a small caster tangent to the floor turns mm of bias into cm of
+            // hole). With the shader's `inc_tan` slope-scaling now carrying the
+            // load, 0.01 keeps grazing/terminator acne cover while staying
+            // donut-safe by default. See the field doc.
+            normal_bias: 0.01,
             resolution: 1024,
             hardness: LightShadowHardness::Soft,
             pcss_penumbra_scale: 1.0,
-            kernel_slack: 2.0,
+            // Quantization slack, halved 2.0 → 1.0 (second donut driver at
+            // moderate-incidence contacts). inc_tan-scaled in the shader.
+            kernel_slack: 1.0,
             shadow_samples: 16,
             max_distance: 0.0,
             cascade_count: 4,

--- a/packages/crates/renderer/src/shadows/light_shadow.rs
+++ b/packages/crates/renderer/src/shadows/light_shadow.rs
@@ -83,23 +83,26 @@ impl Default for LightShadowParams {
     fn default() -> Self {
         Self {
             cast: false,
-            // Slope-scaled by the shadow shader's receiver-plane `inc_tan`
-            // (→ 0 on light-facing receivers); cleans contact-edge acne without
-            // Peter-Panning. Keep in sync with scene `LightShadowConfig::default`.
-            depth_bias: 0.0015,
-            // Small normal-offset. Was 0.05 → 0.02 → 0.01: each step Peter-Panned
-            // a lit "donut" into the contact shadow under a resting/settling mesh
-            // (a small caster tangent to the floor turns mm of bias into cm of
-            // hole). With the shader's `inc_tan` slope-scaling now carrying the
-            // load, 0.01 keeps grazing/terminator acne cover while staying
-            // donut-safe by default. See the field doc.
-            normal_bias: 0.01,
+            // Depth-bias-ONLY shadow biasing (donut-free default). Slope-scaled by
+            // the shader's receiver-plane `inc_tan` (→ 0 on light-facing
+            // receivers), so this cleans the contact edge without Peter-Panning.
+            // `normal_bias` + `kernel_slack` both default to 0: each of them
+            // over-biases the grazing lower hemisphere of a resting caster into a
+            // lit "donut" ring, and a systematic one-term-at-a-time sweep plus
+            // live tuning both landed on depth-only. Keep in sync with scene
+            // `LightShadowConfig::default`.
+            depth_bias: 0.001,
+            // 0 by default — a donut driver (see depth_bias). Per-light knob to
+            // add back a touch of normal-offset if grazing/terminator acne appears
+            // on very different geometry.
+            normal_bias: 0.0,
             resolution: 1024,
             hardness: LightShadowHardness::Soft,
             pcss_penumbra_scale: 1.0,
-            // Quantization slack, halved 2.0 → 1.0 (second donut driver at
-            // moderate-incidence contacts). inc_tan-scaled in the shader.
-            kernel_slack: 1.0,
+            // 0 by default — the second donut driver (quantization slack over-
+            // biases moderate-incidence contacts). Per-light knob if flat-receiver
+            // acne ever needs it.
+            kernel_slack: 0.0,
             shadow_samples: 16,
             max_distance: 0.0,
             cascade_count: 4,

--- a/packages/crates/renderer/src/shadows/schema_convert.rs
+++ b/packages/crates/renderer/src/shadows/schema_convert.rs
@@ -38,6 +38,10 @@ impl From<schema::ShadowsConfig> for ShadowsConfig {
         Self {
             sscs_enabled: s.sscs_enabled,
             sscs_step_count: s.sscs_step_count,
+            sscs_step_world: s.sscs_step_world,
+            sscs_thickness: s.sscs_thickness,
+            sscs_directional_darkening: s.sscs_directional_darkening,
+            sscs_punctual_darkening: s.sscs_punctual_darkening,
             atlas_size: s.atlas_size,
             evsm_atlas_size: s.evsm_atlas_size,
             evsm_exponent: s.evsm_exponent,

--- a/packages/crates/renderer/src/shadows/state.rs
+++ b/packages/crates/renderer/src/shadows/state.rs
@@ -1682,8 +1682,10 @@ impl Shadows {
                 .clamp(0.5, ShadowsConfig::EVSM_EXPONENT_MAX_FP16);
             data[16..20].copy_from_slice(&evsm_exponent.to_ne_bytes());
             data[20..24].copy_from_slice(&(self.config.evsm_blur_radius as f32).to_ne_bytes());
-            data[24..28].copy_from_slice(&(self.config.sscs_step_count as f32).to_ne_bytes());
-            data[28..32].copy_from_slice(&(self.config.sscs_enabled as u32 as f32).to_ne_bytes());
+            // evsm_sscs.z / .w (bytes 24..32) are reserved: SSCS step_count +
+            // enabled are now compile-time template constants (folded into the
+            // shadow module's `sscs_available` gate + baked loop bound), not
+            // uniform reads. Left zeroed.
             data[32..36].copy_from_slice(&(self.config.debug_cascade_colors as u32).to_ne_bytes());
             data[36..40].copy_from_slice(&self.config.max_point_shadows.to_ne_bytes());
             // `flags.z` / `flags.w` are reserved padding (see the
@@ -1695,6 +1697,13 @@ impl Shadows {
             data[52..56].copy_from_slice(&cascade_size.to_ne_bytes());
             data[56..60].copy_from_slice(&(self.cascade_max_layers as f32).to_ne_bytes());
             data[60..64].copy_from_slice(&0.0_f32.to_ne_bytes());
+            // sscs_params vec4: live-tunable SSCS scalars (step_world, thickness,
+            // directional_darkening, punctual_darkening). Loop-invariant reads in
+            // `apply_sscs`; a scalar-only change re-uploads this without recompiling.
+            data[64..68].copy_from_slice(&self.config.sscs_step_world.to_ne_bytes());
+            data[68..72].copy_from_slice(&self.config.sscs_thickness.to_ne_bytes());
+            data[72..76].copy_from_slice(&self.config.sscs_directional_darkening.to_ne_bytes());
+            data[76..80].copy_from_slice(&self.config.sscs_punctual_darkening.to_ne_bytes());
             let n = data.len();
             self.globals_uploader.write_dirty_ranges(
                 gpu,

--- a/packages/crates/renderer/src/wgsl_validation.rs
+++ b/packages/crates/renderer/src/wgsl_validation.rs
@@ -75,6 +75,8 @@ fn first_party_key_prep(
         msaa_sample_count: msaa,
         mipmaps,
         max_shadow_casters: 4,
+        sscs_enabled: false,
+        sscs_step_count: 16,
         shader_id,
         base,
         owns_skybox,
@@ -104,6 +106,8 @@ fn custom_key(
         msaa_sample_count: msaa,
         mipmaps,
         max_shadow_casters: 4,
+        sscs_enabled: false,
+        sscs_step_count: 16,
         shader_id: dyn_id,
         base: ShadingBase::Custom,
         owns_skybox: false,
@@ -132,6 +136,46 @@ fn render(key: &ShaderCacheKeyMaterialOpaque, label: &str) -> String {
 }
 
 const CONFIGS: [(Option<u32>, bool); 3] = [(None, true), (None, false), (Some(4), true)];
+
+#[test]
+fn sscs_enabled_shaders_validate() {
+    // Every other validation test renders the SSCS-OFF variant (sscs_available is
+    // false → `apply_sscs` compiles to `return 1.0`). This one exercises the
+    // SSCS-ON path: the compile-time `{{ sscs_step_count }}` march bound and the
+    // `sscs_params` uniform reads must produce valid WGSL across step counts
+    // (incl. the clamped-minimum 1) for both prep and opaque.
+    use crate::render_passes::material_prep::shader::cache_key::ShaderCacheKeyMaterialPrep;
+    use crate::render_passes::material_prep::shader::template::ShaderTemplateMaterialPrep;
+
+    for step_count in [1u32, 8, 32] {
+        for msaa in [None, Some(4u32)] {
+            // Prep owns the punctual + directional `apply_sscs` call sites.
+            let label = format!("sscs-on prep step={step_count} msaa={msaa:?}");
+            let src = ShaderTemplateMaterialPrep::try_from(&ShaderCacheKeyMaterialPrep {
+                msaa_sample_count: msaa,
+                max_shadow_casters: 4,
+                sscs_enabled: true,
+                sscs_step_count: step_count,
+            })
+            .unwrap_or_else(|e| panic!("{label}: template build failed: {e:?}"))
+            .into_source()
+            .unwrap_or_else(|e| panic!("{label}: render failed: {e:?}"));
+            naga_validate(&src, &label);
+            assert!(
+                src.contains("sscs_params"),
+                "{label}: SSCS-on body should read the sscs_params uniform"
+            );
+
+            // Opaque (first-party PBR bucket) with SSCS enabled.
+            let label = format!("sscs-on opaque step={step_count} msaa={msaa:?}");
+            let mut key =
+                first_party_key(MaterialShaderId::PBR, ShadingBase::Pbr, false, msaa, false);
+            key.sscs_enabled = true;
+            key.sscs_step_count = step_count;
+            naga_validate(&render(&key, &label), &label);
+        }
+    }
+}
 
 #[test]
 fn first_party_opaque_shaders_validate() {
@@ -562,6 +606,8 @@ fn material_prep_shader_validates() {
         let src = ShaderTemplateMaterialPrep::try_from(&ShaderCacheKeyMaterialPrep {
             msaa_sample_count: msaa,
             max_shadow_casters: 4,
+            sscs_enabled: false,
+            sscs_step_count: 16,
         })
         .unwrap_or_else(|e| panic!("{label}: template build failed: {e:?}"))
         .into_source()
@@ -648,6 +694,8 @@ fn custom_froxel_lights_accessors_validate() {
             msaa_sample_count: msaa,
             mipmaps: mips,
             max_shadow_casters: 4,
+            sscs_enabled: false,
+            sscs_step_count: 16,
             shader_id: dyn_id,
             base: ShadingBase::Custom,
             owns_skybox: false,

--- a/packages/crates/scene/src/light.rs
+++ b/packages/crates/scene/src/light.rs
@@ -105,24 +105,25 @@ impl Default for LightShadowConfig {
     fn default() -> Self {
         Self {
             cast: true,
-            // Small world-referenced depth push-back; slope-scaled by the
-            // receiver-plane `inc_tan` in the shadow shader (→ 0 on light-facing
-            // receivers), so it cleans contact-edge acne without Peter-Panning.
-            depth_bias: 0.0015,
-            // Small normal-offset. Was 0.05 → 0.02 → 0.01: each `normal_bias`
-            // step Peter-Panned a lit "donut" into the contact shadow under a
-            // resting mesh (a small caster tangent to the floor amplifies mm of
-            // bias into cm of hole). With the `inc_tan` slope-scaling now doing
-            // the heavy lifting, 0.01 keeps grazing/terminator acne protection
-            // while staying donut-safe out of the box. Keep in sync with
-            // `default_normal_bias()` + renderer `LightShadowParams::default`.
-            normal_bias: 0.01,
+            // Depth-bias-ONLY shadow biasing (donut-free default). Slope-scaled by
+            // the receiver-plane `inc_tan` in the shadow shader (→ 0 on
+            // light-facing receivers), so it cleans the contact edge without
+            // Peter-Panning. Keep in sync with `default_depth_bias()` + renderer
+            // `LightShadowParams::default`.
+            depth_bias: 0.001,
+            // 0 by default — a donut driver: any normal-offset Peter-Pans a lit
+            // "donut" ring into the contact shadow under a resting mesh (a small
+            // caster tangent to the floor amplifies mm of bias into cm of hole).
+            // A one-term-at-a-time sweep + live tuning both landed on depth-only.
+            // Per-light knob to add back if grazing/terminator acne shows up.
+            normal_bias: 0.0,
             resolution: 1024,
             hardness: LightShadowHardness::Soft,
             pcss_penumbra_scale: 1.0,
-            // Quantization slack, halved 2.0 → 1.0: the full 2× slack was a
-            // second donut driver at moderate-incidence contacts. inc_tan-scaled.
-            kernel_slack: 1.0,
+            // 0 by default — the second donut driver (quantization slack
+            // over-biases moderate-incidence contacts). Per-light knob if flat-
+            // receiver acne ever needs it.
+            kernel_slack: 0.0,
             shadow_samples: default_shadow_samples(),
             max_distance: 0.0,
             cascade_count: 4,
@@ -205,10 +206,10 @@ fn default_true() -> bool {
     true
 }
 fn default_depth_bias() -> f32 {
-    0.0015
+    0.001
 }
 fn default_normal_bias() -> f32 {
-    0.01
+    0.0
 }
 fn default_shadow_res() -> u32 {
     1024
@@ -217,7 +218,7 @@ fn default_pcss_scale() -> f32 {
     1.0
 }
 fn default_kernel_slack() -> f32 {
-    1.0
+    0.0
 }
 fn default_shadow_samples() -> u32 {
     16

--- a/packages/crates/scene/src/light.rs
+++ b/packages/crates/scene/src/light.rs
@@ -105,16 +105,24 @@ impl Default for LightShadowConfig {
     fn default() -> Self {
         Self {
             cast: true,
-            depth_bias: 0.0005,
-            // Modest normal-offset (~2-3 shadow texels). Was 0.05, which
-            // Peter-Panned a hole into contact shadows under a resting mesh;
-            // lowered once depth_bias became world-referenced. Keep in sync with
+            // Small world-referenced depth push-back; slope-scaled by the
+            // receiver-plane `inc_tan` in the shadow shader (→ 0 on light-facing
+            // receivers), so it cleans contact-edge acne without Peter-Panning.
+            depth_bias: 0.0015,
+            // Small normal-offset. Was 0.05 → 0.02 → 0.01: each `normal_bias`
+            // step Peter-Panned a lit "donut" into the contact shadow under a
+            // resting mesh (a small caster tangent to the floor amplifies mm of
+            // bias into cm of hole). With the `inc_tan` slope-scaling now doing
+            // the heavy lifting, 0.01 keeps grazing/terminator acne protection
+            // while staying donut-safe out of the box. Keep in sync with
             // `default_normal_bias()` + renderer `LightShadowParams::default`.
-            normal_bias: 0.02,
+            normal_bias: 0.01,
             resolution: 1024,
             hardness: LightShadowHardness::Soft,
             pcss_penumbra_scale: 1.0,
-            kernel_slack: 2.0,
+            // Quantization slack, halved 2.0 → 1.0: the full 2× slack was a
+            // second donut driver at moderate-incidence contacts. inc_tan-scaled.
+            kernel_slack: 1.0,
             shadow_samples: default_shadow_samples(),
             max_distance: 0.0,
             cascade_count: 4,
@@ -197,10 +205,10 @@ fn default_true() -> bool {
     true
 }
 fn default_depth_bias() -> f32 {
-    0.0005
+    0.0015
 }
 fn default_normal_bias() -> f32 {
-    0.02
+    0.01
 }
 fn default_shadow_res() -> u32 {
     1024
@@ -209,7 +217,7 @@ fn default_pcss_scale() -> f32 {
     1.0
 }
 fn default_kernel_slack() -> f32 {
-    2.0
+    1.0
 }
 fn default_shadow_samples() -> u32 {
     16

--- a/packages/crates/scene/src/shadows.rs
+++ b/packages/crates/scene/src/shadows.rs
@@ -29,6 +29,28 @@ pub struct ShadowsConfig {
     /// faithful contact darkening at the cost of fragment work.
     #[serde(default = "default_sscs_step_count")]
     pub sscs_step_count: u32,
+    /// World-space length of each SSCS ray-march step, in metres. Total
+    /// reach = `sscs_step_world · sscs_step_count`. World-space (not
+    /// pixel-space) so the same surface point samples the same world
+    /// positions every frame regardless of camera zoom.
+    #[serde(default = "default_sscs_step_world")]
+    pub sscs_step_world: f32,
+    /// SSCS occluder-slab thickness in metres: a depth-buffer texel this
+    /// far or less in front of the ray counts as an occluder. Larger
+    /// admits thicker casters (a resting ball) at the cost of over-
+    /// darkening behind thin geometry.
+    #[serde(default = "default_sscs_thickness")]
+    pub sscs_thickness: f32,
+    /// Maximum SSCS darkening for the DIRECTIONAL shadow term (0..1).
+    /// Conservative by default — directional SSCS is a refinement on top
+    /// of a cascade map that already covers the contact.
+    #[serde(default = "default_sscs_directional_darkening")]
+    pub sscs_directional_darkening: f32,
+    /// Maximum SSCS darkening for PUNCTUAL (point/spot) shadow terms
+    /// (0..1). Higher than directional because a cube shadow map leaves a
+    /// fully-lit contact "Peter-Pan" gap that SSCS must actually fill.
+    #[serde(default = "default_sscs_punctual_darkening")]
+    pub sscs_punctual_darkening: f32,
     /// 2D atlas size (square) for the PCF / spot / EVSM-source depth
     /// passes. Must be a power of two. The atlas auto-grows when the
     /// row-pack allocator overflows (capped at 8192).
@@ -72,6 +94,10 @@ impl Default for ShadowsConfig {
         Self {
             sscs_enabled: default_sscs_enabled(),
             sscs_step_count: default_sscs_step_count(),
+            sscs_step_world: default_sscs_step_world(),
+            sscs_thickness: default_sscs_thickness(),
+            sscs_directional_darkening: default_sscs_directional_darkening(),
+            sscs_punctual_darkening: default_sscs_punctual_darkening(),
             atlas_size: default_atlas_size(),
             evsm_atlas_size: default_evsm_atlas_size(),
             evsm_exponent: default_evsm_exponent(),
@@ -92,6 +118,18 @@ fn default_sscs_enabled() -> bool {
 }
 fn default_sscs_step_count() -> u32 {
     16
+}
+fn default_sscs_step_world() -> f32 {
+    0.04
+}
+fn default_sscs_thickness() -> f32 {
+    0.05
+}
+fn default_sscs_directional_darkening() -> f32 {
+    0.35
+}
+fn default_sscs_punctual_darkening() -> f32 {
+    0.9
 }
 fn default_atlas_size() -> u32 {
     4096

--- a/packages/frontend/editor/src/app.rs
+++ b/packages/frontend/editor/src/app.rs
@@ -533,6 +533,7 @@ fn settings_drawer() -> Dom {
                 ))
                 .render(),
         )
+        .child(shadows_section())
         .child(
             DrawerSection::new("Camera")
                 .child(html!("div", {
@@ -580,9 +581,111 @@ fn settings_drawer() -> Dom {
         )
         .child(html!("div", {
             .style("padding", "16px").style("font-size", "11px").style("color", "var(--text-3)").style("line-height", "1.5")
-            .text("Editor settings affect the viewport and chrome only \u{2014} they are not saved into the project file.")
+            .text("Most editor settings affect the viewport and chrome only and aren't saved. The Shadows section is part of the project \u{2014} it is saved into the file and the player bundle.")
         }))
         .render()
+}
+
+/// Global SSCS (screen-space contact shadows) controls. Unlike the ephemeral
+/// Viewport toggles, these persist: every change dispatches `SetShadowsSscs`,
+/// which merges into `scene.shadows` (serialized + bundled) and syncs live to
+/// the renderer. Seeded from the current `scene.shadows` when the drawer opens
+/// (the drawer is a transient popover, so seed-at-open is enough — no two-way
+/// binding needed).
+fn shadows_section() -> Dom {
+    let sh = controller().scene.shadows.get_cloned();
+
+    // `enabled` is compile-time (recompiles the shadow pipelines); route it
+    // through a Mutable so the standard `toggle` widget drives the dispatch.
+    let enabled = Mutable::new(sh.sscs_enabled);
+    spawn_local(clone!(enabled => async move {
+        let mut first = true;
+        enabled
+            .signal()
+            .for_each(move |on| {
+                let fire = !first;
+                first = false;
+                async move {
+                    if fire {
+                        dispatch_sscs(Some(on), None, None, None, None, None);
+                    }
+                }
+            })
+            .await;
+    }));
+
+    DrawerSection::new("Shadows")
+        .child(row("Contact shadows (SSCS)", toggle(enabled)))
+        .child(row(
+            "SSCS steps",
+            NumField::new(sh.sscs_step_count as f64)
+                .min(1.0)
+                .step(1.0)
+                .on_change(|v| dispatch_sscs(None, Some((v as u32).max(1)), None, None, None, None))
+                .render(),
+        ))
+        .child(row(
+            "Step length (m)",
+            NumField::new(sh.sscs_step_world as f64)
+                .min(0.0)
+                .step(0.005)
+                .on_change(|v| dispatch_sscs(None, None, Some(v as f32), None, None, None))
+                .render(),
+        ))
+        .child(row(
+            "Thickness (m)",
+            NumField::new(sh.sscs_thickness as f64)
+                .min(0.0)
+                .step(0.01)
+                .on_change(|v| dispatch_sscs(None, None, None, Some(v as f32), None, None))
+                .render(),
+        ))
+        .child(row(
+            "Directional darkening",
+            NumField::new(sh.sscs_directional_darkening as f64)
+                .min(0.0)
+                .max(1.0)
+                .step(0.05)
+                .on_change(|v| dispatch_sscs(None, None, None, None, Some(v as f32), None))
+                .render(),
+        ))
+        .child(row(
+            "Punctual darkening",
+            NumField::new(sh.sscs_punctual_darkening as f64)
+                .min(0.0)
+                .max(1.0)
+                .step(0.05)
+                .on_change(|v| dispatch_sscs(None, None, None, None, None, Some(v as f32)))
+                .render(),
+        ))
+        .render()
+}
+
+/// Dispatch a single-field (or multi-field) SSCS patch — only the `Some` fields
+/// change. Fire-and-forget; the `settings_sync` observer applies it live.
+fn dispatch_sscs(
+    enabled: Option<bool>,
+    step_count: Option<u32>,
+    step_world: Option<f32>,
+    thickness: Option<f32>,
+    directional_darkening: Option<f32>,
+    punctual_darkening: Option<f32>,
+) {
+    spawn_local(async move {
+        if let Err(e) = controller()
+            .dispatch(EditorCommand::SetShadowsSscs {
+                enabled,
+                step_count,
+                step_world,
+                thickness,
+                directional_darkening,
+                punctual_darkening,
+            })
+            .await
+        {
+            tracing::error!("SetShadowsSscs: {e}");
+        }
+    });
 }
 
 fn open_about() {

--- a/packages/frontend/editor/src/app.rs
+++ b/packages/frontend/editor/src/app.rs
@@ -615,6 +615,43 @@ fn shadows_section() -> Dom {
     }));
 
     DrawerSection::new("Shadows")
+        .right(settings_help_button(
+            "Contact shadows (SSCS)",
+            vec![
+                (
+                    "Contact shadows (SSCS)",
+                    "Screen-space contact shadows: a short view-space ray-march that darkens \
+                     the small contact gaps a shadow map misses (e.g. the lit gap right under \
+                     a resting object). Subtle by design; toggling recompiles the shadow \
+                     shaders. Global — saved into the project + player bundle.",
+                ),
+                (
+                    "SSCS steps",
+                    "How many samples the ray takes toward the light. More = longer reach and \
+                     smoother result, at more cost. Compile-time (changing it recompiles).",
+                ),
+                (
+                    "Step length (m)",
+                    "World distance per step, in metres. Total reach = step length × steps. \
+                     Small hugs the contact; large catches farther occluders.",
+                ),
+                (
+                    "Thickness (m)",
+                    "How thick an occluder can be and still count: a depth sample this far or \
+                     less in front of the ray is treated as a blocker. Raise it to catch \
+                     chunky objects (a ball needs ~0.3); too high over-darkens thin geometry.",
+                ),
+                (
+                    "Directional darkening",
+                    "Maximum darkening (0–1) SSCS applies under a directional (sun) light.",
+                ),
+                (
+                    "Punctual darkening",
+                    "Maximum darkening (0–1) under point/spot lights — usually higher than \
+                     directional, since a cube shadow map leaves a wider lit contact gap.",
+                ),
+            ],
+        ))
         .child(row("Contact shadows (SSCS)", toggle(enabled)))
         .child(row(
             "SSCS steps",

--- a/packages/frontend/editor/src/controller/state.rs
+++ b/packages/frontend/editor/src/controller/state.rs
@@ -2718,6 +2718,46 @@ impl EditorController {
                 self.scene.bump_revision();
                 Ok(Some(EditorCommand::SetEnvironment { env: prev }))
             }
+            EditorCommand::SetShadowsSscs {
+                enabled,
+                step_count,
+                step_world,
+                thickness,
+                directional_darkening,
+                punctual_darkening,
+            } => {
+                let prev = self.scene.shadows.get_cloned();
+                let mut next = prev.clone();
+                if let Some(v) = enabled {
+                    next.sscs_enabled = v;
+                }
+                if let Some(v) = step_count {
+                    next.sscs_step_count = v.max(1);
+                }
+                if let Some(v) = step_world {
+                    next.sscs_step_world = v;
+                }
+                if let Some(v) = thickness {
+                    next.sscs_thickness = v;
+                }
+                if let Some(v) = directional_darkening {
+                    next.sscs_directional_darkening = v;
+                }
+                if let Some(v) = punctual_darkening {
+                    next.sscs_punctual_darkening = v;
+                }
+                self.scene.shadows.set(next);
+                self.scene.bump_revision();
+                // Inverse restores every SSCS field to its prior value.
+                Ok(Some(EditorCommand::SetShadowsSscs {
+                    enabled: Some(prev.sscs_enabled),
+                    step_count: Some(prev.sscs_step_count),
+                    step_world: Some(prev.sscs_step_world),
+                    thickness: Some(prev.sscs_thickness),
+                    directional_darkening: Some(prev.sscs_directional_darkening),
+                    punctual_darkening: Some(prev.sscs_punctual_darkening),
+                }))
+            }
             EditorCommand::SnapCameraToAxis { axis } => {
                 use std::f32::consts::PI;
                 // Just under ±90° for top/bottom to dodge the look-at gimbal.

--- a/packages/frontend/editor/src/controller/state.rs
+++ b/packages/frontend/editor/src/controller/state.rs
@@ -96,6 +96,16 @@ pub struct EditorController {
     /// refreshes which rows exist — while a continuous numeric scrub, which
     /// keeps the structure key constant, never tears out the field being dragged.
     pub structure_rev: Mutable<u64>,
+    /// Bumps after every mutation that arrives from OUTSIDE the local UI — i.e.
+    /// the MCP / remote dispatch path (see `remote.rs`). The inspector rebuilds
+    /// on this so the seed-once property widgets (light/shadow/material/etc.,
+    /// which read their node's value once at build time and are otherwise
+    /// one-way) re-seed from the freshly-mutated `node.kind`. Local UI edits do
+    /// NOT bump this (they own the value they just typed), so an in-progress
+    /// numeric scrub is never torn out by its own dispatch — only an external
+    /// (agent) edit forces the refresh. Kept separate from `structure_rev` so
+    /// the "structure changed" meaning stays precise.
+    pub external_rev: Mutable<u64>,
     /// Whether the Content Browser bottom drawer is expanded. Pure view state
     /// (not project/undo state), held here so the ribbon toggle, the drawer, and
     /// the workspace layout share one source of truth.
@@ -226,6 +236,7 @@ impl EditorController {
             can_undo: Mutable::new(false),
             can_redo: Mutable::new(false),
             structure_rev: Mutable::new(0),
+            external_rev: Mutable::new(0),
             content_browser_open: Mutable::new(false),
             active_camera: Mutable::new(None),
             asset_selection: Mutable::new(None),
@@ -251,6 +262,16 @@ impl EditorController {
     }
 
     /// The single entry point. UI handlers build a command and dispatch it here;
+    /// Force the inspector to re-seed its property widgets. Call this after a
+    /// mutation that did NOT originate from a local UI widget (the MCP / remote
+    /// path) so the seed-once light/shadow/material inspectors pick up the new
+    /// `node.kind` values. Local edits skip this — their widgets already hold the
+    /// value the user typed, so bumping here would tear an in-progress scrub.
+    pub fn note_external_mutation(&self) {
+        self.external_rev
+            .set(self.external_rev.get().wrapping_add(1));
+    }
+
     /// async because some commands await the renderer / FS / network.
     pub async fn dispatch(&self, cmd: EditorCommand) -> EditorResult<()> {
         let transient = cmd.is_transient();

--- a/packages/frontend/editor/src/engine/settings_sync.rs
+++ b/packages/frontend/editor/src/engine/settings_sync.rs
@@ -91,4 +91,50 @@ pub fn start() {
             })
             .await;
     });
+
+    // Global SSCS (screen-space contact shadows): the authored, persisted
+    // `scene.shadows` SSCS fields → renderer. `enabled` / `step_count` are
+    // compile-time template constants, so they can recompile the shadow-consuming
+    // pipelines — route through `commit_load` (a no-op when nothing got flagged);
+    // the scalar params are live uniforms and just re-upload. Guarded against
+    // redundant applies so unrelated `scene.shadows` edits don't churn.
+    spawn_local(async {
+        let mut first = true;
+        controller()
+            .scene
+            .shadows
+            .signal_cloned()
+            .for_each(move |sh| {
+                let skip = first;
+                first = false;
+                async move {
+                    if skip {
+                        return;
+                    }
+                    let handle = renderer_handle();
+                    let mut r = handle.lock().await;
+                    let mut cfg = r.shadows_config().clone();
+                    let changed = cfg.sscs_enabled != sh.sscs_enabled
+                        || cfg.sscs_step_count != sh.sscs_step_count
+                        || cfg.sscs_step_world != sh.sscs_step_world
+                        || cfg.sscs_thickness != sh.sscs_thickness
+                        || cfg.sscs_directional_darkening != sh.sscs_directional_darkening
+                        || cfg.sscs_punctual_darkening != sh.sscs_punctual_darkening;
+                    if !changed {
+                        return;
+                    }
+                    cfg.sscs_enabled = sh.sscs_enabled;
+                    cfg.sscs_step_count = sh.sscs_step_count;
+                    cfg.sscs_step_world = sh.sscs_step_world;
+                    cfg.sscs_thickness = sh.sscs_thickness;
+                    cfg.sscs_directional_darkening = sh.sscs_directional_darkening;
+                    cfg.sscs_punctual_darkening = sh.sscs_punctual_darkening;
+                    r.set_shadows_config(cfg);
+                    if let Err(e) = r.commit_load(|_| {}).await {
+                        tracing::warn!("commit_load after SSCS change: {e}");
+                    }
+                }
+            })
+            .await;
+    });
 }

--- a/packages/frontend/editor/src/remote.rs
+++ b/packages/frontend/editor/src/remote.rs
@@ -368,7 +368,13 @@ async fn dispatch(req: Request) -> Response {
             crate::engine::activity_feed::narrate(&cmd);
             follow_agent_mode(crate::engine::activity_feed::command_mode(&cmd));
             match ctrl.dispatch(cmd).await {
-                Ok(()) => Response::Ok,
+                Ok(()) => {
+                    // External (agent) edit → re-seed the inspector's seed-once
+                    // property widgets from the mutated node.kind. Local UI edits
+                    // don't hit this path, so scrubs are never torn.
+                    ctrl.note_external_mutation();
+                    Response::Ok
+                }
                 Err(e) => Response::Err(format!("{e}")),
             }
         }
@@ -379,7 +385,10 @@ async fn dispatch(req: Request) -> Response {
                     .find_map(crate::engine::activity_feed::command_mode),
             );
             match ctrl.dispatch_batch(cmds).await {
-                Ok(()) => Response::Ok,
+                Ok(()) => {
+                    ctrl.note_external_mutation();
+                    Response::Ok
+                }
                 Err(e) => Response::Err(format!("{e}")),
             }
         }

--- a/packages/frontend/editor/src/scene_mode/inspector.rs
+++ b/packages/frontend/editor/src/scene_mode/inspector.rs
@@ -47,14 +47,17 @@ fn node_panel() -> Dom {
         .child(html!("div", {
             .style("flex", "1")
             .style("overflow-y", "auto")
-            // Rebuild on selection change OR a *structural* kind change
+            // Rebuild on selection change, a *structural* kind change
             // (`structure_rev` — a discrete PBR↔Unlit / Persp↔Ortho toggle that
-            // changes which rows exist). A continuous numeric scrub keeps the
-            // structure key constant, so the field being dragged is never torn
-            // out mid-drag by its own dispatched edits.
+            // changes which rows exist), OR an external/MCP edit (`external_rev`)
+            // so the seed-once property widgets re-seed from the mutated
+            // node.kind. A continuous *local* numeric scrub bumps neither rev, so
+            // the field being dragged is never torn out mid-drag by its own
+            // dispatched edits.
             .child_signal(map_ref! {
                 let sel = ctrl.selected.signal_cloned(),
-                let _rev = ctrl.structure_rev.signal() =>
+                let _rev = ctrl.structure_rev.signal(),
+                let _ext = ctrl.external_rev.signal() =>
                 Some(content(sel))
             })
         }))

--- a/packages/frontend/editor/src/scene_mode/inspector.rs
+++ b/packages/frontend/editor/src/scene_mode/inspector.rs
@@ -3636,7 +3636,73 @@ fn light_shadow_editor(node: &Arc<Node>, cfg: &LightConfig) -> Dom {
         }).await;
     }));
 
-    let mut sec = Section::new("Shadows").child(row("Cast", toggle(cast)));
+    let mut sec = Section::new("Shadows")
+        .right(settings_help_button(
+            "Shadow settings",
+            vec![
+                ("Cast", "Whether this light casts shadows at all."),
+                (
+                    "Hardness",
+                    "Hard = crisp, cheap edges. Soft (PCF) = fixed-width soft edges. PCSS = \
+                     contact-hardening soft edges that widen with distance from the caster \
+                     (most realistic, most costly).",
+                ),
+                (
+                    "Softness",
+                    "Penumbra width for Soft/PCSS — scales the soft-edge disc (Soft) or the \
+                     virtual light size (PCSS). No effect in Hard mode.",
+                ),
+                (
+                    "Samples",
+                    "Taps the Soft/PCSS filter takes per shadowed pixel. More = smoother \
+                     penumbra and less speckle at the penumbra edge, at proportional cost. No \
+                     effect in Hard mode.",
+                ),
+                (
+                    "Resolution",
+                    "Shadow-map size in texels (per cube face for point lights). Higher = \
+                     sharper shadows and less bias needed, at more memory + fill cost.",
+                ),
+                (
+                    "Depth Bias",
+                    "Pushes the receiver away from the light (metres, slope-scaled) so a \
+                     surface stops shadowing itself ('acne'). Too much lifts the shadow off \
+                     the contact ('Peter-Panning' — a lit donut under a resting object). The \
+                     primary, safest bias knob; often the only one you need.",
+                ),
+                (
+                    "Normal Bias",
+                    "Offsets the shadow lookup along the surface normal — extra acne cover on \
+                     grazing/curved surfaces, but any amount tends to Peter-Pan a lit ring \
+                     into tight contacts. Defaults to 0; raise only if depth bias alone \
+                     leaves acne.",
+                ),
+                (
+                    "Kernel Slack",
+                    "Quantization slack folded into the bias so one shadow-map texel can't \
+                     bridge a real occluder gap. Like Normal Bias it Peter-Pans a lit ring \
+                     into tight contacts — defaults to 0; raise only for flat-receiver acne.",
+                ),
+                (
+                    "Max Distance",
+                    "Distance beyond which this light's shadows fade out (0 = no limit). Saves \
+                     cost on far geometry.",
+                ),
+                (
+                    "Cube Update",
+                    "Point lights only — how often the six cube-map shadow faces re-render. \
+                     Lower rates amortize cost, but are only safe when the shadow-CASTING \
+                     geometry in the light's range is static: a moving caster (even under a \
+                     fixed light) needs frequent updates or its shadow lags behind it.",
+                ),
+                (
+                    "Cascades",
+                    "Directional lights only — how many shadow-map slices the view range is \
+                     split into. More slices keep distant shadows sharp, at more cost.",
+                ),
+            ],
+        ))
+        .child(row("Cast", toggle(cast)));
 
     let n = node.clone();
     sec = sec.child(enum_select_row(

--- a/packages/frontend/web-shared/src/atoms/help.rs
+++ b/packages/frontend/web-shared/src/atoms/help.rs
@@ -1,0 +1,59 @@
+//! A "?" help button that opens a definition-list modal explaining a group of
+//! settings. Drop it into a `Section` / `DrawerSection` header via `.right(...)`
+//! so a panel of terse controls can carry its own inline documentation.
+
+use crate::prelude::*;
+
+/// A "?" icon button that opens a modal titled `title`, listing each
+/// `(term, description)` pair in `entries`. `entries` is owned (static strs) so
+/// the modal content can be rebuilt on each open — `Modal::open` wants `Fn`.
+pub fn settings_help_button(
+    title: impl Into<String>,
+    entries: Vec<(&'static str, &'static str)>,
+) -> Dom {
+    let title = title.into();
+    IconBtn::new("help")
+        .size(13.0)
+        .title("What do these settings do?")
+        .on_click(move || {
+            let title = title.clone();
+            let entries = entries.clone();
+            Modal::open(move || help_card(&title, &entries));
+        })
+        .render()
+}
+
+fn help_card(title: &str, entries: &[(&'static str, &'static str)]) -> Dom {
+    ModalCard::new(title)
+        .width(460.0)
+        .child(html!("div", {
+            .style("display", "flex")
+            .style("flex-direction", "column")
+            .style("gap", "12px")
+            .style("font-size", "12.5px")
+            .style("color", "var(--text-1)")
+            .style("line-height", "1.5")
+            .style("max-height", "60vh")
+            .style("overflow-y", "auto")
+            .children(entries.iter().map(|(term, desc)| {
+                html!("div", {
+                    .style("display", "flex")
+                    .style("flex-direction", "column")
+                    .style("gap", "2px")
+                    .child(html!("strong", {
+                        .style("color", "var(--text-0)")
+                        .text(term)
+                    }))
+                    .child(html!("span", { .text(desc) }))
+                })
+            }))
+        }))
+        .footer(
+            Btn::new()
+                .label("Close")
+                .variant(BtnVariant::Primary)
+                .on_click(Modal::close)
+                .render(),
+        )
+        .render()
+}

--- a/packages/frontend/web-shared/src/atoms/mod.rs
+++ b/packages/frontend/web-shared/src/atoms/mod.rs
@@ -3,6 +3,7 @@
 pub mod button;
 pub mod controls;
 pub mod field;
+pub mod help;
 pub mod icon;
 pub mod num_field;
 pub mod overlay;

--- a/packages/frontend/web-shared/src/prelude.rs
+++ b/packages/frontend/web-shared/src/prelude.rs
@@ -7,6 +7,7 @@
 pub use crate::atoms::button::*;
 pub use crate::atoms::controls::*;
 pub use crate::atoms::field::*;
+pub use crate::atoms::help::*;
 pub use crate::atoms::icon::*;
 pub use crate::atoms::num_field::*;
 pub use crate::atoms::overlay::*;

--- a/packages/mcp/editor-protocol/src/command.rs
+++ b/packages/mcp/editor-protocol/src/command.rs
@@ -425,6 +425,21 @@ pub enum EditorCommand {
     /// side effect. Inverse: restore the prior environment.
     SetEnvironment { env: EnvironmentConfig },
 
+    /// Patch the global SSCS (screen-space contact-shadow) settings on
+    /// `scene.shadows` (persisted; the `sscs_sync` bridge pushes them into the
+    /// renderer live). Every field is optional — only the `Some` ones change.
+    /// `enabled` + `step_count` recompile the shadow-consuming pipelines (they're
+    /// compile-time template constants); the scalars are live uniforms. Inverse:
+    /// restore the prior SSCS values.
+    SetShadowsSscs {
+        enabled: Option<bool>,
+        step_count: Option<u32>,
+        step_world: Option<f32>,
+        thickness: Option<f32>,
+        directional_darkening: Option<f32>,
+        punctual_darkening: Option<f32>,
+    },
+
     /// Snap the viewport camera to a world axis (the nav-cube directions).
     /// **Transient** — camera/view state, not recorded in the undo log.
     SnapCameraToAxis { axis: CameraAxis },
@@ -1279,6 +1294,7 @@ impl EditorCommand {
             EditorCommand::SetMaterialTexture { .. } => "Bind texture",
             EditorCommand::SetMaterialBuffer { .. } => "Bind buffer",
             EditorCommand::SetEnvironment { .. } => "Set environment",
+            EditorCommand::SetShadowsSscs { .. } => "Set SSCS",
             EditorCommand::SnapCameraToAxis { .. } => "Snap camera",
             EditorCommand::ResetCamera => "Reset view",
             EditorCommand::SetCameraOrbit { .. } => "Orbit camera",

--- a/packages/mcp/src/mcp.rs
+++ b/packages/mcp/src/mcp.rs
@@ -999,6 +999,35 @@ pub struct EnvironmentParams {
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct SscsParams {
+    /// Master enable for screen-space contact shadows (a short view-space
+    /// ray-march that darkens contact gaps the shadow map misses). Off by
+    /// default. Compile-time — toggling recompiles the shadow pipelines.
+    #[serde(default)]
+    pub enabled: Option<bool>,
+    /// Ray-march step count (clamped >= 1). Compile-time loop bound — changing it
+    /// recompiles. More steps = longer reach / more cost.
+    #[serde(default)]
+    pub step_count: Option<u32>,
+    /// World-space length of each march step, in metres. Live uniform. Total
+    /// reach = step_world * step_count.
+    #[serde(default)]
+    pub step_world: Option<f32>,
+    /// Occluder-slab thickness in metres — a depth texel this far or less in
+    /// front of the ray counts as an occluder. Live uniform. Larger admits
+    /// thicker casters (a resting ball) at the cost of over-darkening thin geo.
+    #[serde(default)]
+    pub thickness: Option<f32>,
+    /// Max darkening (0..1) applied to the DIRECTIONAL shadow term. Live uniform.
+    #[serde(default)]
+    pub directional_darkening: Option<f32>,
+    /// Max darkening (0..1) for PUNCTUAL (point/spot) shadow terms — higher than
+    /// directional since a cube map leaves a fully-lit contact gap to fill. Live.
+    #[serde(default)]
+    pub punctual_darkening: Option<f32>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ModeArg {
     Scene,
@@ -3420,6 +3449,24 @@ impl EditorMcp {
         };
         self.dispatch(EditorCommand::SetEnvironment {
             env: EnvironmentConfig { skybox, ibl },
+        })
+        .await
+    }
+
+    #[tool(
+        description = "Set the global SSCS (screen-space contact shadows) settings — a short view-space ray-march that darkens contact gaps the shadow map leaves lit (e.g. the 'Peter-Pan' hole under a resting ball). Persisted on scene.shadows + carried in the player bundle; applied to the live renderer immediately. Every field is optional (patch semantics — only the ones you pass change). `enabled` + `step_count` are compile-time and recompile the shadow pipelines; the scalars are live uniforms. Off by default."
+    )]
+    async fn set_sscs(
+        &self,
+        Parameters(p): Parameters<SscsParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.dispatch(EditorCommand::SetShadowsSscs {
+            enabled: p.enabled,
+            step_count: p.step_count,
+            step_world: p.step_world,
+            thickness: p.thickness,
+            directional_darkening: p.directional_darkening,
+            punctual_darkening: p.punctual_darkening,
         })
         .await
     }


### PR DESCRIPTION
## Shadow quality fixes + SSCS as a persisted, tunable global

Base `main`. Highlights:

### Shadow correctness + donut-free defaults
- **Donut / Peter-Pan** self-shadow on a resting caster traced to bias: `normal_bias` and `kernel_slack` both Peter-Pan a lit ring into the contact (the grazing lower hemisphere gets the most slack). Defaults switched to **depth-bias-only** — `depth_bias 0.001, normal_bias 0.0, kernel_slack 0.0` — matching a one-term-at-a-time sweep *and* the author's live tuning. Each stays a per-light knob to add back if grazing/terminator acne shows up on very different geometry.
- **Green fringe** on the MSAA visibility→color resolve: world-position was reconstructed once per pixel instead of per-sample; fixed to per-sample.
- Sky-silhouette aliasing investigated → not a bug (inherent 4× MSAA quantization).

### SSCS (screen-space contact shadows) as a compile-time global
- `enabled` + `step_count` are compile-time template constants baked via the shader cache key (off ⇒ `apply_sscs` folds to `return 1.0`, zero cost); scalars (`step_world`, `thickness`, `directional/punctual_darkening`) are live uniforms. No new runtime branches.
- Persisted to scene schema + player bundle; recompiles lazily only when the compile-time values change. New naga-validated WGSL test across `step_count` ∈ {1,8,32}.

### Editor + MCP surface
- **Inspector refresh on MCP edits** (`external_rev`): seed-once light/shadow/material widgets re-seed on agent edits without tearing local scrubs. Verified live.
- **MCP `set_sscs`** + `SetShadowsSscs` command + `settings_sync` observer → `scene.shadows` applies live.
- **Editor SSCS controls** in the Settings drawer (persist via `SetShadowsSscs`).
- **Inline help**: reusable `settings_help_button` atom (web-shared) — a "?" in a Section/DrawerSection header opening a definition-list modal. Wired into the per-light Shadows inspector and the SSCS drawer section so the terse controls carry their own docs.

## Testing
- `cargo test` (renderer 303 incl. SSCS WGSL validation + scene 22 + others) — green.
- `task lint` (workspace clippy `-D warnings`) — clean.
- Verified live: MCP→inspector refresh; SSCS end-to-end via the drawer (Thickness darkens the ball contact); both help modals render.

## Evaluated + declined
- **`inc_tan` hoist** out of the per-tap cube Soft/PCSS loops: the per-tap value depends on `tap_dir`, so hoisting to the central receiver is an *approximation* that shifts bias exactly at grazing angles (where acne is most delicate). Loops are texture-fetch-bound so the per-tap `sqrt`+divide hides under sample latency → negligible wall-clock. Left as-is.

## Note
The example test scene's saved light still carries pre-change explicit bias values (0.005 / 0.02 / 2), so it doesn't pick up the new depth-only defaults on load — only new lights (or projects that omit the fields) do. Re-save the example with the tuned values if you want it donut-free out of the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
