### PR TITLE
Environment: three independent IBL slots (+ editor SMAA toggle)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "askama",
@@ -229,7 +229,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-core"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "binpack2d",
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-curves"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "glam 0.32.1",
  "serde",
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-debugging"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -277,7 +277,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-editor"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-editor-protocol"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "awsm-renderer-meshgen",
  "awsm-renderer-scene",
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-geometry"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "glam 0.32.1",
  "serde",
@@ -346,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-glb-export"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "awsm-renderer-meshgen",
  "awsm-renderer-tangents",
@@ -361,7 +361,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-gltf"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-gltf-convert"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "awsm-renderer-glb-export",
  "awsm-renderer-meshgen",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-lod-bake"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "glam 0.32.1",
  "serde",
@@ -412,7 +412,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-lod-bake-cli"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "awsm-renderer-glb-export",
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-materials"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "awsm-renderer-core",
  "thiserror 2.0.18",
@@ -434,7 +434,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-meshgen"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "awsm-renderer-curves",
  "awsm-renderer-geometry",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-model-tests"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-multithreaded-example"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "awsm-renderer",
  "awsm-renderer-core",
@@ -506,7 +506,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-particles"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "awsm-renderer-curves",
  "awsm-renderer-geometry",
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-render-worker-example"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -536,7 +536,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-scene"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "bitcode",
  "glam 0.32.1",
@@ -550,7 +550,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-scene-loader"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -572,7 +572,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-scene-mcp"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "awsm-renderer-editor-protocol",
@@ -594,14 +594,14 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-tangents"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "bevy_mikktspace",
 ]
 
 [[package]]
 name = "awsm-renderer-web-shared"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ resolver = "2"
 [workspace.package]
 description = "awsm renderer"
 edition = "2021"
-version = "0.13.0"
+version = "0.14.0"
 license = "MIT OR Apache-2.0"
 authors = ["David Komer"]
 # 1.85 floor: rmcp 1.x (the MCP server SDK) is edition-2024, which requires
@@ -118,23 +118,23 @@ opt-level = 1
 # `workspace.package.version` so the published crates carry concrete
 # version requirements on each other (crates.io rejects path-only deps).
 # Bump this block together with the version above on every release.
-awsm-renderer-curves = { path = "packages/crates/curves", version = "0.13.0" }
-awsm-renderer-geometry = { path = "packages/crates/geometry", version = "0.13.0" }
-awsm-renderer-scene = { path = "packages/crates/scene", version = "0.13.0" }
-awsm-renderer-scene-loader = { path = "packages/crates/scene-loader", version = "0.13.0" }
-awsm-renderer-editor-protocol = { path = "packages/mcp/editor-protocol", version = "0.13.0" }
-awsm-renderer-core = { path = "packages/crates/renderer-core", version = "0.13.0" }
-awsm-renderer-meshgen = { path = "packages/crates/meshgen", version = "0.13.0" }
-awsm-renderer-glb-export = { path = "packages/crates/glb-export", version = "0.13.0" }
-awsm-renderer-gltf-convert = { path = "packages/crates/gltf-convert", version = "0.13.0" }
-awsm-renderer-tangents = { path = "packages/crates/tangents", version = "0.13.0" }
-awsm-renderer-lod-bake = { path = "packages/crates/lod-bake", version = "0.13.0" }
-awsm-renderer-particles = { path = "packages/crates/particles", version = "0.13.0" }
-awsm-renderer-materials = { path = "packages/crates/materials", version = "0.13.0" }
-awsm-renderer = { path = "packages/crates/renderer", version = "0.13.0" }
-awsm-renderer-gltf = { path = "packages/crates/renderer-gltf", version = "0.13.0" }
+awsm-renderer-curves = { path = "packages/crates/curves", version = "0.14.0" }
+awsm-renderer-geometry = { path = "packages/crates/geometry", version = "0.14.0" }
+awsm-renderer-scene = { path = "packages/crates/scene", version = "0.14.0" }
+awsm-renderer-scene-loader = { path = "packages/crates/scene-loader", version = "0.14.0" }
+awsm-renderer-editor-protocol = { path = "packages/mcp/editor-protocol", version = "0.14.0" }
+awsm-renderer-core = { path = "packages/crates/renderer-core", version = "0.14.0" }
+awsm-renderer-meshgen = { path = "packages/crates/meshgen", version = "0.14.0" }
+awsm-renderer-glb-export = { path = "packages/crates/glb-export", version = "0.14.0" }
+awsm-renderer-gltf-convert = { path = "packages/crates/gltf-convert", version = "0.14.0" }
+awsm-renderer-tangents = { path = "packages/crates/tangents", version = "0.14.0" }
+awsm-renderer-lod-bake = { path = "packages/crates/lod-bake", version = "0.14.0" }
+awsm-renderer-particles = { path = "packages/crates/particles", version = "0.14.0" }
+awsm-renderer-materials = { path = "packages/crates/materials", version = "0.14.0" }
+awsm-renderer = { path = "packages/crates/renderer", version = "0.14.0" }
+awsm-renderer-gltf = { path = "packages/crates/renderer-gltf", version = "0.14.0" }
 # Frontend-only (not published); workspace dep keeps consumers path-agnostic.
-awsm-renderer-web-shared = { path = "packages/frontend/web-shared", version = "0.13.0" }
+awsm-renderer-web-shared = { path = "packages/frontend/web-shared", version = "0.14.0" }
 
 # Misc
 cfg-if = "1.0.4"

--- a/docs/ASSET_WORKFLOWS.md
+++ b/docs/ASSET_WORKFLOWS.md
@@ -14,11 +14,18 @@ Serving locally: any static server with permissive CORS works, e.g.
 
 ## 1. Environment (skybox + IBL)
 
+The environment has **three independent slots**, each set separately:
+- **skybox** — the background cubemap the camera sees.
+- **specular** — the prefiltered / roughness-mipped IBL map that drives reflections
+  ("prefiltered env" and "specular" are the same thing).
+- **irradiance** — the diffuse-convolved IBL map that drives ambient light.
+
+Omit a slot to leave it unchanged; pass `"builtin"` to reset it to the default sky.
 Two ways, pick by need:
 
 ### a) Two-color sky gradient — no hosting, instant
-`set_environment { zenith:[r,g,b], nadir:[r,g,b] }` (linear RGB). Drives BOTH the
-skybox and the IBL from the same gradient. Great for dusk / overcast / studio.
+`set_environment { zenith:[r,g,b], nadir:[r,g,b] }` (linear RGB). Sets ALL THREE
+slots from the same gradient. Great for dusk / overcast / studio.
 
 ### b) KTX2 cubemaps by URL — full HDRI / studio lighting / chrome
 A `.ktx2` cubemap is **baked offline** from an `.hdr`/`.exr` and served. You author
@@ -35,16 +42,20 @@ no runtime equirect projection). Pipeline (full flags in `docs/DEVELOPMENT.md`):
 3. `ktx create --cubemap --format B10G11R11_UFLOAT_PACK32 …` → `skybox.ktx2`,
    `env.ktx2` (prefiltered, `--levels 6`, all mip faces), `irradiance.ktx2`.
 4. Serve them, then:
-   `set_environment { skybox:"<url>/skybox.ktx2", ibl_prefiltered:"<url>/env.ktx2", ibl_irradiance:"<url>/irradiance.ktx2" }`
+   `set_environment { skybox:"<url>/skybox.ktx2", specular:"<url>/env.ktx2", irradiance:"<url>/irradiance.ktx2" }`
 
 Notes:
-- **KTX IBL needs BOTH** `ibl_prefiltered` AND `ibl_irradiance`.
-- The **skybox can differ from the IBL** — a clean grey skybox + a studio IBL gives
-  a chrome ball its reflections while the punctual (point/dir) lights own the primary
-  specular hotspot. (`zenith`/`nadir` forces skybox==IBL; to get a gradient *look* with
-  a separate KTX IBL, bake the gradient into a skybox `.ktx2` too.)
-- Each of `skybox` / `ibl_prefiltered` / `ibl_irradiance` also accepts `"builtin"`
-  (or omit) for the default, or an existing KTX texture-asset UUID.
+- **Slots are fully independent.** Set only the ones you want; the rest stay put.
+  E.g. keep the default-sky irradiance and override *only* `specular`, or set a
+  clean `skybox:"builtin"` while pointing `specular`/`irradiance` at a studio KTX.
+- The **skybox can differ from the IBL** — a clean grey skybox + a studio specular/
+  irradiance gives a chrome ball its reflections while the punctual (point/dir)
+  lights own the primary specular hotspot. (`zenith`/`nadir` sets all three slots
+  to the same gradient; to get a gradient *look* with a separate KTX IBL, bake the
+  gradient into a skybox `.ktx2` too.)
+- Each of `skybox` / `specular` / `irradiance` also accepts `"builtin"` (or omit)
+  for the default sky, an existing KTX cubemap asset UUID, or a `https://` `.ktx2` URL.
+- Read what's set via `get_snapshot` → `project.environment` (per-slot kind + asset).
 
 ---
 

--- a/packages/crates/scene-loader/src/environment.rs
+++ b/packages/crates/scene-loader/src/environment.rs
@@ -19,21 +19,31 @@ use awsm_renderer::AwsmRenderer;
 use awsm_renderer_core::command::color::Color;
 use awsm_renderer_core::cubemap::images::CubemapSkyGradient;
 use awsm_renderer_core::cubemap::CubemapImage;
-use awsm_renderer_scene::{env_ktx_path, AssetId, EnvironmentConfig, IblConfig, SkyboxConfig};
+use awsm_renderer_scene::{env_ktx_path, AssetId, EnvSlot, EnvironmentConfig};
 
 use crate::assets::SceneAssets;
 
+/// The procedural-gradient cubemap resolution for each slot role. Skybox and the
+/// prefiltered specular map are full-res; irradiance is a tiny diffuse-convolved
+/// map. Shared with `env_sync` (the editor counterpart) so both paths generate
+/// the built-in default identically.
+const SKYBOX_SIZE: u32 = 1024;
+const SPECULAR_SIZE: u32 = 1024;
+const IRRADIANCE_SIZE: u32 = 32;
+
 /// Apply a scene's `EnvironmentConfig` (skybox + IBL) to the renderer. KTX
-/// cubemaps are read from the bundle by the `assets/<id>.ktx2` convention.
+/// cubemaps are read from the bundle by the `assets/<id>.ktx2` convention. All
+/// three slots (skybox / specular / irradiance) resolve independently.
 pub async fn apply_environment(
     renderer: &mut AwsmRenderer,
     env: &EnvironmentConfig,
     assets: &impl SceneAssets,
 ) -> Result<()> {
-    let skybox = skybox_image(&env.skybox, assets).await?;
+    let skybox = slot_image(&env.skybox, SKYBOX_SIZE, assets).await?;
     set_skybox(renderer, skybox).await?;
 
-    let (prefiltered, irradiance) = ibl_images(&env.ibl, assets).await?;
+    let prefiltered = slot_image(&env.specular, SPECULAR_SIZE, assets).await?;
+    let irradiance = slot_image(&env.irradiance, IRRADIANCE_SIZE, assets).await?;
     set_ibl(renderer, prefiltered, irradiance).await?;
     Ok(())
 }
@@ -44,52 +54,26 @@ fn sky_gradient(zenith: [f32; 3], nadir: [f32; 3]) -> CubemapSkyGradient {
     CubemapSkyGradient::new(c(zenith), c(nadir))
 }
 
-async fn skybox_image(cfg: &SkyboxConfig, assets: &impl SceneAssets) -> Result<CubemapImage> {
-    match cfg {
-        SkyboxConfig::BuiltInDefault => {
-            CubemapImage::new_sky_gradient(CubemapSkyGradient::default(), 1024, 1024)
-                .await
-                .map_err(|e| anyhow!("sky gradient: {e}"))
-        }
-        SkyboxConfig::SkyGradient { zenith, nadir } => {
-            CubemapImage::new_sky_gradient(sky_gradient(*zenith, *nadir), 1024, 1024)
-                .await
-                .map_err(|e| anyhow!("sky gradient: {e}"))
-        }
-        SkyboxConfig::Ktx { asset_id } => load_ktx(*asset_id, assets).await,
-    }
-}
-
-async fn ibl_images(
-    cfg: &IblConfig,
+/// Resolve one environment slot to a cubemap at the role's `size` (KTX slots
+/// ignore `size` — the file carries its own resolution/mips).
+async fn slot_image(
+    slot: &EnvSlot,
+    size: u32,
     assets: &impl SceneAssets,
-) -> Result<(CubemapImage, CubemapImage)> {
-    match cfg {
-        IblConfig::BuiltInDefault => gradient_ibl(CubemapSkyGradient::default()).await,
-        IblConfig::SkyGradient { zenith, nadir } => {
-            gradient_ibl(sky_gradient(*zenith, *nadir)).await
+) -> Result<CubemapImage> {
+    match slot {
+        EnvSlot::BuiltInDefault => {
+            CubemapImage::new_sky_gradient(CubemapSkyGradient::default(), size, size)
+                .await
+                .map_err(|e| anyhow!("sky gradient: {e}"))
         }
-        IblConfig::Ktx {
-            prefiltered_asset_id,
-            irradiance_asset_id,
-        } => {
-            let p = load_ktx(*prefiltered_asset_id, assets).await?;
-            let i = load_ktx(*irradiance_asset_id, assets).await?;
-            Ok((p, i))
+        EnvSlot::SkyGradient { zenith, nadir } => {
+            CubemapImage::new_sky_gradient(sky_gradient(*zenith, *nadir), size, size)
+                .await
+                .map_err(|e| anyhow!("sky gradient: {e}"))
         }
+        EnvSlot::Ktx { asset_id } => load_ktx(*asset_id, assets).await,
     }
-}
-
-/// Prefiltered (1024²) + irradiance (32²) env from a sky gradient — matches
-/// `env_sync::gradient_ibl`.
-async fn gradient_ibl(gradient: CubemapSkyGradient) -> Result<(CubemapImage, CubemapImage)> {
-    let p = CubemapImage::new_sky_gradient(gradient.clone(), 1024, 1024)
-        .await
-        .map_err(|e| anyhow!("prefiltered: {e}"))?;
-    let i = CubemapImage::new_sky_gradient(gradient, 32, 32)
-        .await
-        .map_err(|e| anyhow!("irradiance: {e}"))?;
-    Ok((p, i))
 }
 
 /// Read + parse a KTX2 cubemap from the bundle, at the shared [`env_ktx_path`]

--- a/packages/crates/scene-loader/src/environment.rs
+++ b/packages/crates/scene-loader/src/environment.rs
@@ -56,11 +56,7 @@ fn sky_gradient(zenith: [f32; 3], nadir: [f32; 3]) -> CubemapSkyGradient {
 
 /// Resolve one environment slot to a cubemap at the role's `size` (KTX slots
 /// ignore `size` — the file carries its own resolution/mips).
-async fn slot_image(
-    slot: &EnvSlot,
-    size: u32,
-    assets: &impl SceneAssets,
-) -> Result<CubemapImage> {
+async fn slot_image(slot: &EnvSlot, size: u32, assets: &impl SceneAssets) -> Result<CubemapImage> {
     match slot {
         EnvSlot::BuiltInDefault => {
             CubemapImage::new_sky_gradient(CubemapSkyGradient::default(), size, size)

--- a/packages/crates/scene/src/environment.rs
+++ b/packages/crates/scene/src/environment.rs
@@ -1,72 +1,96 @@
 use super::assets::AssetId;
 
+/// Image-based-lighting + skybox for a scene. Three **independent** slots, each a
+/// self-contained [`EnvSlot`]:
+/// - `skybox`     — the background cubemap the camera sees.
+/// - `specular`   — the prefiltered (roughness-mipped) env map that drives
+///   specular reflections. ("Prefiltered env" and "specular" are the same thing.)
+/// - `irradiance` — the diffuse-convolved env map that drives ambient lighting.
+///
+/// Slots are fully decoupled: a scene can keep the built-in default sky for the
+/// skybox and irradiance while overriding *only* the specular with a KTX file,
+/// or any other mix. Each slot serializes inline into the scene document.
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[derive(Default)]
 pub struct EnvironmentConfig {
     #[serde(default)]
-    pub skybox: SkyboxConfig,
+    pub skybox: EnvSlot,
     #[serde(default)]
-    pub ibl: IblConfig,
+    pub specular: EnvSlot,
+    #[serde(default)]
+    pub irradiance: EnvSlot,
 }
 
 impl EnvironmentConfig {
-    /// Every KTX2 cubemap asset id this environment references (skybox +
-    /// IBL-prefiltered + IBL-irradiance, when file-based). These are exactly the
-    /// ids whose BYTES must accompany the config — the editor's Save/export
-    /// write them to [`crate::project_dir::env_ktx_path`] and the player's
-    /// `apply_environment` reads them back from the same path. Procedural
-    /// variants (built-in default / sky-gradient) reference no assets.
+    /// Every KTX2 cubemap asset id this environment references (across all three
+    /// slots, when file-based). These are exactly the ids whose BYTES must
+    /// accompany the config — the editor's Save/export write them to
+    /// [`crate::project_dir::env_ktx_path`] and the player's `apply_environment`
+    /// reads them back from the same path. Procedural variants (built-in default
+    /// / sky-gradient) reference no assets. Duplicates are preserved so the count
+    /// reflects the referencing slots, but callers that dedup (bundle/save) are
+    /// free to collect into a set.
     pub fn ktx_asset_ids(&self) -> Vec<AssetId> {
-        let mut ids = Vec::new();
-        if let SkyboxConfig::Ktx { asset_id } = self.skybox {
-            ids.push(asset_id);
-        }
-        if let IblConfig::Ktx {
-            prefiltered_asset_id,
-            irradiance_asset_id,
-        } = self.ibl
-        {
-            ids.push(prefiltered_asset_id);
-            ids.push(irradiance_asset_id);
-        }
-        ids
+        [&self.skybox, &self.specular, &self.irradiance]
+            .into_iter()
+            .filter_map(|slot| match slot {
+                EnvSlot::Ktx { asset_id } => Some(*asset_id),
+                _ => None,
+            })
+            .collect()
     }
 }
 
+/// A single environment slot (skybox / specular / irradiance). All three slots
+/// share this type; the *role* (and therefore the generated resolution for the
+/// procedural variants) is decided by which field it fills, not by the enum.
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[derive(Copy, Default)]
-pub enum SkyboxConfig {
+pub enum EnvSlot {
+    /// The baked-in "Default sky" — a procedural [`CubemapSkyGradient`] default.
+    /// Referenced by no asset.
     #[default]
     BuiltInDefault,
-    Ktx {
-        asset_id: AssetId,
-    },
+    /// A KTX2 cubemap asset (skybox faces, or a prefiltered/irradiance map).
+    Ktx { asset_id: AssetId },
     /// Agent-authored two-color sky gradient (zenith→nadir), linear RGB. The
     /// generic "environment from agent data" hook (§18): pick a zenith (sky) and
     /// nadir (ground) color to author dusk / overcast / night / studio — no
     /// preset menu, no externally-hosted `.ktx2` required. Same generator the
     /// built-in default uses (`CubemapSkyGradient`).
-    SkyGradient {
-        zenith: [f32; 3],
-        nadir: [f32; 3],
-    },
+    SkyGradient { zenith: [f32; 3], nadir: [f32; 3] },
 }
 
-#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
-#[derive(Copy, Default)]
-pub enum IblConfig {
-    #[default]
-    BuiltInDefault,
-    Ktx {
-        prefiltered_asset_id: AssetId,
-        irradiance_asset_id: AssetId,
-    },
-    /// Agent-authored two-color sky-gradient IBL (zenith→nadir), linear RGB —
-    /// the IBL counterpart of [`SkyboxConfig::SkyGradient`] (§18). Drives both the
-    /// prefiltered-env and irradiance from the same gradient the built-in default
-    /// uses, so a custom sky also lights the scene consistently.
-    SkyGradient { zenith: [f32; 3], nadir: [f32; 3] },
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The three slots are fully independent: skybox / specular / irradiance can
+    /// each be a different kind (built-in default, sky-gradient, or KTX) in the
+    /// SAME config, and it round-trips through the scene.toml / project.toml serde
+    /// shape unchanged. `ktx_asset_ids()` reports only the KTX slot, so default +
+    /// gradient slots ship no side files.
+    #[test]
+    fn per_slot_kinds_are_independent_and_round_trip() {
+        let cfg = EnvironmentConfig {
+            skybox: EnvSlot::BuiltInDefault,
+            specular: EnvSlot::SkyGradient {
+                zenith: [0.1, 0.3, 0.9],
+                nadir: [0.02, 0.02, 0.05],
+            },
+            irradiance: EnvSlot::Ktx {
+                asset_id: AssetId::new(),
+            },
+        };
+        let toml = toml::to_string_pretty(&cfg).unwrap();
+        let back: EnvironmentConfig = toml::from_str(&toml).unwrap();
+        assert_eq!(cfg, back, "mixed per-slot env round-trips");
+        assert_eq!(
+            cfg.ktx_asset_ids().len(),
+            1,
+            "only the KTX slot carries bytes"
+        );
+    }
 }

--- a/packages/crates/scene/src/project_dir.rs
+++ b/packages/crates/scene/src/project_dir.rs
@@ -179,10 +179,12 @@ mod tests {
         let prefiltered = AssetId::new();
         let irradiance = AssetId::new();
         scene.environment = EnvironmentConfig {
-            skybox: crate::SkyboxConfig::Ktx { asset_id: skybox },
-            ibl: crate::IblConfig::Ktx {
-                prefiltered_asset_id: prefiltered,
-                irradiance_asset_id: irradiance,
+            skybox: crate::EnvSlot::Ktx { asset_id: skybox },
+            specular: crate::EnvSlot::Ktx {
+                asset_id: prefiltered,
+            },
+            irradiance: crate::EnvSlot::Ktx {
+                asset_id: irradiance,
             },
         };
         // The bake emits one file per env KTX id, at the shared convention path.
@@ -214,15 +216,14 @@ mod tests {
     #[test]
     fn gradient_environment_round_trips_through_scene_toml() {
         let mut scene = sample_scene();
+        let grad = crate::EnvSlot::SkyGradient {
+            zenith: [0.9, 0.3, 0.1],
+            nadir: [0.05, 0.02, 0.1],
+        };
         scene.environment = EnvironmentConfig {
-            skybox: crate::SkyboxConfig::SkyGradient {
-                zenith: [0.9, 0.3, 0.1],
-                nadir: [0.05, 0.02, 0.1],
-            },
-            ibl: crate::IblConfig::SkyGradient {
-                zenith: [0.9, 0.3, 0.1],
-                nadir: [0.05, 0.02, 0.1],
-            },
+            skybox: grad,
+            specular: grad,
+            irradiance: grad,
         };
         let toml = scene_to_toml(&scene).unwrap();
         let loaded = scene_from_toml(&toml).unwrap();

--- a/packages/frontend/editor/src/app.rs
+++ b/packages/frontend/editor/src/app.rs
@@ -521,6 +521,7 @@ fn settings_drawer() -> Dom {
                 .child(row("Light gizmos", toggle(s.light_gizmos.clone())))
                 .child(row("Skeleton overlay", toggle(s.skeleton_viz.clone())))
                 .child(row("MSAA", toggle(s.msaa.clone())))
+                .child(row("SMAA", toggle(s.smaa.clone())))
                 .child(row("Shadow denoise", toggle(s.shadow_denoise.clone())))
                 .child(row("Light heatmap", toggle(s.heatmap.clone())))
                 .child(row(

--- a/packages/frontend/editor/src/controller/query.rs
+++ b/packages/frontend/editor/src/controller/query.rs
@@ -5,7 +5,7 @@
 //! reads live controller + renderer state) stays in [`super::state`].
 pub use awsm_renderer_editor_protocol::{
     AnimationSnapshot, ClipSnapshot, CompileDiagnostics, CompileError, EditorQuery, EditorSnapshot,
-    EnvSlotSnapshot, EnvironmentSnapshot, MapResult, MaterialSnapshot, PixelsResult, ProjectSnapshot,
-    QueryResult, ReadbackTarget, SettledResult, StatsResult, TextureSnapshot, TimeseriesFrame,
-    TimeseriesResult, TrackSnapshot,
+    EnvSlotSnapshot, EnvironmentSnapshot, MapResult, MaterialSnapshot, PixelsResult,
+    ProjectSnapshot, QueryResult, ReadbackTarget, SettledResult, StatsResult, TextureSnapshot,
+    TimeseriesFrame, TimeseriesResult, TrackSnapshot,
 };

--- a/packages/frontend/editor/src/controller/query.rs
+++ b/packages/frontend/editor/src/controller/query.rs
@@ -5,6 +5,7 @@
 //! reads live controller + renderer state) stays in [`super::state`].
 pub use awsm_renderer_editor_protocol::{
     AnimationSnapshot, ClipSnapshot, CompileDiagnostics, CompileError, EditorQuery, EditorSnapshot,
-    MapResult, MaterialSnapshot, PixelsResult, ProjectSnapshot, QueryResult, ReadbackTarget,
-    SettledResult, StatsResult, TextureSnapshot, TimeseriesFrame, TimeseriesResult, TrackSnapshot,
+    EnvSlotSnapshot, EnvironmentSnapshot, MapResult, MaterialSnapshot, PixelsResult, ProjectSnapshot,
+    QueryResult, ReadbackTarget, SettledResult, StatsResult, TextureSnapshot, TimeseriesFrame,
+    TimeseriesResult, TrackSnapshot,
 };

--- a/packages/frontend/editor/src/controller/state.rs
+++ b/packages/frontend/editor/src/controller/state.rs
@@ -2767,15 +2767,21 @@ impl EditorController {
                 self.scene.bump_revision();
                 Ok(Some(EditorCommand::SetEnvironment { env: prev }))
             }
-            EditorCommand::PatchEnvironment { skybox, ibl } => {
+            EditorCommand::PatchEnvironment {
+                skybox,
+                specular,
+                irradiance,
+            } => {
                 // Partial update: `None` slots PRESERVE the current config, so
-                // setting just the IBL doesn't silently reset the skybox (and
-                // vice versa) — the split skybox/IBL workflow survives
-                // sequential MCP calls. Inverse: the prior FULL environment.
+                // setting just one slot (skybox / specular / irradiance) doesn't
+                // silently reset the others — mixed workflows (default-sky
+                // irradiance + custom specular, neutral skybox + keyed IBL, …)
+                // survive sequential MCP calls. Inverse: the prior FULL env.
                 let prev = self.scene.environment.get_cloned();
                 let next = crate::engine::scene::EnvironmentConfig {
                     skybox: skybox.unwrap_or(prev.skybox),
-                    ibl: ibl.unwrap_or(prev.ibl),
+                    specular: specular.unwrap_or(prev.specular),
+                    irradiance: irradiance.unwrap_or(prev.irradiance),
                 };
                 self.scene.environment.set(next);
                 self.scene.bump_revision();
@@ -4486,6 +4492,7 @@ impl EditorController {
                 env_unsaved: self.scene.environment.get_cloned()
                     != self.env_saved_baseline.get_cloned(),
                 missing_assets: self.missing_assets.get_cloned(),
+                environment: self.environment_snapshot(),
                 coordinate_system: "right-handed, Y-up, -Z forward".to_string(),
                 units: self.settings.units.get_cloned(),
             },
@@ -4553,6 +4560,44 @@ impl EditorController {
                 _ => None,
             })
             .collect()
+    }
+
+    /// Per-slot read of the current environment for the snapshot — so an MCP
+    /// driver can see WHAT is set (built-in default vs. a KTX asset vs. a sky
+    /// gradient), mirroring the editor's three per-slot pickers.
+    fn environment_snapshot(&self) -> query::EnvironmentSnapshot {
+        use crate::engine::scene::{AssetSource, EnvSlot};
+        let env = self.scene.environment.get_cloned();
+        let assets = self.scene.assets.lock().unwrap();
+        let slot = |s: &EnvSlot| -> query::EnvSlotSnapshot {
+            match s {
+                EnvSlot::BuiltInDefault => query::EnvSlotSnapshot::default(),
+                EnvSlot::SkyGradient { zenith, nadir } => query::EnvSlotSnapshot {
+                    kind: "sky_gradient".to_string(),
+                    asset_id: None,
+                    label: None,
+                    gradient: Some([*zenith, *nadir]),
+                },
+                EnvSlot::Ktx { asset_id } => {
+                    let label = assets.entries.get(asset_id).and_then(|e| match &e.source {
+                        AssetSource::Filename(name) => Some(name.clone()),
+                        AssetSource::Url(url) => url.rsplit('/').next().map(str::to_string),
+                        _ => None,
+                    });
+                    query::EnvSlotSnapshot {
+                        kind: "ktx".to_string(),
+                        asset_id: Some(asset_id.to_string()),
+                        label,
+                        gradient: None,
+                    }
+                }
+            }
+        };
+        query::EnvironmentSnapshot {
+            skybox: slot(&env.skybox),
+            specular: slot(&env.specular),
+            irradiance: slot(&env.irradiance),
+        }
     }
 
     /// The Animation-mode projection of `snapshot()`.

--- a/packages/frontend/editor/src/controller/state.rs
+++ b/packages/frontend/editor/src/controller/state.rs
@@ -197,6 +197,12 @@ pub struct Settings {
     /// inert in Scene/Material modes.
     pub auto_key: Mutable<bool>,
     pub msaa: Mutable<bool>,
+    /// SMAA (post-process morphological AA). Transient, like [`Self::msaa`] —
+    /// NOT persisted (AA is a player/runtime decision, not scene data); it's here
+    /// only so aliasing can be eyeballed/debugged in the editor viewport. Drives
+    /// the renderer's `AntiAliasing::smaa` via `settings_sync`. Off by default
+    /// (MSAA already on), independent of MSAA so both can be compared.
+    pub smaa: Mutable<bool>,
     pub heatmap: Mutable<bool>,
     /// Edge-aware shadow denoise blur (global). Drives the renderer's
     /// `ShadowsConfig::denoise` via `settings_sync`.
@@ -218,6 +224,7 @@ impl Default for Settings {
             skeleton_viz: Mutable::new(true),
             auto_key: Mutable::new(true),
             msaa: Mutable::new(true),
+            smaa: Mutable::new(false),
             heatmap: Mutable::new(false),
             // On by default — matches the renderer's `ShadowsConfig::denoise`
             // default; keeps point-light soft/PCSS penumbras clean out of box.

--- a/packages/frontend/editor/src/engine/bridge/env_sync.rs
+++ b/packages/frontend/editor/src/engine/bridge/env_sync.rs
@@ -25,8 +25,15 @@ use awsm_renderer_core::cubemap::CubemapImage;
 
 use crate::controller::controller;
 use crate::engine::context::renderer_handle;
-use crate::engine::scene::{AssetId, AssetSource, EnvironmentConfig, IblConfig, SkyboxConfig};
+use crate::engine::scene::{AssetId, AssetSource, EnvSlot, EnvironmentConfig};
 use crate::prelude::*;
+
+/// Procedural-gradient cubemap sizes per slot role — mirror
+/// `scene_loader::environment` so the editor and player generate the built-in
+/// default identically.
+const SKYBOX_SIZE: u32 = 1024;
+const SPECULAR_SIZE: u32 = 1024;
+const IRRADIANCE_SIZE: u32 = 32;
 
 thread_local! {
     /// In-memory KTX bytes for HDR assets picked this session, keyed by the
@@ -76,7 +83,7 @@ pub async fn apply_initial() {
     if let Err(err) = apply_skybox(&env.skybox).await {
         tracing::error!("initial skybox apply failed: {err}");
     }
-    if let Err(err) = apply_ibl(&env.ibl).await {
+    if let Err(err) = apply_ibl(&env.specular, &env.irradiance).await {
         tracing::error!("initial ibl apply failed: {err}");
     }
 }
@@ -97,7 +104,12 @@ pub fn start() {
                     .as_ref()
                     .map(|p| p.skybox != env.skybox)
                     .unwrap_or(true);
-                let ibl_changed = previous.as_ref().map(|p| p.ibl != env.ibl).unwrap_or(true);
+                // IBL re-applies if EITHER the specular (prefiltered) or the
+                // irradiance slot changed — both feed a single `set_ibl`.
+                let ibl_changed = previous
+                    .as_ref()
+                    .map(|p| p.specular != env.specular || p.irradiance != env.irradiance)
+                    .unwrap_or(true);
                 previous = Some(env.clone());
                 async move {
                     if sky_changed {
@@ -107,7 +119,7 @@ pub fn start() {
                         }
                     }
                     if ibl_changed {
-                        if let Err(err) = apply_ibl(&env.ibl).await {
+                        if let Err(err) = apply_ibl(&env.specular, &env.irradiance).await {
                             tracing::error!("ibl apply failed: {err}");
                             Toast::error(format!("IBL failed: {err}"));
                         }
@@ -125,58 +137,39 @@ fn sky_gradient(zenith: [f32; 3], nadir: [f32; 3]) -> CubemapSkyGradient {
     CubemapSkyGradient::new(c(zenith), c(nadir))
 }
 
-async fn apply_skybox(cfg: &SkyboxConfig) -> anyhow::Result<()> {
-    let image = match cfg {
-        SkyboxConfig::BuiltInDefault => {
-            CubemapImage::new_sky_gradient(CubemapSkyGradient::default(), 1024, 1024)
-                .await
-                .map_err(|e| anyhow::anyhow!("sky gradient: {e}"))?
-        }
-        // §18: agent-authored sky gradient — same generator as BuiltInDefault.
-        SkyboxConfig::SkyGradient { zenith, nadir } => {
-            CubemapImage::new_sky_gradient(sky_gradient(*zenith, *nadir), 1024, 1024)
-                .await
-                .map_err(|e| anyhow::anyhow!("sky gradient: {e}"))?
-        }
-        SkyboxConfig::Ktx { asset_id } => load_ktx_by_id(*asset_id).await?,
-    };
+async fn apply_skybox(slot: &EnvSlot) -> anyhow::Result<()> {
+    let image = slot_image(slot, SKYBOX_SIZE).await?;
     let handle = renderer_handle();
     let mut renderer = handle.lock().await;
     set_skybox_on_renderer(&mut renderer, image).await
 }
 
-async fn apply_ibl(cfg: &IblConfig) -> anyhow::Result<()> {
-    let (prefiltered, irradiance) = match cfg {
-        IblConfig::BuiltInDefault => gradient_ibl(CubemapSkyGradient::default()).await?,
-        // §18: agent-authored sky-gradient IBL — same generator as BuiltInDefault.
-        IblConfig::SkyGradient { zenith, nadir } => {
-            gradient_ibl(sky_gradient(*zenith, *nadir)).await?
-        }
-        IblConfig::Ktx {
-            prefiltered_asset_id,
-            irradiance_asset_id,
-        } => {
-            let p = load_ktx_by_id(*prefiltered_asset_id).await?;
-            let i = load_ktx_by_id(*irradiance_asset_id).await?;
-            (p, i)
-        }
-    };
+async fn apply_ibl(specular: &EnvSlot, irradiance: &EnvSlot) -> anyhow::Result<()> {
+    let prefiltered = slot_image(specular, SPECULAR_SIZE).await?;
+    let irradiance = slot_image(irradiance, IRRADIANCE_SIZE).await?;
     let handle = renderer_handle();
     let mut renderer = handle.lock().await;
     set_ibl_on_renderer(&mut renderer, prefiltered, irradiance).await
 }
 
-/// Prefiltered (1024²) + irradiance (32²) env from a sky gradient.
-async fn gradient_ibl(
-    gradient: CubemapSkyGradient,
-) -> anyhow::Result<(CubemapImage, CubemapImage)> {
-    let p = CubemapImage::new_sky_gradient(gradient.clone(), 1024, 1024)
-        .await
-        .map_err(|e| anyhow::anyhow!("prefiltered: {e}"))?;
-    let i = CubemapImage::new_sky_gradient(gradient, 32, 32)
-        .await
-        .map_err(|e| anyhow::anyhow!("irradiance: {e}"))?;
-    Ok((p, i))
+/// Resolve one environment slot to a cubemap at the role's `size`. `Ktx` slots
+/// ignore `size` (the file carries its own resolution/mips); the procedural
+/// variants generate at `size`. §18 sky-gradient uses the same generator as the
+/// built-in default.
+async fn slot_image(slot: &EnvSlot, size: u32) -> anyhow::Result<CubemapImage> {
+    match slot {
+        EnvSlot::BuiltInDefault => {
+            CubemapImage::new_sky_gradient(CubemapSkyGradient::default(), size, size)
+                .await
+                .map_err(|e| anyhow::anyhow!("sky gradient: {e}"))
+        }
+        EnvSlot::SkyGradient { zenith, nadir } => {
+            CubemapImage::new_sky_gradient(sky_gradient(*zenith, *nadir), size, size)
+                .await
+                .map_err(|e| anyhow::anyhow!("sky gradient: {e}"))
+        }
+        EnvSlot::Ktx { asset_id } => load_ktx_by_id(*asset_id).await,
+    }
 }
 
 /// Resolve a KTX cubemap by `AssetId`: the scene asset table gives the source,

--- a/packages/frontend/editor/src/engine/scene/mod.rs
+++ b/packages/frontend/editor/src/engine/scene/mod.rs
@@ -25,6 +25,6 @@ pub use model::{Scene, SceneStats};
 pub use node::{Node, NodeId};
 #[allow(unused_imports)]
 pub use types::{
-    AssetStatus, CameraConfig, CameraProjection, ColliderShape, EnvironmentConfig, IblConfig,
-    LightConfig, LightKind, NodeKind, SkyboxConfig, Trs,
+    AssetStatus, CameraConfig, CameraProjection, ColliderShape, EnvSlot, EnvironmentConfig,
+    LightConfig, LightKind, NodeKind, Trs,
 };

--- a/packages/frontend/editor/src/engine/scene/types.rs
+++ b/packages/frontend/editor/src/engine/scene/types.rs
@@ -8,8 +8,8 @@
 //! never serialized.
 
 pub use awsm_renderer_editor_protocol::{
-    CameraConfig, CameraProjection, ColliderShape, EnvironmentConfig, IblConfig, LightConfig,
-    LightKind, NodeKind, SkyboxConfig, Trs,
+    CameraConfig, CameraProjection, ColliderShape, EnvSlot, EnvironmentConfig, LightConfig,
+    LightKind, NodeKind, Trs,
 };
 
 /// Load state of the renderer-side asset (glb/gltf) for a `Model` node.

--- a/packages/frontend/editor/src/engine/settings_sync.rs
+++ b/packages/frontend/editor/src/engine/settings_sync.rs
@@ -92,6 +92,42 @@ pub fn start() {
             .await;
     });
 
+    // SMAA on/off — post-process AA on `AntiAliasing::smaa`. Recompiles the
+    // effects/display pipelines (via `set_anti_aliasing`), so it's async + guarded
+    // against redundant re-applies, mirroring the MSAA observer above. Transient
+    // (not persisted) — a debug-only editor view of what a player might enable.
+    spawn_local(async {
+        let mut first = true;
+        controller()
+            .settings
+            .smaa
+            .signal()
+            .for_each(move |on| {
+                let skip = first;
+                first = false;
+                async move {
+                    if skip {
+                        return;
+                    }
+                    let handle = renderer_handle();
+                    let mut r = handle.lock().await;
+                    if r.anti_aliasing.smaa != on {
+                        let mut aa = r.anti_aliasing.clone();
+                        aa.smaa = on;
+                        if let Err(e) = r.set_anti_aliasing(aa).await {
+                            tracing::warn!("set_anti_aliasing (smaa): {e}");
+                        }
+                        // Same as the MSAA flip: route the material-variant
+                        // reconcile through the one compile path.
+                        if let Err(e) = r.commit_load(|_| {}).await {
+                            tracing::warn!("commit_load after smaa toggle: {e}");
+                        }
+                    }
+                }
+            })
+            .await;
+    });
+
     // Global SSCS (screen-space contact shadows): the authored, persisted
     // `scene.shadows` SSCS fields → renderer. `enabled` / `step_count` are
     // compile-time template constants, so they can recompile the shadow-consuming

--- a/packages/frontend/editor/src/scene_mode/content_browser.rs
+++ b/packages/frontend/editor/src/scene_mode/content_browser.rs
@@ -515,9 +515,11 @@ fn collect_cards(cat: Cat, query: &str) -> Vec<Card> {
     cards
 }
 
-/// Environment cubemap files (.ktx2/.ktx, from the ribbon HDR picker or an MCP
-/// `set_environment` URL import) — carded as ENV, never as MODEL.
-fn is_env_cubemap(name: &str) -> bool {
+/// Environment cubemap files (.ktx2/.ktx, from the ribbon env pickers or an MCP
+/// `set_environment` URL import) — carded as ENV, never as MODEL. Shared with the
+/// ribbon's per-slot pickers (`collect_env_assets`) so both agree on what counts
+/// as an assignable environment map.
+pub(crate) fn is_env_cubemap(name: &str) -> bool {
     let lower = name.to_ascii_lowercase();
     lower.ends_with(".ktx2") || lower.ends_with(".ktx")
 }

--- a/packages/frontend/editor/src/scene_mode/ribbon.rs
+++ b/packages/frontend/editor/src/scene_mode/ribbon.rs
@@ -6,7 +6,7 @@
 use awsm_renderer_editor_protocol::{LightKind, PrimitiveShape};
 
 use crate::controller::InsertSpec;
-use crate::engine::scene::{EnvironmentConfig, IblConfig, SkyboxConfig};
+use crate::engine::scene::{AssetId, AssetSource, EnvSlot};
 use crate::prelude::*;
 
 /// Dispatch an insert of `spec` at the scene root.
@@ -295,55 +295,134 @@ fn object_row() -> Dom {
     })
 }
 
+/// The three independent environment slots. Each renders as its own picker
+/// showing the current assignment (see [`env_slot_picker`]).
+#[derive(Clone, Copy, PartialEq)]
+enum Slot {
+    Skybox,
+    Specular,
+    Irradiance,
+}
+
+impl Slot {
+    fn title(self) -> &'static str {
+        match self {
+            Slot::Skybox => "Skybox",
+            Slot::Specular => "IBL Specular",
+            Slot::Irradiance => "IBL Irradiance",
+        }
+    }
+    /// This slot's current value out of an environment config.
+    fn get(self, env: &crate::engine::scene::EnvironmentConfig) -> EnvSlot {
+        match self {
+            Slot::Skybox => env.skybox,
+            Slot::Specular => env.specular,
+            Slot::Irradiance => env.irradiance,
+        }
+    }
+    /// A `PatchEnvironment` that changes ONLY this slot (the others stay `None` →
+    /// preserved), so assigning one slot never resets the other two.
+    fn patch(self, value: EnvSlot) -> EditorCommand {
+        let (skybox, specular, irradiance) = match self {
+            Slot::Skybox => (Some(value), None, None),
+            Slot::Specular => (None, Some(value), None),
+            Slot::Irradiance => (None, None, Some(value)),
+        };
+        EditorCommand::PatchEnvironment {
+            skybox,
+            specular,
+            irradiance,
+        }
+    }
+}
+
 fn environment_row() -> Dom {
     html!("div", {
         .style("display", "flex").style("align-items", "center").style("gap", "8px")
-        .child(DropButton::new().label("Environment\u{2026}").icon("env").size(BtnSize::Sm)
-            .items(move |close: Close| {
-                vec![
-                    MenuItem::new("Simple Sky")
-                        .on_click(clone!(close => move || {
-                            // Default = BuiltInDefault skybox + IBL (the procedural sky gradient).
-                            set_environment(EnvironmentConfig::default());
-                            (close.borrow_mut())();
-                        }))
-                        .render(),
-                ]
-            }).render())
-        .child(Btn::new().label("HDR set\u{2026}").icon("sphere").variant(BtnVariant::Ghost).size(BtnSize::Sm)
-            .on_click(open_hdr_modal).render())
-        // Live readout of the ACTIVE environment — reacts to every write path
-        // (ribbon preset, HDR picker, MCP set_environment, project load), so
-        // an agent-set environment is visible in the UI, not just the render.
-        .child(html!("span", {
-            .style("font-size", "11.5px").style("color", "var(--text-3)")
-            .style("white-space", "nowrap")
-            .text_signal(controller().scene.environment.signal_cloned().map(|env| {
-                let sky = match &env.skybox {
-                    SkyboxConfig::BuiltInDefault => "Simple Sky".to_string(),
-                    SkyboxConfig::SkyGradient { .. } => "sky gradient".to_string(),
-                    SkyboxConfig::Ktx { asset_id } => env_asset_label(*asset_id),
-                };
-                let ibl = match &env.ibl {
-                    IblConfig::BuiltInDefault => "Simple Sky".to_string(),
-                    IblConfig::SkyGradient { .. } => "sky gradient".to_string(),
-                    IblConfig::Ktx { prefiltered_asset_id, .. } =>
-                        env_asset_label(*prefiltered_asset_id),
-                };
-                if sky == ibl {
-                    format!("Sky+IBL: {sky}")
-                } else {
-                    format!("Sky: {sky} \u{b7} IBL: {ibl}")
-                }
-            }))
+        .child(env_slot_picker(Slot::Skybox))
+        .child(env_slot_picker(Slot::Specular))
+        .child(env_slot_picker(Slot::Irradiance))
+    })
+}
+
+/// A per-slot picker. The trigger label reflects the CURRENT assignment (reacts
+/// to every write path — this picker, MCP `set_environment`, project load), so
+/// what's set is always visible. The menu offers the built-in default sky, every
+/// imported env cubemap asset, and an import action.
+fn env_slot_picker(slot: Slot) -> Dom {
+    html!("span", {
+        .child_signal(controller().scene.environment.signal_cloned().map(move |env| {
+            Some(env_slot_button(slot, slot.get(&env)))
         }))
     })
 }
 
+fn env_slot_button(slot: Slot, current: EnvSlot) -> Dom {
+    let label = format!("{}: {}", slot.title(), env_slot_label(&current));
+    DropButton::new().label(label).icon("env").size(BtnSize::Sm)
+        .items(move |close: Close| {
+            let mut rows = vec![
+                MenuItem::new("Default sky")
+                    .checked(matches!(current, EnvSlot::BuiltInDefault))
+                    .on_click(clone!(close => move || {
+                        patch_env_slot(slot, EnvSlot::BuiltInDefault);
+                        (close.borrow_mut())();
+                    }))
+                    .render(),
+            ];
+            // Preserve (and mark) an agent-authored sky gradient if that's what
+            // this slot currently holds — the UI can't author one, but it must
+            // not hide it or misreport the slot as "Default sky".
+            if matches!(current, EnvSlot::SkyGradient { .. }) {
+                rows.push(
+                    MenuItem::new("Sky gradient (set via MCP)")
+                        .checked(true)
+                        .disabled(true)
+                        .render(),
+                );
+            }
+            let assets = collect_env_assets();
+            if !assets.is_empty() {
+                rows.push(menu_sep());
+                for (id, name) in assets {
+                    let is_current = matches!(current, EnvSlot::Ktx { asset_id } if asset_id == id);
+                    rows.push(
+                        MenuItem::new(name)
+                            .checked(is_current)
+                            .on_click(clone!(close => move || {
+                                patch_env_slot(slot, EnvSlot::Ktx { asset_id: id });
+                                (close.borrow_mut())();
+                            }))
+                            .render(),
+                    );
+                }
+            }
+            rows.push(menu_sep());
+            rows.push(
+                MenuItem::new("Import .ktx2\u{2026}")
+                    .icon("sphere")
+                    .on_click(clone!(close => move || {
+                        import_env_ktx(slot);
+                        (close.borrow_mut())();
+                    }))
+                    .render(),
+            );
+            rows
+        }).render()
+}
+
+/// Short display label for a slot's current value.
+fn env_slot_label(slot: &EnvSlot) -> String {
+    match slot {
+        EnvSlot::BuiltInDefault => "Default sky".to_string(),
+        EnvSlot::SkyGradient { .. } => "sky gradient".to_string(),
+        EnvSlot::Ktx { asset_id } => env_asset_label(*asset_id),
+    }
+}
+
 /// Display label for a KTX environment asset — its `Filename`/`Url` leaf name,
 /// or a short id when the asset entry is gone.
-fn env_asset_label(id: crate::engine::scene::AssetId) -> String {
-    use crate::engine::scene::AssetSource;
+fn env_asset_label(id: AssetId) -> String {
     let name = controller()
         .scene
         .assets
@@ -359,15 +438,34 @@ fn env_asset_label(id: crate::engine::scene::AssetId) -> String {
     name.unwrap_or_else(|| format!("{:.8}", id.0.to_string()))
 }
 
-/// Dispatch a `SetEnvironment` command — the only path to the renderer skybox/IBL
-/// (so the environment is serialized into the scene, undoable, and MCP-drivable).
-fn set_environment(env: EnvironmentConfig) {
+/// Every env-cubemap asset (`.ktx2`/`.ktx`, from an import here or an MCP URL
+/// import) that a slot can reference, sorted by name. Shares `is_env_cubemap`
+/// with the Content Browser so both agree on what's an environment map.
+fn collect_env_assets() -> Vec<(AssetId, String)> {
+    use crate::scene_mode::content_browser::is_env_cubemap;
+    let ctrl = controller();
+    let assets = ctrl.scene.assets.lock().unwrap();
+    let mut out: Vec<(AssetId, String)> = assets
+        .entries
+        .iter()
+        .filter_map(|(id, e)| match &e.source {
+            AssetSource::Filename(name) if is_env_cubemap(name) => Some((*id, name.clone())),
+            AssetSource::Url(url) if is_env_cubemap(url) => {
+                Some((*id, url.rsplit('/').next().unwrap_or(url).to_string()))
+            }
+            _ => None,
+        })
+        .collect();
+    out.sort_by(|a, b| a.1.to_lowercase().cmp(&b.1.to_lowercase()));
+    out
+}
+
+/// Assign `value` to `slot` via a partial `PatchEnvironment` (undoable,
+/// serialized, MCP-consistent).
+fn patch_env_slot(slot: Slot, value: EnvSlot) {
     spawn_local(async move {
-        if let Err(err) = controller()
-            .dispatch(EditorCommand::SetEnvironment { env })
-            .await
-        {
-            tracing::error!("ribbon: SetEnvironment failed: {err}");
+        if let Err(err) = controller().dispatch(slot.patch(value)).await {
+            tracing::error!("ribbon: PatchEnvironment failed: {err}");
         }
     });
 }
@@ -379,38 +477,35 @@ async fn read_file_bytes(file: &web_sys::File) -> Result<Vec<u8>, String> {
     Ok(js_sys::Uint8Array::new(&buf).to_vec())
 }
 
-/// Photoreal HDR environment: three KTX2 file pickers (skybox + prefiltered env
-/// + irradiance) → stashed as assets → a `SetEnvironment` command.
-fn open_hdr_modal() {
-    Modal::open(|| {
-        let skybox: Mutable<Option<web_sys::File>> = Mutable::new(None);
-        let env: Mutable<Option<web_sys::File>> = Mutable::new(None);
-        let irr: Mutable<Option<web_sys::File>> = Mutable::new(None);
-        ModalCard::new("Load HDR environment")
-            .width(560.0)
+/// Import a single `.ktx2` cubemap and assign it to `slot`. One file picker,
+/// then a partial patch — the other two slots are untouched.
+fn import_env_ktx(slot: Slot) {
+    Modal::open(move || {
+        let file: Mutable<Option<web_sys::File>> = Mutable::new(None);
+        ModalCard::new(format!("Import .ktx2 \u{2192} {}", slot.title()))
+            .width(480.0)
             .child(html!("div", {
                 .style("display", "flex").style("flex-direction", "column").style("gap", "10px")
                 .child(html!("span", { .style("font-size", "12.5px").style("color", "var(--text-2)").style("line-height", "1.5")
-                    .text("Pick the three KTX2 cubemaps for this environment.") }))
-                .child(hdr_file_row("Skybox (.ktx2)", skybox.clone()))
-                .child(hdr_file_row("Prefiltered env (.ktx2)", env.clone()))
-                .child(hdr_file_row("Irradiance (.ktx2)", irr.clone()))
+                    .text("Pick a .ktx2 cubemap to assign to this slot. It joins the project assets and can be reused by the other slots.") }))
+                .child(env_file_row(".ktx2 cubemap", file.clone()))
             }))
             .footer(html!("div", {
                 .style("display", "flex").style("gap", "8px")
                 .child(Btn::new().label("Cancel").variant(BtnVariant::Ghost).on_click(Modal::close).render())
-                .child(Btn::new().label("Load").icon("sphere").variant(BtnVariant::Primary)
-                    .on_click(clone!(skybox, env, irr => move || {
-                        let (Some(sky), Some(envf), Some(irrf)) =
-                            (skybox.get_cloned(), env.get_cloned(), irr.get_cloned())
-                        else {
-                            Toast::error("Pick all three .ktx2 files.");
+                .child(Btn::new().label("Import").icon("sphere").variant(BtnVariant::Primary)
+                    .on_click(clone!(file => move || {
+                        let Some(f) = file.get_cloned() else {
+                            Toast::error("Pick a .ktx2 file.");
                             return;
                         };
                         spawn_local(async move {
-                            match load_hdr(sky, envf, irrf).await {
-                                Ok(cfg) => { set_environment(cfg); Modal::close(); }
-                                Err(e) => Toast::error(format!("HDR load failed: {e}")),
+                            match import_env_file(f).await {
+                                Ok(id) => {
+                                    patch_env_slot(slot, EnvSlot::Ktx { asset_id: id });
+                                    Modal::close();
+                                }
+                                Err(e) => Toast::error(format!("Import failed: {e}")),
                             }
                         });
                     })).render())
@@ -419,10 +514,10 @@ fn open_hdr_modal() {
     });
 }
 
-fn hdr_file_row(label: &str, slot: Mutable<Option<web_sys::File>>) -> Dom {
+fn env_file_row(label: &str, slot: Mutable<Option<web_sys::File>>) -> Dom {
     html!("div", {
         .style("display", "flex").style("align-items", "center").style("gap", "8px")
-        .child(html!("span", { .style("font-size", "12.5px").style("color", "var(--text-2)").style("min-width", "150px").text(label) }))
+        .child(html!("span", { .style("font-size", "12.5px").style("color", "var(--text-2)").style("min-width", "120px").text(label) }))
         .child(html!("input" => web_sys::HtmlInputElement, {
             .attr("type", "file").attr("accept", ".ktx2,.ktx")
             .with_node!(el => {
@@ -434,39 +529,24 @@ fn hdr_file_row(label: &str, slot: Mutable<Option<web_sys::File>>) -> Dom {
     })
 }
 
-/// Read the three picked KTX files, stash their bytes + register asset entries,
-/// and build the `EnvironmentConfig` that references them by id.
-async fn load_hdr(
-    skybox: web_sys::File,
-    env: web_sys::File,
-    irr: web_sys::File,
-) -> Result<EnvironmentConfig, String> {
+/// Read a picked KTX file, register it as a project asset + stash its bytes, and
+/// return the new asset id (to reference from a slot). Mirrors the MCP
+/// `ImportKtxEnvFromUrl` path (a `Filename` asset entry + `env_sync` byte stash).
+async fn import_env_file(file: web_sys::File) -> Result<AssetId, String> {
     use crate::engine::bridge::env_sync::stash_ktx;
-    use crate::engine::scene::{AssetId, AssetSource};
     use awsm_renderer_editor_protocol::AssetEntry;
 
-    async fn stash(file: web_sys::File) -> Result<AssetId, String> {
-        let bytes = read_file_bytes(&file).await?;
-        let id = AssetId::new();
-        controller()
-            .scene
-            .assets
-            .lock()
-            .unwrap()
-            .entries
-            .insert(id, AssetEntry::new(AssetSource::Filename(file.name())));
-        stash_ktx(id, bytes);
-        Ok(id)
-    }
-
-    let sky_id = stash(skybox).await?;
-    let env_id = stash(env).await?;
-    let irr_id = stash(irr).await?;
-    Ok(EnvironmentConfig {
-        skybox: SkyboxConfig::Ktx { asset_id: sky_id },
-        ibl: IblConfig::Ktx {
-            prefiltered_asset_id: env_id,
-            irradiance_asset_id: irr_id,
-        },
-    })
+    let bytes = read_file_bytes(&file).await?;
+    let id = AssetId::new();
+    controller()
+        .scene
+        .assets
+        .lock()
+        .unwrap()
+        .entries
+        .insert(id, AssetEntry::new(AssetSource::Filename(file.name())));
+    stash_ktx(id, bytes);
+    // Surface the new asset in the Content Browser / other pickers immediately.
+    controller().scene.bump_revision();
+    Ok(id)
 }

--- a/packages/frontend/editor/src/scene_mode/ribbon.rs
+++ b/packages/frontend/editor/src/scene_mode/ribbon.rs
@@ -359,17 +359,18 @@ fn env_slot_picker(slot: Slot) -> Dom {
 
 fn env_slot_button(slot: Slot, current: EnvSlot) -> Dom {
     let label = format!("{}: {}", slot.title(), env_slot_label(&current));
-    DropButton::new().label(label).icon("env").size(BtnSize::Sm)
+    DropButton::new()
+        .label(label)
+        .icon("env")
+        .size(BtnSize::Sm)
         .items(move |close: Close| {
-            let mut rows = vec![
-                MenuItem::new("Default sky")
-                    .checked(matches!(current, EnvSlot::BuiltInDefault))
-                    .on_click(clone!(close => move || {
-                        patch_env_slot(slot, EnvSlot::BuiltInDefault);
-                        (close.borrow_mut())();
-                    }))
-                    .render(),
-            ];
+            let mut rows = vec![MenuItem::new("Default sky")
+                .checked(matches!(current, EnvSlot::BuiltInDefault))
+                .on_click(clone!(close => move || {
+                    patch_env_slot(slot, EnvSlot::BuiltInDefault);
+                    (close.borrow_mut())();
+                }))
+                .render()];
             // Preserve (and mark) an agent-authored sky gradient if that's what
             // this slot currently holds — the UI can't author one, but it must
             // not hide it or misreport the slot as "Default sky".
@@ -408,7 +409,8 @@ fn env_slot_button(slot: Slot, current: EnvSlot) -> Dom {
                     .render(),
             );
             rows
-        }).render()
+        })
+        .render()
 }
 
 /// Short display label for a slot's current value.
@@ -456,7 +458,7 @@ fn collect_env_assets() -> Vec<(AssetId, String)> {
             _ => None,
         })
         .collect();
-    out.sort_by(|a, b| a.1.to_lowercase().cmp(&b.1.to_lowercase()));
+    out.sort_by_key(|(_, name)| name.to_lowercase());
     out
 }
 

--- a/packages/mcp/editor-protocol/src/command.rs
+++ b/packages/mcp/editor-protocol/src/command.rs
@@ -16,8 +16,8 @@ use awsm_renderer_scene::particle::{
     ColorOverLifeDef, EmitterSpaceDef, ForceDef, SizeOverLifeDef, SpawnShapeDef,
 };
 use awsm_renderer_scene::{
-    AssetId, EnvironmentConfig, IblConfig, MaterialDef, MaterialShading, NodeId, NodeKind,
-    SkyboxConfig, ToneMappingConfig, Trs,
+    AssetId, EnvSlot, EnvironmentConfig, MaterialDef, MaterialShading, NodeId, NodeKind,
+    ToneMappingConfig, Trs,
 };
 
 use awsm_renderer_meshgen::recipe::{Modifier, ModifierStack};
@@ -428,13 +428,15 @@ pub enum EditorCommand {
 
     /// Patch the scene environment: only the `Some` slots change; a `None` slot
     /// PRESERVES the current config. This is what the MCP `set_environment`
-    /// tool dispatches, so setting just the IBL (or just the skybox) no longer
-    /// silently resets the other slot to `BuiltInDefault` — the split
-    /// skybox/IBL workflow (neutral background, keyed reflections) survives
-    /// sequential calls. Inverse: restore the prior full environment.
+    /// tool dispatches, so setting just one slot (skybox / specular / irradiance)
+    /// no longer silently resets the others to `BuiltInDefault` — the split
+    /// skybox/IBL workflow (neutral background, keyed reflections, default-sky
+    /// irradiance + custom specular, …) survives sequential calls. Inverse:
+    /// restore the prior full environment.
     PatchEnvironment {
-        skybox: Option<SkyboxConfig>,
-        ibl: Option<IblConfig>,
+        skybox: Option<EnvSlot>,
+        specular: Option<EnvSlot>,
+        irradiance: Option<EnvSlot>,
     },
 
     /// Patch the global SSCS (screen-space contact-shadow) settings on

--- a/packages/mcp/editor-protocol/src/lib.rs
+++ b/packages/mcp/editor-protocol/src/lib.rs
@@ -49,9 +49,9 @@ pub use node_spec::{kind_tag, InsertSpec, NodeQuery, NodeSpec};
 pub use project::{EditorProject, StoredMaterial, StoredSlot};
 pub use query::{
     AnimationSnapshot, ClipSnapshot, CompileDiagnostics, CompileError, EditorQuery, EditorSnapshot,
-    MapResult, MaterialSnapshot, PixelsResult, ProjectSnapshot, QueryResult, ReadbackTarget,
-    SettledResult, StatsResult, TextureSnapshot, TimeseriesFrame, TimeseriesResult, TrackSnapshot,
-    VertexPredicate,
+    EnvSlotSnapshot, EnvironmentSnapshot, MapResult, MaterialSnapshot, PixelsResult, ProjectSnapshot,
+    QueryResult, ReadbackTarget, SettledResult, StatsResult, TextureSnapshot, TimeseriesFrame,
+    TimeseriesResult, TrackSnapshot, VertexPredicate,
 };
 pub use transport::{
     BundleFileMeta, BundleHandle, EditorEvent, GlbHandle, PngHandle, Request, Response,

--- a/packages/mcp/editor-protocol/src/lib.rs
+++ b/packages/mcp/editor-protocol/src/lib.rs
@@ -49,9 +49,9 @@ pub use node_spec::{kind_tag, InsertSpec, NodeQuery, NodeSpec};
 pub use project::{EditorProject, StoredMaterial, StoredSlot};
 pub use query::{
     AnimationSnapshot, ClipSnapshot, CompileDiagnostics, CompileError, EditorQuery, EditorSnapshot,
-    EnvSlotSnapshot, EnvironmentSnapshot, MapResult, MaterialSnapshot, PixelsResult, ProjectSnapshot,
-    QueryResult, ReadbackTarget, SettledResult, StatsResult, TextureSnapshot, TimeseriesFrame,
-    TimeseriesResult, TrackSnapshot, VertexPredicate,
+    EnvSlotSnapshot, EnvironmentSnapshot, MapResult, MaterialSnapshot, PixelsResult,
+    ProjectSnapshot, QueryResult, ReadbackTarget, SettledResult, StatsResult, TextureSnapshot,
+    TimeseriesFrame, TimeseriesResult, TrackSnapshot, VertexPredicate,
 };
 pub use transport::{
     BundleFileMeta, BundleHandle, EditorEvent, GlbHandle, PngHandle, Request, Response,

--- a/packages/mcp/editor-protocol/src/query.rs
+++ b/packages/mcp/editor-protocol/src/query.rs
@@ -135,6 +135,12 @@ pub struct ProjectSnapshot {
     #[serde(default)]
     pub env_unsaved: bool,
     pub missing_assets: Vec<String>,
+    /// The currently-applied environment, per slot (skybox / specular /
+    /// irradiance) — so a driver can READ what is set (which slot is the
+    /// built-in default vs. a KTX asset vs. a sky gradient) rather than only
+    /// knowing it changed. Mirrors what the editor's per-slot pickers show.
+    #[serde(default)]
+    pub environment: EnvironmentSnapshot,
     /// Coordinate-system description (handedness / up-axis / units) so a driver
     /// doesn't have to guess the frame. Constant for now.
     #[serde(default = "default_coordinate_system")]
@@ -142,6 +148,39 @@ pub struct ProjectSnapshot {
     /// World units. Constant ("meters") for now.
     #[serde(default = "default_units")]
     pub units: String,
+}
+
+/// Read-only view of the scene environment's three slots.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct EnvironmentSnapshot {
+    pub skybox: EnvSlotSnapshot,
+    pub specular: EnvSlotSnapshot,
+    pub irradiance: EnvSlotSnapshot,
+}
+
+/// Read-only view of one environment slot. `kind` is `"builtin"` (the default
+/// sky), `"ktx"` (a cubemap asset — `asset_id`/`label` populated), or
+/// `"sky_gradient"` (`gradient` = `[zenith, nadir]` linear RGB).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EnvSlotSnapshot {
+    pub kind: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub asset_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gradient: Option<[[f32; 3]; 2]>,
+}
+
+impl Default for EnvSlotSnapshot {
+    fn default() -> Self {
+        Self {
+            kind: "builtin".to_string(),
+            asset_id: None,
+            label: None,
+            gradient: None,
+        }
+    }
 }
 
 fn default_coordinate_system() -> String {

--- a/packages/mcp/src/mcp.rs
+++ b/packages/mcp/src/mcp.rs
@@ -38,8 +38,8 @@ use awsm_renderer_scene::animation::{
     TrackTarget, TrackValue, TransformProp,
 };
 use awsm_renderer_scene::{
-    AssetId, EnvironmentConfig, IblConfig, LightKind, MaterialShading, MeshLodConfig,
-    MeshShadowConfig, NodeId, NodeKind, PrimitiveShape, SkyboxConfig, ToneMappingConfig, Trs,
+    AssetId, EnvSlot, EnvironmentConfig, LightKind, MaterialShading, MeshLodConfig,
+    MeshShadowConfig, NodeId, NodeKind, PrimitiveShape, ToneMappingConfig, Trs,
 };
 
 use crate::link::{AgentSession, EditorLink, LinkError};
@@ -978,22 +978,27 @@ pub struct LightAnglesParams {
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct EnvironmentParams {
-    /// Skybox: omit/"builtin" for the built-in default, or a KTX texture asset
-    /// UUID for a custom cubemap.
+    /// Skybox (the background cubemap): omit to keep the current one, "builtin"
+    /// for the built-in default sky, a KTX cubemap asset UUID, or a https:// URL
+    /// to a .ktx2 cubemap.
     #[serde(default)]
     pub skybox: Option<String>,
-    /// IBL prefiltered specular: omit/"builtin" for the built-in default, or a
-    /// KTX asset UUID (then `ibl_irradiance` is required too).
+    /// IBL specular (a.k.a. the prefiltered / roughness-mipped env map that
+    /// drives reflections): omit to keep the current one, "builtin" for the
+    /// built-in default, a KTX asset UUID, or a https:// .ktx2 URL. Independent
+    /// of `irradiance` — you can override just this one.
     #[serde(default)]
-    pub ibl_prefiltered: Option<String>,
-    /// IBL irradiance KTX asset UUID (required when `ibl_prefiltered` is a UUID).
+    pub specular: Option<String>,
+    /// IBL irradiance (the diffuse-convolved env map that drives ambient light):
+    /// omit to keep the current one, "builtin" for the built-in default, a KTX
+    /// asset UUID, or a https:// .ktx2 URL. Independent of `specular`.
     #[serde(default)]
-    pub ibl_irradiance: Option<String>,
+    pub irradiance: Option<String>,
     /// Agent-authored SKY-GRADIENT environment (§18): linear-RGB `[r,g,b]` zenith
-    /// (sky) color. When `zenith`+`nadir` are both given they set BOTH the skybox
-    /// and the IBL to that two-color gradient (overriding skybox/ibl_* above) —
-    /// author dusk / overcast / night / studio from your own colors, no hosted
-    /// `.ktx2` needed.
+    /// (sky) color. When `zenith`+`nadir` are both given they set ALL THREE slots
+    /// (skybox + specular + irradiance) to that two-color gradient (overriding the
+    /// slot args above) — author dusk / overcast / night / studio from your own
+    /// colors, no hosted `.ktx2` needed.
     #[serde(default)]
     pub zenith: Option<[f32; 3]>,
     /// Agent-authored sky-gradient nadir (ground) color, linear-RGB `[r,g,b]`.
@@ -3447,20 +3452,22 @@ impl EditorMcp {
     }
 
     #[tool(
-        description = "Set the scene environment (skybox + IBL). Two ways: (1) `zenith` + `nadir` ([r,g,b] linear) for a two-color SKY GRADIENT (skybox + IBL) — author dusk / overcast / night / studio from your own colors (no hosting needed). (2) Otherwise each of skybox / ibl_prefiltered / ibl_irradiance accepts: 'builtin' for the built-in default, an existing KTX texture asset UUID, OR a https:// URL to a .ktx2 cubemap. PARTIAL UPDATE: an OMITTED skybox / ibl_* slot keeps its current config (pass 'builtin' to explicitly reset one) — so setting just the IBL never silently resets the skybox, and vice versa (split skybox/IBL survives sequential calls). KTX IBL needs both ibl_prefiltered + ibl_irradiance. URL cubemaps are fetched AND parse-validated here — a non-cubemap/bad .ktx2 fails this call instead of silently keeping the previous environment. Precedence: zenith/nadir > skybox/ibl_*. A fresh scene already seeds the built-in environment."
+        description = "Set the scene environment. THREE INDEPENDENT slots — skybox (background), specular (the prefiltered/roughness-mipped IBL map that drives reflections), and irradiance (the diffuse-convolved IBL map that drives ambient light). Two ways: (1) `zenith` + `nadir` ([r,g,b] linear) sets ALL THREE to a two-color SKY GRADIENT — author dusk / overcast / night / studio from your own colors (no hosting needed). (2) Otherwise each of skybox / specular / irradiance accepts: 'builtin' for the built-in default sky, an existing KTX cubemap asset UUID, OR a https:// URL to a .ktx2 cubemap. PARTIAL UPDATE: an OMITTED slot keeps its current config (pass 'builtin' to explicitly reset one) — so e.g. keeping default-sky irradiance while overriding just specular is one call, and slots never silently reset each other across sequential calls. Slots are fully decoupled (unlike before, specular and irradiance are set separately). URL cubemaps are fetched AND parse-validated here — a non-cubemap/bad .ktx2 fails this call instead of silently keeping the previous environment. Precedence: zenith/nadir > per-slot args. A fresh scene already seeds the built-in environment. Use get_snapshot (project.environment) to read what is currently set."
     )]
     async fn set_environment(
         &self,
         Parameters(p): Parameters<EnvironmentParams>,
     ) -> Result<CallToolResult, McpError> {
-        // §18: agent-authored sky-gradient short-circuit — zenith+nadir drive both
-        // the skybox and the IBL from the same two colors (no KTX2 needed).
+        // §18: agent-authored sky-gradient short-circuit — zenith+nadir drive all
+        // three slots from the same two colors (no KTX2 needed).
         if let (Some(zenith), Some(nadir)) = (p.zenith, p.nadir) {
+            let grad = EnvSlot::SkyGradient { zenith, nadir };
             return self
                 .dispatch(EditorCommand::SetEnvironment {
                     env: EnvironmentConfig {
-                        skybox: SkyboxConfig::SkyGradient { zenith, nadir },
-                        ibl: IblConfig::SkyGradient { zenith, nadir },
+                        skybox: grad,
+                        specular: grad,
+                        irradiance: grad,
                     },
                 })
                 .await;
@@ -3487,33 +3494,29 @@ impl EditorMcp {
                 }
             }};
         }
-        // PARTIAL semantics: an omitted slot is `None` → the editor PRESERVES
-        // its current config; 'builtin' explicitly resets that slot.
-        let skybox = match p.skybox.as_deref() {
-            None => None,
-            Some("builtin") | Some("builtin_default") => Some(SkyboxConfig::BuiltInDefault),
-            Some(v) => Some(SkyboxConfig::Ktx {
-                asset_id: resolve_ktx!(v),
-            }),
-        };
-        let ibl = match p.ibl_prefiltered.as_deref() {
-            None => None,
-            Some("builtin") | Some("builtin_default") => Some(IblConfig::BuiltInDefault),
-            Some(prefiltered) => {
-                let irradiance = p.ibl_irradiance.as_deref().ok_or_else(|| {
-                    McpError::invalid_params(
-                        "ibl_irradiance is required when ibl_prefiltered is set (KTX asset UUID or .ktx2 URL)",
-                        None,
-                    )
-                })?;
-                Some(IblConfig::Ktx {
-                    prefiltered_asset_id: resolve_ktx!(prefiltered),
-                    irradiance_asset_id: resolve_ktx!(irradiance),
-                })
-            }
-        };
-        self.dispatch(EditorCommand::PatchEnvironment { skybox, ibl })
-            .await
+        // PARTIAL semantics: an omitted slot is `None` → the editor PRESERVES its
+        // current config; 'builtin' explicitly resets that slot. Each slot
+        // resolves identically and independently.
+        macro_rules! resolve_slot {
+            ($arg:expr) => {
+                match $arg.as_deref() {
+                    None => None,
+                    Some("builtin") | Some("builtin_default") => Some(EnvSlot::BuiltInDefault),
+                    Some(v) => Some(EnvSlot::Ktx {
+                        asset_id: resolve_ktx!(v),
+                    }),
+                }
+            };
+        }
+        let skybox = resolve_slot!(p.skybox);
+        let specular = resolve_slot!(p.specular);
+        let irradiance = resolve_slot!(p.irradiance);
+        self.dispatch(EditorCommand::PatchEnvironment {
+            skybox,
+            specular,
+            irradiance,
+        })
+        .await
     }
 
     #[tool(
@@ -4724,8 +4727,13 @@ const PROMPT_SETUP_ENVIRONMENT: &str = "\
 Set the scene environment. Assets come from URLs — there is NO inline-base64 / \
 equirect tool. Two routes:
 
+The environment has THREE independent slots — skybox, specular (the prefiltered/\
+roughness-mipped IBL map that drives reflections), irradiance (the diffuse-\
+convolved IBL map that drives ambient light). Each is set separately; omit a slot \
+to leave it unchanged. Two routes:
+
 A) Quick two-color sky (no hosting):
-   1. set_environment { zenith: [r,g,b], nadir: [r,g,b] }  (linear RGB; drives skybox + IBL).
+   1. set_environment { zenith: [r,g,b], nadir: [r,g,b] }  (linear RGB; sets all three slots).
    2. wait_render_settled, then screenshot_scene.
 
 B) Baked HDRI / studio KTX2 cubemaps by URL (read awsm://docs/asset-workflows for full flags):
@@ -4734,9 +4742,12 @@ B) Baked HDRI / studio KTX2 cubemaps by URL (read awsm://docs/asset-workflows fo
       The equirect→cubemap projection happens HERE, offline (there is no runtime equirect).
    3. ktx create --cubemap --format B10G11R11_UFLOAT_PACK32 … → skybox.ktx2, env.ktx2, irradiance.ktx2.
    4. Serve them (a local CORS static server is fine), then:
-      set_environment { skybox: \"<url>/skybox.ktx2\", ibl_prefiltered: \"<url>/env.ktx2\", ibl_irradiance: \"<url>/irradiance.ktx2\" }.
-      (KTX IBL needs BOTH ibl_prefiltered + ibl_irradiance. Skybox may differ from the IBL — e.g. clean grey sky + studio IBL for chrome.)
-   5. wait_render_settled, then screenshot_scene. Save embeds the .ktx2 bytes so it survives reload with no server.";
+      set_environment { skybox: \"<url>/skybox.ktx2\", specular: \"<url>/env.ktx2\", irradiance: \"<url>/irradiance.ktx2\" }.
+      (Slots are independent — set only the ones you want. Mix freely: e.g. skybox: \"builtin\" for a \
+clean default sky + a studio specular/irradiance for chrome, or keep default-sky irradiance and \
+override just specular.)
+   5. wait_render_settled, then screenshot_scene. Save embeds the .ktx2 bytes so it survives reload with no server.
+   To read what's currently set: get_snapshot → project.environment (per-slot kind + asset).";
 
 /// The legal Pass-Dependency keys, appended to the contract output.
 const MATERIAL_KEYS_DOC: &str = "\


### PR DESCRIPTION
## Summary

Two changes on this branch.

### 1. Environment → three independent IBL slots (the bulk of the diff)

The scene environment went from `EnvironmentConfig { skybox, ibl }` — where `ibl` welded prefiltered-**specular** + **irradiance** into a single all-or-nothing variant — to **three fully independent slots**: `skybox`, `specular`, `irradiance`. Each is a shared `EnvSlot` = `BuiltInDefault` | `Ktx { asset_id }` | `SkyGradient { … }`.

This lets a scene mix them freely — e.g. keep the built-in default sky for skybox + irradiance but override **only** the specular with a KTX — which the old coupled model literally could not express.

**Editor UI:** the ribbon's `Environment… / HDR set…` (a modal that forced picking all three KTX files at once) is replaced by **three per-slot pickers** — *Skybox / IBL Specular / IBL Irradiance* — each labeled with its current assignment; the menu offers *Default sky*, every imported `.ktx2` env asset, and *Import .ktx2…*.

**MCP:** `set_environment` now takes independent `skybox` / `specular` / `irradiance` (each `builtin` | asset-UUID | `.ktx2` URL); `zenith`/`nadir` still set all three to a gradient. Partial-update semantics are per-slot (omit = preserve). Added the previously-missing **read path**: `get_snapshot → project.environment` reports each slot's kind + asset id + filename.

> ⚠️ **Breaking format change (intentional, no back-compat):** the serialized `scene.toml` / `project.toml` shape changes from `[environment.ibl]` to `[environment.specular]` + `[environment.irradiance]`. This touches the **published** crates `awsm-renderer-scene` (public `EnvironmentConfig`/`EnvSlot`) and `awsm-renderer-scene-loader`, so it warrants a workspace **version bump** before release. Not bumped in this PR — flagging for the release call.

The byte plumbing is unchanged in shape: `EnvironmentConfig::ktx_asset_ids()` now spans all three slots, so Save (`ktx_files`/`restore_ktx`), the save census, and bundle export (`env_ktx_bundle_files`) keep working through that one seam.

### 2. Editor SMAA toggle (transient, editor-only)

A Settings → Viewport SMAA switch mirroring the existing MSAA toggle. **Transient** — a `controller().settings` `Mutable<bool>`, never persisted (AA is a player/runtime decision, not scene data); it exists so aliasing can be eyeballed in the editor viewport. The renderer already exposed `AntiAliasing::smaa`, so this is editor-only (settings field + drawer row + `settings_sync` observer). Not a crate change.

## Verification
- `task lint` clean (fmt + clippy `-D warnings`); workspace check + `wasm32` build clean; scene tests pass (incl. a new per-slot-independence round-trip test).
- Environment: three pickers + decoupling browser-verified in the editor; MCP set/query per-slot verified; a real matched KTX trio round-trips through `project.toml`, player-bundle export, and a player-path `load_player_bundle` reload.
- SMAA: line-for-line copy of the working MSAA toggle; renderer SMAA path already proven in the model-viewer — not separately runtime-tested (by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)