### PR TITLE
editor+MCP: material overrides made non-inert everywhere; shadow-flag live sync; bundle flatten carries textures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "askama",
@@ -229,7 +229,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-core"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "binpack2d",
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-curves"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "glam 0.32.1",
  "serde",
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-debugging"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -277,7 +277,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-editor"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-editor-protocol"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "awsm-renderer-meshgen",
  "awsm-renderer-scene",
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-geometry"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "glam 0.32.1",
  "serde",
@@ -346,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-glb-export"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "awsm-renderer-meshgen",
  "awsm-renderer-tangents",
@@ -361,7 +361,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-gltf"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-gltf-convert"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "awsm-renderer-glb-export",
  "awsm-renderer-meshgen",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-lod-bake"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "glam 0.32.1",
  "serde",
@@ -412,7 +412,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-lod-bake-cli"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "awsm-renderer-glb-export",
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-materials"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "awsm-renderer-core",
  "thiserror 2.0.18",
@@ -434,7 +434,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-meshgen"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "awsm-renderer-curves",
  "awsm-renderer-geometry",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-model-tests"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-multithreaded-example"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "awsm-renderer",
  "awsm-renderer-core",
@@ -506,7 +506,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-particles"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "awsm-renderer-curves",
  "awsm-renderer-geometry",
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-render-worker-example"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -536,7 +536,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-scene"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "bitcode",
  "glam 0.32.1",
@@ -550,7 +550,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-scene-loader"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -572,7 +572,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-scene-mcp"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "awsm-renderer-editor-protocol",
@@ -594,14 +594,14 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-tangents"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "bevy_mikktspace",
 ]
 
 [[package]]
 name = "awsm-renderer-web-shared"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ resolver = "2"
 [workspace.package]
 description = "awsm renderer"
 edition = "2021"
-version = "0.11.1"
+version = "0.12.0"
 license = "MIT OR Apache-2.0"
 authors = ["David Komer"]
 # 1.85 floor: rmcp 1.x (the MCP server SDK) is edition-2024, which requires
@@ -118,23 +118,23 @@ opt-level = 1
 # `workspace.package.version` so the published crates carry concrete
 # version requirements on each other (crates.io rejects path-only deps).
 # Bump this block together with the version above on every release.
-awsm-renderer-curves = { path = "packages/crates/curves", version = "0.11.1" }
-awsm-renderer-geometry = { path = "packages/crates/geometry", version = "0.11.1" }
-awsm-renderer-scene = { path = "packages/crates/scene", version = "0.11.1" }
-awsm-renderer-scene-loader = { path = "packages/crates/scene-loader", version = "0.11.1" }
-awsm-renderer-editor-protocol = { path = "packages/mcp/editor-protocol", version = "0.11.1" }
-awsm-renderer-core = { path = "packages/crates/renderer-core", version = "0.11.1" }
-awsm-renderer-meshgen = { path = "packages/crates/meshgen", version = "0.11.1" }
-awsm-renderer-glb-export = { path = "packages/crates/glb-export", version = "0.11.1" }
-awsm-renderer-gltf-convert = { path = "packages/crates/gltf-convert", version = "0.11.1" }
-awsm-renderer-tangents = { path = "packages/crates/tangents", version = "0.11.1" }
-awsm-renderer-lod-bake = { path = "packages/crates/lod-bake", version = "0.11.1" }
-awsm-renderer-particles = { path = "packages/crates/particles", version = "0.11.1" }
-awsm-renderer-materials = { path = "packages/crates/materials", version = "0.11.1" }
-awsm-renderer = { path = "packages/crates/renderer", version = "0.11.1" }
-awsm-renderer-gltf = { path = "packages/crates/renderer-gltf", version = "0.11.1" }
+awsm-renderer-curves = { path = "packages/crates/curves", version = "0.12.0" }
+awsm-renderer-geometry = { path = "packages/crates/geometry", version = "0.12.0" }
+awsm-renderer-scene = { path = "packages/crates/scene", version = "0.12.0" }
+awsm-renderer-scene-loader = { path = "packages/crates/scene-loader", version = "0.12.0" }
+awsm-renderer-editor-protocol = { path = "packages/mcp/editor-protocol", version = "0.12.0" }
+awsm-renderer-core = { path = "packages/crates/renderer-core", version = "0.12.0" }
+awsm-renderer-meshgen = { path = "packages/crates/meshgen", version = "0.12.0" }
+awsm-renderer-glb-export = { path = "packages/crates/glb-export", version = "0.12.0" }
+awsm-renderer-gltf-convert = { path = "packages/crates/gltf-convert", version = "0.12.0" }
+awsm-renderer-tangents = { path = "packages/crates/tangents", version = "0.12.0" }
+awsm-renderer-lod-bake = { path = "packages/crates/lod-bake", version = "0.12.0" }
+awsm-renderer-particles = { path = "packages/crates/particles", version = "0.12.0" }
+awsm-renderer-materials = { path = "packages/crates/materials", version = "0.12.0" }
+awsm-renderer = { path = "packages/crates/renderer", version = "0.12.0" }
+awsm-renderer-gltf = { path = "packages/crates/renderer-gltf", version = "0.12.0" }
 # Frontend-only (not published); workspace dep keeps consumers path-agnostic.
-awsm-renderer-web-shared = { path = "packages/frontend/web-shared", version = "0.11.1" }
+awsm-renderer-web-shared = { path = "packages/frontend/web-shared", version = "0.12.0" }
 
 # Misc
 cfg-if = "1.0.4"

--- a/packages/crates/scene/src/material.rs
+++ b/packages/crates/scene/src/material.rs
@@ -220,6 +220,32 @@ pub struct PbrExtensions {
     pub iridescence: Option<IridescenceExt>,
 }
 
+impl PbrExtensions {
+    /// The per-mesh MERGED view of a node's `inline` extension layer over the
+    /// shared library `variant`: per extension, the inline value wins when
+    /// present, otherwise the variant's authored values carry through —
+    /// presence in EITHER layer enables the extension (an inline-only
+    /// extension re-specializes that mesh's pipeline, mirroring texture-slot
+    /// presence). THE single definition of this rule: the editor's mesh
+    /// materialization and the inspector's extension controls both call this,
+    /// so what the UI shows is what actually renders.
+    pub fn merged_over(inline: &Self, variant: &Self) -> Self {
+        Self {
+            emissive_strength: inline.emissive_strength.or(variant.emissive_strength),
+            ior: inline.ior.or(variant.ior),
+            specular: inline.specular.or(variant.specular),
+            transmission: inline.transmission.or(variant.transmission),
+            diffuse_transmission: inline.diffuse_transmission.or(variant.diffuse_transmission),
+            volume: inline.volume.or(variant.volume),
+            clearcoat: inline.clearcoat.or(variant.clearcoat),
+            sheen: inline.sheen.or(variant.sheen),
+            dispersion: inline.dispersion.or(variant.dispersion),
+            anisotropy: inline.anisotropy.or(variant.anisotropy),
+            iridescence: inline.iridescence.or(variant.iridescence),
+        }
+    }
+}
+
 macro_rules! ext_struct {
     ($(#[$m:meta])* $name:ident { $($field:ident : $ty:ty = $def:expr),* $(,)? }) => {
         $(#[$m])*

--- a/packages/frontend/editor/src/controller/export.rs
+++ b/packages/frontend/editor/src/controller/export.rs
@@ -96,7 +96,16 @@ pub async fn bake_player_bundle(
     use awsm_renderer_editor_protocol::{lower_mesh, project_to_scene};
 
     let project = crate::controller::persistence::to_editor_project(ctrl);
-    let scene = project_to_scene(&project);
+    let mut scene = project_to_scene(&project);
+    // Flatten each node's built-in assignment to the MERGED def the editor
+    // actually renders with (`builtin_merged`: shared variant ∪ per-mesh
+    // inline). Built-in LIBRARY defs don't travel in the bundle — the player
+    // reads each node's `inline` as a complete, self-contained MaterialDef —
+    // but the inline seed is taken at ASSIGN time, so library edits made
+    // after assignment (typically the texture bindings of an art pass) never
+    // reach it: the bundle carried the label/factors/extensions yet DROPPED
+    // the texture refs, and textured library materials played back untextured.
+    flatten_builtin_materials(&mut scene.nodes);
     let mut files: Vec<BundleFile> = Vec::new();
 
     // 0. Custom-material BUFFER overrides → `assets/<asset>.bin`. Each override
@@ -225,6 +234,29 @@ pub async fn bake_player_bundle(
     files.extend(env_ktx_bundle_files(ctrl).await?);
 
     assemble_bundle(&scene, files).map_err(|e| e.to_string())
+}
+
+/// Replace every assigned built-in `MaterialInstance.inline` in the baked
+/// node tree with the MERGED def (`builtin_merged`) so the bundle is
+/// self-contained: the player renders each node exactly as the editor did,
+/// including library texture refs bound after assignment. Dynamic-WGSL
+/// assignments (no builtin def) keep their instance untouched — their def
+/// travels as a material folder instead.
+fn flatten_builtin_materials(nodes: &mut [awsm_renderer_editor_protocol::EditorNode]) {
+    use awsm_renderer_editor_protocol::NodeKind;
+    for node in nodes {
+        let material = match &mut node.kind {
+            NodeKind::Mesh { material, .. } => material.as_mut(),
+            NodeKind::SkinnedMesh { material, .. } => material.as_mut(),
+            _ => None,
+        };
+        if let Some(inst) = material {
+            if let Some(merged) = crate::engine::bridge::node_sync::builtin_merged(inst) {
+                inst.inline = merged;
+            }
+        }
+        flatten_builtin_materials(&mut node.children);
+    }
 }
 
 /// The environment's KTX2 cubemap files for the player bundle — one
@@ -642,7 +674,13 @@ fn collect_texture_assets(node: &Node, ids: &mut Vec<AssetId>, seen: &mut HashSe
         .map(|m| m.builtin.get_cloned().is_some())
         .unwrap_or(false);
         if is_builtin {
-            for t in material_texture_refs(&inst.inline) {
+            // Collect from the MERGED def (variant ∪ inline), matching what the
+            // bundle's flattened node actually references — a texture bound on
+            // the LIBRARY material after assignment lives only on the variant,
+            // and reading `inst.inline` alone skipped its bytes.
+            let merged = crate::engine::bridge::node_sync::builtin_merged(inst)
+                .unwrap_or_else(|| inst.inline.clone());
+            for t in material_texture_refs(&merged) {
                 if seen.insert(t.asset) {
                     ids.push(t.asset);
                 }
@@ -855,7 +893,13 @@ fn map_material(material: &Option<MaterialInstance>, tex_index: &TexIndex) -> Ex
     .map(|m| m.builtin.get_cloned().is_some())
     .unwrap_or(false);
     if is_builtin {
-        map_material_def(&inst.inline, Some(inst.asset), tex_index)
+        // Export the MERGED def (variant ∪ inline) — same fix as the player
+        // bundle: a texture (or extension) bound on the LIBRARY material after
+        // assignment lives only on the variant, and exporting `inst.inline`
+        // alone dropped it from the glb.
+        let merged = crate::engine::bridge::node_sync::builtin_merged(inst)
+            .unwrap_or_else(|| inst.inline.clone());
+        map_material_def(&merged, Some(inst.asset), tex_index)
     } else {
         ExportMaterial::None {
             id: Some(inst.asset.to_string()),

--- a/packages/frontend/editor/src/controller/persistence.rs
+++ b/packages/frontend/editor/src/controller/persistence.rs
@@ -791,9 +791,10 @@ pub fn apply_project(ctrl: &EditorController, project: EditorProject) {
         .lock_mut()
         .replace_cloned(mats.clone());
     for m in mats {
-        if m.is_builtin() {
-            super::spawn_builtin_resync(m);
-        } else {
+        // Built-ins need no per-material observer: `UpdateBuiltinMaterial`
+        // re-materializes assigned meshes directly now (the observer approach
+        // had coverage holes — glTF-imported materials never spawned one).
+        if !m.is_builtin() {
             super::spawn_auto_register(m);
         }
     }
@@ -1130,6 +1131,8 @@ pub async fn load_from_dir(
     .await;
     ctrl.reset_history();
     ctrl.dirty.set_neq(false);
+    ctrl.env_saved_baseline
+        .set(ctrl.scene.environment.get_cloned());
     Ok(())
 }
 
@@ -1228,6 +1231,8 @@ pub async fn apply_inmem(
     .await;
     ctrl.reset_history();
     ctrl.dirty.set_neq(false);
+    ctrl.env_saved_baseline
+        .set(ctrl.scene.environment.get_cloned());
     Ok(())
 }
 

--- a/packages/frontend/editor/src/controller/state.rs
+++ b/packages/frontend/editor/src/controller/state.rs
@@ -2034,6 +2034,14 @@ impl EditorController {
                 crate::engine::thumbnail::invalidate(mat.id);
                 crate::engine::thumbnail::request(mat.clone());
                 crate::engine::bridge::rematerialize_for_material(id);
+                // A variant edit changes which per-mesh controls exist on every
+                // node assigned this material (extension rows appear/disappear,
+                // texture slots gate on it) — rebuild the node inspector like
+                // AssignMaterial does. Without this a LOCAL material-panel edit
+                // (which by design bumps no external_rev) left a still-selected
+                // node's panel stale until reselect.
+                self.structure_rev
+                    .set(self.structure_rev.get().wrapping_add(1));
                 self.scene.bump_revision();
                 self.dirty.set_neq(true);
                 Ok(Some(EditorCommand::UpdateBuiltinMaterial {

--- a/packages/frontend/editor/src/controller/state.rs
+++ b/packages/frontend/editor/src/controller/state.rs
@@ -87,6 +87,12 @@ pub struct EditorController {
     pub mode: Mutable<EditorMode>,
     pub project_name: Mutable<String>,
     pub dirty: Mutable<bool>,
+    /// The environment config as of the last save / load / new-project — the
+    /// baseline `snapshot()` compares against to surface `env_unsaved` (a
+    /// live-applied `set_environment` is lost on reload unless saved; agents
+    /// read the flag to know to prompt for a Save). Updated wherever `dirty`
+    /// resets to false.
+    pub env_saved_baseline: Mutable<awsm_renderer_editor_protocol::EnvironmentConfig>,
     pub missing_assets: Mutable<Vec<String>>,
     pub can_undo: Mutable<bool>,
     pub can_redo: Mutable<bool>,
@@ -232,6 +238,7 @@ impl EditorController {
             mode: Mutable::new(EditorMode::default()),
             project_name: Mutable::new("untitled.awsm".to_string()),
             dirty: Mutable::new(false),
+            env_saved_baseline: Mutable::new(Default::default()),
             missing_assets: Mutable::new(Vec::new()),
             can_undo: Mutable::new(false),
             can_redo: Mutable::new(false),
@@ -1089,6 +1096,8 @@ impl EditorController {
                     .set(awsm_renderer_editor_protocol::EnvironmentConfig::default());
                 self.scene.bump_revision();
                 self.dirty.set_neq(false);
+                self.env_saved_baseline
+                    .set(self.scene.environment.get_cloned());
                 self.undo.borrow_mut().clear();
                 self.redo.borrow_mut().clear();
                 self.refresh_history_signals();
@@ -1191,6 +1200,8 @@ impl EditorController {
                 }
                 self.project_name.set("round-trip.awsm".to_string());
                 self.dirty.set_neq(false);
+                self.env_saved_baseline
+                    .set(self.scene.environment.get_cloned());
                 self.undo.borrow_mut().clear();
                 self.redo.borrow_mut().clear();
                 self.refresh_history_signals();
@@ -1998,8 +2009,6 @@ impl EditorController {
                 let mat = CM::new_builtin(id, format!("{label} Material {n}"), shading);
                 self.custom_materials.lock_mut().push_cloned(mat.clone());
                 self.current_material.set(Some(id));
-                // Re-materialize assigned meshes when its variant settings change.
-                spawn_builtin_resync(mat);
                 self.scene.bump_revision();
                 self.dirty.set_neq(true);
                 Ok(None)
@@ -2016,10 +2025,15 @@ impl EditorController {
                 };
                 mat.builtin.set(Some(*def));
                 // Variant changed → refresh its card thumbnail + re-materialize
-                // every assigned mesh (debounced).
+                // every assigned mesh DIRECTLY. This used to ride a per-material
+                // `spawn_builtin_resync` observer, which only existed for
+                // materials created through `AddBuiltinMaterial` / project load —
+                // glTF-IMPORTED library materials never spawned one, so updating
+                // them (e.g. enabling a PBR extension over MCP) silently changed
+                // nothing on screen. A direct call can't have coverage holes.
                 crate::engine::thumbnail::invalidate(mat.id);
                 crate::engine::thumbnail::request(mat.clone());
-                spawn_builtin_resync(mat);
+                crate::engine::bridge::rematerialize_for_material(id);
                 self.scene.bump_revision();
                 self.dirty.set_neq(true);
                 Ok(Some(EditorCommand::UpdateBuiltinMaterial {
@@ -2907,6 +2921,8 @@ impl EditorController {
                         self.redo.borrow_mut().clear();
                         self.refresh_history_signals();
                         self.dirty.set_neq(false);
+                        self.env_saved_baseline
+                            .set(self.scene.environment.get_cloned());
                         Toast::info("Project loaded");
                     }
                     Err(e) => Toast::error(format!("Load failed: {e}")),
@@ -4372,6 +4388,8 @@ impl EditorController {
             project: ProjectSnapshot {
                 name: self.project_name.get_cloned(),
                 dirty: self.dirty.get(),
+                env_unsaved: self.scene.environment.get_cloned()
+                    != self.env_saved_baseline.get_cloned(),
                 missing_assets: self.missing_assets.get_cloned(),
                 coordinate_system: "right-handed, Y-up, -Z forward".to_string(),
                 units: self.settings.units.get_cloned(),
@@ -4397,6 +4415,7 @@ impl EditorController {
                         name: m.name.get_cloned(),
                         registered: m.registered.get(),
                         builtin: m.builtin.lock_ref().is_some(),
+                        builtin_def: m.builtin.get_cloned().map(Box::new),
                         uniforms: m
                             .uniforms
                             .lock_ref()
@@ -7422,28 +7441,6 @@ pub(crate) fn spawn_auto_register(mat: Arc<CM>) {
     });
 }
 
-/// Re-materialize meshes using a **built-in** material whenever its shared
-/// variant settings change (node_sync re-merges the variant with each mesh's
-/// per-mesh uniforms).
-pub(crate) fn spawn_builtin_resync(mat: Arc<CM>) {
-    use futures_signals::signal::SignalExt;
-    let id = mat.id;
-    spawn_local(async move {
-        let sig = mat.builtin.signal_cloned();
-        let mut first = true;
-        sig.for_each(move |_| {
-            let fire = !first;
-            first = false;
-            async move {
-                if fire {
-                    crate::engine::bridge::rematerialize_for_material(id);
-                }
-            }
-        })
-        .await;
-    });
-}
-
 /// Default parameters for a freshly-created procedural texture asset, one per
 /// generator family the Content Browser offers.
 fn default_procedural(proc: ProceduralKind) -> ProceduralTextureDef {
@@ -7469,6 +7466,27 @@ fn default_procedural(proc: ProceduralKind) -> ProceduralTextureDef {
             seed: 1337,
             scale: 4.0,
         },
+    }
+}
+
+/// Whether the extension owning the `"<ext>.<field>"` slot is ENABLED
+/// (`Some`) — the slot-visibility gate, distinct from "has a texture bound"
+/// ([`get_ext_texture`] conflates the two: it returns `None` both for a
+/// disabled extension and for an enabled one with no texture yet).
+pub(crate) fn ext_slot_enabled(
+    ext: &awsm_renderer_editor_protocol::PbrExtensions,
+    slot: &str,
+) -> bool {
+    match slot.split('.').next().unwrap_or("") {
+        "specular" => ext.specular.is_some(),
+        "transmission" => ext.transmission.is_some(),
+        "diffuse_transmission" => ext.diffuse_transmission.is_some(),
+        "volume" => ext.volume.is_some(),
+        "clearcoat" => ext.clearcoat.is_some(),
+        "sheen" => ext.sheen.is_some(),
+        "anisotropy" => ext.anisotropy.is_some(),
+        "iridescence" => ext.iridescence.is_some(),
+        _ => false,
     }
 }
 

--- a/packages/frontend/editor/src/engine/bridge/node_sync.rs
+++ b/packages/frontend/editor/src/engine/bridge/node_sync.rs
@@ -693,7 +693,7 @@ fn merge_slot_texture(
 /// with this mesh's per-mesh uniform values (`inline`: base color / metallic /
 /// roughness / emissive) into a final `MaterialDef`. Returns `None` for a dynamic
 /// material or an unknown id (callers then try the dynamic path / inline).
-fn builtin_merged(
+pub(crate) fn builtin_merged(
     inst: &awsm_renderer_editor_protocol::dynamic_material::MaterialInstance,
 ) -> Option<awsm_renderer_editor_protocol::MaterialDef> {
     use awsm_renderer_editor_protocol::material::{
@@ -734,30 +734,16 @@ fn builtin_merged(
         )
     };
 
-    // Extension PARAMS per mesh, ENABLE from the variant: an extension the
-    // material doesn't enable stays off (enabling it would recompile); an enabled
-    // one takes this mesh's parameters (falling back to defaults if unseeded).
-    macro_rules! merge_ext {
-        ($f:ident) => {
-            variant
-                .extensions
-                .$f
-                .map(|_| inline.extensions.$f.unwrap_or_default())
-        };
-    }
-    let extensions = PbrExtensions {
-        emissive_strength: merge_ext!(emissive_strength),
-        ior: merge_ext!(ior),
-        specular: merge_ext!(specular),
-        transmission: merge_ext!(transmission),
-        diffuse_transmission: merge_ext!(diffuse_transmission),
-        volume: merge_ext!(volume),
-        clearcoat: merge_ext!(clearcoat),
-        sheen: merge_ext!(sheen),
-        dispersion: merge_ext!(dispersion),
-        anisotropy: merge_ext!(anisotropy),
-        iridescence: merge_ext!(iridescence),
-    };
+    // Extension merge, mirroring texture-slot presence (§11): enabled when
+    // EITHER layer carries the extension — a per-node `inline` extension
+    // re-specializes THIS mesh's pipeline (one extra bucket per distinct
+    // feature combination, not one per mesh) instead of being silently
+    // dropped. Params: inline wins, else the variant's AUTHORED values
+    // (previously an enabled-but-inline-unseeded extension fell back to
+    // struct DEFAULTS, discarding the library material's factors). The rule
+    // lives on `PbrExtensions::merged_over` — shared with the inspector so
+    // the UI shows exactly what renders.
+    let extensions = PbrExtensions::merged_over(&inline.extensions, &variant.extensions);
 
     // Alpha MODE (Opaque/Mask/Blend) is variant routing; the Mask *cutoff* value
     // is a per-mesh uniform compare, so carry it from inline when both are Mask.
@@ -1588,6 +1574,22 @@ async fn upload_simple_mesh(
     // to transparency geometry without a separate entry point.
     match r.add_raw_mesh(raw, sub_tk, mat_key) {
         Ok(mk) => {
+            // Apply the node's CURRENT shadow flags + visibility at creation,
+            // exactly like the skinned / cluster materialize paths. Without
+            // this, a `shadow.cast` (or any kind) edit re-materializes the
+            // mesh back to renderer DEFAULTS: the kind observer tears down and
+            // rebuilds, the visibility observer doesn't re-fire (node.visible
+            // didn't change), and the shadow flags were never applied at all —
+            // so `set_mesh_shadow cast=false` silently kept casting.
+            let shadow_cfg = entry
+                .node
+                .kind
+                .get_cloned()
+                .mesh_shadow()
+                .copied()
+                .unwrap_or_default();
+            let _ = r.set_mesh_shadow_flags(mk, mesh_shadow_flags_from_config(&shadow_cfg));
+            let _ = r.set_mesh_hidden(mk, !entry.node.visible.get());
             if !declare_only {
                 if let Err(e) = r
                     .commit_load(crate::engine::activity::commit_phase_handler())

--- a/packages/frontend/editor/src/material_mode/studio.rs
+++ b/packages/frontend/editor/src/material_mode/studio.rs
@@ -44,7 +44,15 @@ pub fn render() -> Dom {
             }))
             .child(html!("div", {
                 .style("border-right", "1px solid var(--line)").style("min-height", "0")
-                .child_signal(controller().current_material.signal().map(|id| Some(definition(id))))
+                // Rebuild on `external_rev` too (like the scene inspector's
+                // node panel) so an MCP `update_builtin_material` refreshes
+                // the alpha / textures / toon / name rows live instead of
+                // leaving a stale once-per-selection snapshot until reselect.
+                .child_signal(map_ref! {
+                    let id = controller().current_material.signal(),
+                    let _ext = controller().external_rev.signal() =>
+                    Some(definition(*id))
+                })
             }))
             .child(html!("div", {
                 .style("min-width", "0").style("min-height", "0").style("background", "var(--bg-0)")

--- a/packages/frontend/editor/src/scene_mode/inspector.rs
+++ b/packages/frontend/editor/src/scene_mode/inspector.rs
@@ -2005,9 +2005,20 @@ fn material_editor(node: &Arc<Node>, mat: &MaterialDef, _has_custom: bool) -> Do
         for (slot, label, d) in core {
             entries.push((slot, label, d, false));
         }
+        // Extension slots gate on the extension being ENABLED in the MERGED
+        // view (inline over variant — an MCP-set inline-only extension gets
+        // its slots too), and show even when no texture is bound yet so one
+        // can be ASSIGNED per-mesh — the same rule as the core slots above.
+        // The default ref comes from the merged view, so an inline-bound
+        // texture shows as this mesh's current binding.
+        let merged_ext = awsm_renderer_editor_protocol::material::PbrExtensions::merged_over(
+            &mat.extensions,
+            &def.extensions,
+        );
         for (slot, label) in ext_slots {
-            if let Some(t) = crate::controller::get_ext_texture(&def.extensions, slot) {
-                entries.push((slot, label, Some(t), true));
+            if crate::controller::ext_slot_enabled(&merged_ext, slot) {
+                let t = crate::controller::get_ext_texture(&merged_ext, slot);
+                entries.push((slot, label, t, true));
             }
         }
         if !entries.is_empty() {
@@ -2289,8 +2300,18 @@ fn builtin_uniform_extras(
     }
 
     // ── KHR extension parameters (per enabled extension) ──
-    let e = &variant.extensions;
-    let ie = &inline.extensions;
+    // Gate AND seed from the MERGED view (inline wins, variant fills,
+    // presence from either — `PbrExtensions::merged_over`, the same rule
+    // mesh materialization applies), so the controls show exactly what this
+    // mesh renders with: an MCP-set inline-only extension is visible/editable
+    // here, and an enabled-but-unedited extension shows the library's
+    // authored factors instead of struct defaults.
+    let merged_ext = awsm_renderer_editor_protocol::material::PbrExtensions::merged_over(
+        &inline.extensions,
+        &variant.extensions,
+    );
+    let e = &merged_ext;
+    let ie = &merged_ext;
     let any = e.emissive_strength.is_some()
         || e.ior.is_some()
         || e.specular.is_some()

--- a/packages/mcp/editor-protocol/src/query.rs
+++ b/packages/mcp/editor-protocol/src/query.rs
@@ -52,6 +52,12 @@ pub struct MaterialSnapshot {
     pub name: String,
     pub registered: bool,
     pub builtin: bool,
+    /// For a built-in material: its FULL shared variant `MaterialDef` — the
+    /// read half of `update_builtin_material`'s read-modify-write workflow
+    /// (the def is all-fields-required on write, so agents need the current
+    /// one to modify). `None` for custom-WGSL materials.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub builtin_def: Option<Box<crate::MaterialDef>>,
     pub uniforms: Vec<String>,
     /// True when the material has no outstanding compile errors (always true for
     /// built-ins, which need no compile). Closes the old `query.rs` TODO.
@@ -122,6 +128,12 @@ pub struct TrackSnapshot {
 pub struct ProjectSnapshot {
     pub name: String,
     pub dirty: bool,
+    /// The LIVE-APPLIED environment (skybox/IBL) differs from the last-saved
+    /// one — a project reload loses it unless the project is saved first.
+    /// Agents driving `set_environment` should prompt for a Save when this is
+    /// set.
+    #[serde(default)]
+    pub env_unsaved: bool,
     pub missing_assets: Vec<String>,
     /// Coordinate-system description (handedness / up-axis / units) so a driver
     /// doesn't have to guess the frame. Constant for now.

--- a/packages/mcp/src/mcp.rs
+++ b/packages/mcp/src/mcp.rs
@@ -563,8 +563,12 @@ pub struct ShadingParams {
 pub struct UpdateBuiltinParams {
     /// The built-in material's asset id.
     pub id: String,
-    /// The FULL MaterialDef as JSON (read the current one from get_snapshot,
-    /// modify, send back). See the tool description for field shapes.
+    /// The FULL MaterialDef as a JSON **object** (read the current one from
+    /// get_snapshot, modify, send back). See the tool description for field
+    /// shapes. Typed as `object` in the schema (like `patch_kind.patch`) so
+    /// clients don't stringify it — a bare `Value` schema made every client
+    /// send a string, which the server then rejected.
+    #[schemars(with = "serde_json::Map<String, serde_json::Value>")]
     pub def: serde_json::Value,
 }
 
@@ -1414,17 +1418,17 @@ impl EditorMcp {
     }
 
     #[tool(
-        description = "Replace a built-in library material's VARIANT definition wholesale (idempotent full MaterialDef as JSON, undoable; assigned meshes re-materialize). Key fields: shading ({\"pbr\":null} | {\"unlit\":null} | {\"toon\":{...}} | {\"flip_book\":{\"cols\":2,\"rows\":2,\"frame_count\":4,\"fps\":2.0,\"time_offset\":0.0,\"mode\":\"loop\",\"flip_y\":false}}), alpha_mode ({\"opaque\":null} | {\"mask\":{\"cutoff\":0.5}} | {\"blend\":null}), double_sided, base_color (rgba), base_color_texture ({\"asset\":\"<texture-asset-id>\"} — for a FlipBook this is the ATLAS), label. Read the current def from get_snapshot first and send it back modified. A Mask-mode FlipBook = an ANIMATED CUTOUT (alpha-tested opaque, hole-shaped shadows)."
+        description = "Replace a built-in library material's VARIANT definition wholesale (idempotent full MaterialDef as a JSON object, undoable; assigned meshes re-materialize). Key fields: shading (unit variants are PLAIN STRINGS: \"pbr\" | \"unlit\"; struct variants are single-key objects: {\"toon\":{...}} | {\"flip_book\":{\"cols\":2,\"rows\":2,\"frame_count\":4,\"fps\":2.0,\"time_offset\":0.0,\"mode\":\"loop\",\"flip_y\":false}}), alpha_mode (\"opaque\" | {\"mask\":{\"cutoff\":0.5}} | \"blend\"), double_sided, base_color (rgba), base_color_texture ({\"asset\":\"<texture-asset-id>\"} — for a FlipBook this is the ATLAS), extensions (e.g. {\"clearcoat\":{\"factor\":1.0,\"roughness_factor\":0.0}}), label. Read the current def from get_snapshot first and send it back modified. A Mask-mode FlipBook = an ANIMATED CUTOUT (alpha-tested opaque, hole-shaped shadows)."
     )]
     async fn update_builtin_material(
         &self,
         Parameters(p): Parameters<UpdateBuiltinParams>,
     ) -> Result<CallToolResult, McpError> {
         let id = parse_asset(&p.id)?;
-        let def: awsm_renderer_editor_protocol::MaterialDef = serde_json::from_value(p.def.clone())
-            .map_err(|e| {
-                McpError::invalid_params(format!("def does not parse as a MaterialDef: {e}"), None)
-            })?;
+        // `json_arg` (not a bare `from_value`) so a client that double-encodes
+        // the object as a JSON string still parses.
+        let def: awsm_renderer_editor_protocol::MaterialDef =
+            json_arg(p.def.clone(), "def (a MaterialDef object)")?;
         self.dispatch(EditorCommand::UpdateBuiltinMaterial {
             id,
             def: Box::new(def),
@@ -3006,7 +3010,7 @@ impl EditorMcp {
     }
 
     #[tool(
-        description = "Set a built-in material factor on a mesh node's inline material. param: base_color (value = 3 floats RGB, OR 4 floats RGBA where the 4th is the base-color ALPHA — pair with set_builtin_alpha_mode blend for glass) | emissive (3 floats) | metallic | roughness | normal_scale | occlusion_strength (1 float)."
+        description = "Set a built-in material factor on a mesh node's inline material. param: base_color (value = 3 floats RGB, OR 4 floats RGBA where the 4th is the base-color ALPHA — pair with set_builtin_alpha_mode blend for glass) | emissive (3 floats) | metallic | roughness | normal_scale | occlusion_strength (1 float). For KHR extension params (clearcoat, sheen, transmission, ior, ...) use patch_kind on mesh.material.inline.extensions — e.g. {\"mesh\":{\"material\":{\"inline\":{\"extensions\":{\"clearcoat\":{\"factor\":1.0,\"roughness_factor\":0.0}}}}}} — an inline extension ENABLES it for that mesh (recompiles its variant) and null disables."
     )]
     async fn set_builtin_param(
         &self,
@@ -3074,7 +3078,7 @@ impl EditorMcp {
     }
 
     #[tool(
-        description = "Patch a node's kind with a JSON merge-patch (RFC 7386) — edit only the fields you name instead of resending the whole NodeKind via dispatch_command SetKind. `node` is the node UUID; `patch` is a partial JSON **object** (send it as an object, not a stringified object) merged over the node's current kind (fields present overwrite; null removes a key; nested objects merge recursively; arrays replace wholesale). Read get_node_details to see the exact shape + field names, then send just the delta. The result must still be a valid NodeKind (rejected loudly with the deserialize error otherwise). Ideal for escape-hatch edits with no typed tool: particle-emitter config, decal, sprite, collider, etc."
+        description = "Patch a node's kind with a JSON merge-patch (RFC 7386) — edit only the fields you name instead of resending the whole NodeKind via dispatch_command SetKind. `node` is the node UUID; `patch` is a partial JSON **object** (send it as an object, not a stringified object) merged over the node's current kind (fields present overwrite; null removes a key; nested objects merge recursively; arrays replace wholesale). Read get_node_details to see the exact shape + field names, then send just the delta. The result must still be a valid NodeKind (rejected loudly with the deserialize error otherwise). Ideal for escape-hatch edits with no typed tool: particle-emitter config, decal, sprite, collider, and per-mesh PBR extension params (mesh.material.inline.extensions.clearcoat = {\"factor\":1.0,\"roughness_factor\":0.0} enables + parameterizes clearcoat on JUST this mesh; null disables)."
     )]
     async fn patch_kind(
         &self,


### PR DESCRIPTION
Sprint of fixes found while driving the editor over MCP for the physics-multithreaded template's art pass. Common thread: **silently accepted, never rendered**.

## 1. PBR extensions on builtin materials were inert (both paths)

The downstream pipeline (`PbrFeatures` variant bits → bucket cache key → `{% if %}`-gated WGSL) was already fully wired — the drops were at two authoring seams:

- **Library defs** (`update_builtin_material`): re-materialization rode a per-material `spawn_builtin_resync` observer that **glTF-imported materials never spawned** — updating them changed nothing on screen, settling in 32ms with no recompile (the reported repro). The handler now re-materializes directly; the observer web is deleted.
- **Inline defs** (`patch_kind`): the merge took extension *enables* only from the shared variant (inline-only extensions silently dropped) and *params* only from inline (variant-authored factors discarded when unseeded). New **`PbrExtensions::merged_over`** — inline wins, variant fills, presence from either layer enables — is the single shared rule used by mesh materialization, the inspector, and export.

## 2. Editor UI parity + live refresh

- Inspector extension params + texture slots gate/seed from the **merged** view: MCP-set inline-only extensions are visible/editable, and enabled extension slots show even when unbound (so a texture can be assigned per-mesh, matching the core-slot rule).
- The material panel's Definition rail rebuilds on `external_rev` — MCP `update_builtin_material` refreshes it live instead of a stale once-per-selection snapshot.

## 3. `update_builtin_material` schema + workflow

- `def` now publishes `"type": "object"` (was untyped → clients stringified → server rejected; the tool was unusable as published). Server-side is also string-tolerant via the existing `json_arg`.
- Docs fixed: shading unit variants are plain strings (`"pbr"`), not `{"pbr": null}`; alpha_mode likewise; extensions shape documented.
- **New: `MaterialSnapshot.builtin_def`** — `get_snapshot` now returns each builtin's full current def. The documented read-modify-write workflow previously had no read half (defs are all-fields-required on write).

## 4. Shadow flags / kind edits inert for plain meshes

`upload_simple_mesh` (plain `NodeKind::Mesh` materialization) never applied shadow flags or initial visibility — every kind edit re-materialized back to renderer defaults, so `set_mesh_shadow cast=false` kept casting (repro'd identically on `main` during the culling PR). Now applied at creation, matching the skinned/cluster paths.

## 5. Bundle/glb flatten drops library texture refs

The player reads each node's `inline` as a complete def, but inline is seeded at **assign** time — textures bound on the library material afterwards (the normal art-pass order) lived only on the variant, which the live editor merge papered over and the bundle dropped (striped ball → plain white). The bake and glb export now flatten the **merged** def, and texture-byte collection reads it too.

## 6. `env_unsaved` in `get_snapshot`

Project state now surfaces when the live-applied environment differs from the last save/load baseline, so agents know to prompt for a Save before a reload loses it.

## Verified end-to-end over MCP (browser)

- Clearcoat `{factor:1, roughness_factor:0}` renders a **visibly mirror-coated sphere** (studio KTX env) via BOTH the typed `update_builtin_material` (def read from `get_snapshot`) and `patch_kind` inline (affects only that mesh); toggles cleanly off. Pixel-level A/B for every case.
- `set_mesh_shadow cast=false` removes the shadow live.
- Exported bundle's `scene.toml` carries `inline.base_color_texture` + the png for a texture bound on the library **after** assignment.
- `env_unsaved: true` after a live `set_environment`.
- `task lint` + full workspace test suite (49 suites) green.

**Deferred with rationale:** offscreen/on-demand capture for backgrounded tabs (needs an rAF-independent render drive — render-loop surgery, not a sprint rider); animatable extension scalars in `BuiltinParamKind` (pulls in the animation runtime; `patch_kind` covers per-node extension params today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YSfWhD9Ja2mZx98qm3wfwa