### PR TITLE
MCP/editor: agent-session fixes + API additions (0.16.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "askama",
@@ -229,7 +229,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-core"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "binpack2d",
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-curves"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "glam 0.32.1",
  "serde",
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-debugging"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -277,7 +277,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-editor"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-editor-protocol"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "awsm-renderer-meshgen",
  "awsm-renderer-scene",
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-geometry"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "glam 0.32.1",
  "serde",
@@ -346,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-glb-export"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "awsm-renderer-meshgen",
  "awsm-renderer-tangents",
@@ -361,7 +361,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-gltf"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-gltf-convert"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "awsm-renderer-glb-export",
  "awsm-renderer-meshgen",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-lod-bake"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "glam 0.32.1",
  "serde",
@@ -412,7 +412,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-lod-bake-cli"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "awsm-renderer-glb-export",
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-materials"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "awsm-renderer-core",
  "thiserror 2.0.18",
@@ -434,7 +434,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-meshgen"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "awsm-renderer-curves",
  "awsm-renderer-geometry",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-model-tests"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-multithreaded-example"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "awsm-renderer",
  "awsm-renderer-core",
@@ -506,7 +506,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-particles"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "awsm-renderer-curves",
  "awsm-renderer-geometry",
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-render-worker-example"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -536,7 +536,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-scene"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "bitcode",
  "glam 0.32.1",
@@ -550,7 +550,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-scene-loader"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -572,7 +572,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-scene-mcp"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "awsm-renderer-editor-protocol",
@@ -594,14 +594,14 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-tangents"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "bevy_mikktspace",
 ]
 
 [[package]]
 name = "awsm-renderer-web-shared"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ resolver = "2"
 [workspace.package]
 description = "awsm renderer"
 edition = "2021"
-version = "0.15.0"
+version = "0.16.0"
 license = "MIT OR Apache-2.0"
 authors = ["David Komer"]
 # 1.85 floor: rmcp 1.x (the MCP server SDK) is edition-2024, which requires
@@ -118,23 +118,23 @@ opt-level = 1
 # `workspace.package.version` so the published crates carry concrete
 # version requirements on each other (crates.io rejects path-only deps).
 # Bump this block together with the version above on every release.
-awsm-renderer-curves = { path = "packages/crates/curves", version = "0.15.0" }
-awsm-renderer-geometry = { path = "packages/crates/geometry", version = "0.15.0" }
-awsm-renderer-scene = { path = "packages/crates/scene", version = "0.15.0" }
-awsm-renderer-scene-loader = { path = "packages/crates/scene-loader", version = "0.15.0" }
-awsm-renderer-editor-protocol = { path = "packages/mcp/editor-protocol", version = "0.15.0" }
-awsm-renderer-core = { path = "packages/crates/renderer-core", version = "0.15.0" }
-awsm-renderer-meshgen = { path = "packages/crates/meshgen", version = "0.15.0" }
-awsm-renderer-glb-export = { path = "packages/crates/glb-export", version = "0.15.0" }
-awsm-renderer-gltf-convert = { path = "packages/crates/gltf-convert", version = "0.15.0" }
-awsm-renderer-tangents = { path = "packages/crates/tangents", version = "0.15.0" }
-awsm-renderer-lod-bake = { path = "packages/crates/lod-bake", version = "0.15.0" }
-awsm-renderer-particles = { path = "packages/crates/particles", version = "0.15.0" }
-awsm-renderer-materials = { path = "packages/crates/materials", version = "0.15.0" }
-awsm-renderer = { path = "packages/crates/renderer", version = "0.15.0" }
-awsm-renderer-gltf = { path = "packages/crates/renderer-gltf", version = "0.15.0" }
+awsm-renderer-curves = { path = "packages/crates/curves", version = "0.16.0" }
+awsm-renderer-geometry = { path = "packages/crates/geometry", version = "0.16.0" }
+awsm-renderer-scene = { path = "packages/crates/scene", version = "0.16.0" }
+awsm-renderer-scene-loader = { path = "packages/crates/scene-loader", version = "0.16.0" }
+awsm-renderer-editor-protocol = { path = "packages/mcp/editor-protocol", version = "0.16.0" }
+awsm-renderer-core = { path = "packages/crates/renderer-core", version = "0.16.0" }
+awsm-renderer-meshgen = { path = "packages/crates/meshgen", version = "0.16.0" }
+awsm-renderer-glb-export = { path = "packages/crates/glb-export", version = "0.16.0" }
+awsm-renderer-gltf-convert = { path = "packages/crates/gltf-convert", version = "0.16.0" }
+awsm-renderer-tangents = { path = "packages/crates/tangents", version = "0.16.0" }
+awsm-renderer-lod-bake = { path = "packages/crates/lod-bake", version = "0.16.0" }
+awsm-renderer-particles = { path = "packages/crates/particles", version = "0.16.0" }
+awsm-renderer-materials = { path = "packages/crates/materials", version = "0.16.0" }
+awsm-renderer = { path = "packages/crates/renderer", version = "0.16.0" }
+awsm-renderer-gltf = { path = "packages/crates/renderer-gltf", version = "0.16.0" }
 # Frontend-only (not published); workspace dep keeps consumers path-agnostic.
-awsm-renderer-web-shared = { path = "packages/frontend/web-shared", version = "0.15.0" }
+awsm-renderer-web-shared = { path = "packages/frontend/web-shared", version = "0.16.0" }
 
 # Misc
 cfg-if = "1.0.4"

--- a/docs/plans/offscreen-editor-screenshots.md
+++ b/docs/plans/offscreen-editor-screenshots.md
@@ -1,0 +1,116 @@
+# Plan: Offscreen editor rendering (screenshots while the tab is hidden)
+
+## Problem
+
+Every frame-bound MCP operation — `screenshot_scene`, `wait_render_settled`,
+thumbnail refreshes, anything that awaits a *presented* frame — dies when the
+editor tab is not visible, because the render loop rides
+`requestAnimationFrame` (`packages/frontend/editor/src/engine/render_loop.rs`)
+and browsers pause/throttle rAF for hidden tabs (and for any tab when no
+display is on).
+
+This is the single biggest obstacle to **unattended agent sessions**. Real
+case (2026-07-05, the DANCE-OFF overnight build): an agent-driven material
+pass stalled for ~8 hours because the laptop lid was closed — the editor tab
+stayed connected (WebSocket alive, JS-only queries kept answering), but every
+screenshot/verify step hung until a human made the tab visible again. An
+agent cannot verify what it cannot see.
+
+### Current mitigation (shipped, not a fix)
+
+The editor pushes `visibilitychange` state to the MCP server
+(`EditorEvent { kind: "visibility", hidden }`, see
+`packages/frontend/editor/src/remote.rs::hook_visibility`); the server tracks
+it per connection and:
+
+- `ping` / `pairing_status` report `tab=HIDDEN` / `tab_hidden: true`;
+- hidden-tab requests fail fast (15s, `HIDDEN_REQUEST_TIMEOUT` in
+  `packages/mcp/src/link.rs`) with an actionable error instead of burning the
+  120s timeout.
+
+Agents now *know* they are blind, quickly — but they are still blind.
+
+## Goal
+
+An attached editor can serve `screenshot_scene` / `wait_render_settled` (and
+keep animation/preview state advancing predictably) while its tab is hidden,
+backgrounded, or the display is off — without a human present.
+
+Acceptance:
+
+1. With the editor tab fully hidden (background tab AND display asleep),
+   `screenshot_scene` returns a current, correct render within normal latency.
+2. `wait_render_settled` resolves (frames actually advance) while hidden.
+3. No regression to foreground behavior: vsync pacing, input latency,
+   thumbnails, the activity pulse.
+4. Power sanity: hidden-tab rendering is on-demand or heavily throttled — we
+   must not spin a full-rate render loop in every backgrounded tab forever.
+
+## Design directions (decide during implementation)
+
+### A. Worker + OffscreenCanvas (the "real" fix)
+
+Move rendering to a Web Worker driving an `OffscreenCanvas`
+(`transferControlToOffscreen`). Workers are not rAF-frozen with the tab
+(timers are throttled but run), so the loop can keep ticking on
+`setTimeout`/`requestAnimationFrame`-in-worker with a fallback cadence.
+
+- WebGPU in workers + OffscreenCanvas is supported in Chromium (our target).
+- Largest touch surface: the renderer currently lives on the main thread next
+  to the controller/UI (`engine/context.rs`, `with_renderer_mut` callers
+  everywhere). Everything crossing to the worker becomes message-passing or
+  shared memory — this is effectively the existing "multithreaded" experiment
+  (`taskfiles/examples/multithreaded.yml`) promoted to the editor proper.
+- Biggest risk: the scene→GPU bridge (`engine/bridge/*`) assumes same-thread
+  `Mutable` observers.
+
+### B. On-demand hidden-frame rendering (cheap, screenshot-focused)
+
+Keep the main-thread rAF loop for the visible case. When the tab is hidden
+AND a frame-bound request arrives, render **synchronously on demand** off the
+request path: run one `tick()` + readback per request (or a short timer-driven
+burst while requests are in flight), never presenting to the (invisible)
+swapchain — render into an offscreen target and read that back for the PNG.
+
+- Much smaller change: a `render_once_for_capture()` entry point plus routing
+  in `engine/query.rs::scene_png` / the settle barrier when
+  `document.hidden`.
+- Caveats: `setTimeout` in a hidden tab is clamped (≥1s, sometimes more under
+  Chrome's Intensive Throttling) — but MCP requests arrive over the WebSocket,
+  whose `onmessage` still fires promptly, and rendering *inside that message
+  handler's task* avoids timer clamping entirely.
+- Animation playback time can be driven from the wall clock at capture time,
+  so scrub-then-screenshot flows (the agent's main verify loop) are exact.
+- Does NOT make continuous background playback smooth — acceptable: agents
+  scrub + capture; they don't watch.
+
+### C. Headless/CLI editor (long-term alternative)
+
+A native (non-browser) headless build serving the same MCP surface (wgpu
+instead of web-sys WebGPU). Solves unattended runs completely, but forks the
+renderer's "WebGPU via web-sys, browser-only by design" premise (see README);
+out of scope unless A/B prove untenable.
+
+## Recommendation
+
+Start with **B** — it directly unblocks the agent verify loop (screenshot /
+settle on demand via the socket's message task, no rAF dependency), is
+incremental, and doesn't disturb the foreground path. Keep **A** as the
+follow-on once the multithreaded experiment matures; B's capture entry point
+(`render_once_for_capture`) remains useful under A as well.
+
+## Verification plan
+
+Drive it exactly like the incident: attach an editor, hide the tab (and/or
+`Object.defineProperty(document, 'hidden', …)` + dispatch `visibilitychange`
+for CI), then over MCP: `set_playhead` → `screenshot_scene` → assert pixels
+change across playheads; `wait_render_settled` resolves; `ping` may still
+report `tab=HIDDEN` (truthful) while captures succeed. Remove/relax the
+`HIDDEN_REQUEST_TIMEOUT` fail-fast for capture-capable requests once green.
+
+## Context / provenance
+
+Extracted from the DANCE-OFF session handoff (UPSTREAM-FIXES.md, item F3 —
+the only item not implemented in the 2026-07-05 fix sessions; everything else
+from that doc is in the repo as of those sessions' working tree). The
+fail-fast mitigation and visibility plumbing referenced above landed there.

--- a/packages/crates/scene/src/animation.rs
+++ b/packages/crates/scene/src/animation.rs
@@ -16,6 +16,7 @@ use crate::tree::NodeId;
 /// How a clip's shared clock wraps at its duration boundary.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum ClipLoop {
     Loop,
     PingPong,
@@ -25,6 +26,7 @@ pub enum ClipLoop {
 /// The default playback direction a clip's clock advances.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum ClipDirection {
     Forward,
     Reverse,
@@ -33,6 +35,7 @@ pub enum ClipDirection {
 /// Per-keyframe interpolation (display); lowering uses the track's [`SamplerKind`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum Interp {
     Step,
     Linear,
@@ -42,6 +45,7 @@ pub enum Interp {
 /// The renderer sampler kind a whole track lowers to.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum SamplerKind {
     Step,
     Linear,
@@ -55,6 +59,7 @@ pub enum SamplerKind {
 // newtype variant requires a map payload — a `[f32;N]` is a sequence and errors
 // at runtime). `tag + content` round-trips any payload, in JSON *and* TOML.
 #[serde(tag = "kind", content = "value", rename_all = "snake_case")]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum TrackValue {
     /// Translation / scale (vec3).
     Vec3([f32; 3]),
@@ -70,6 +75,7 @@ pub enum TrackValue {
 
 /// One keyframe, aligned to a track's shared `times[i]`.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Keyframe {
     pub value: TrackValue,
     pub interp: Interp,
@@ -80,6 +86,7 @@ pub struct Keyframe {
 /// Which transform component a transform track drives.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum TransformProp {
     Translation,
     Rotation,
@@ -181,6 +188,7 @@ pub enum CameraParamKind {
 /// A serializable descriptor binding a track to a real animatable target.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "target", rename_all = "snake_case")]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum TrackTarget {
     Transform {
         node: NodeId,
@@ -218,6 +226,7 @@ pub enum TrackTarget {
 
 /// Serializable snapshot of one track.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct StoredTrack {
     pub target: TrackTarget,
     pub sampler: SamplerKind,
@@ -262,6 +271,7 @@ pub struct CustomAnimationRef {
 /// How a mixer layer composites (clips referenced by `AssetId`).
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "mode", rename_all = "snake_case")]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum LayerModeDoc {
     #[default]
     Replace,
@@ -273,6 +283,7 @@ pub enum LayerModeDoc {
 
 /// One clip placement on a mixer layer's timeline.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct StripDoc {
     pub clip: AssetId,
     pub start: f64,
@@ -289,6 +300,7 @@ fn one_f64() -> f64 {
 
 /// One mixer layer.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct LayerDoc {
     pub mode: LayerModeDoc,
     #[serde(default = "one_f64")]

--- a/packages/crates/scene/src/environment.rs
+++ b/packages/crates/scene/src/environment.rs
@@ -13,6 +13,7 @@ use super::assets::AssetId;
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[derive(Default)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct EnvironmentConfig {
     #[serde(default)]
     pub skybox: EnvSlot,
@@ -48,6 +49,7 @@ impl EnvironmentConfig {
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[derive(Copy, Default)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum EnvSlot {
     /// The baked-in "Default sky" — a procedural [`CubemapSkyGradient`] default.
     /// Referenced by no asset.

--- a/packages/crates/scene/src/light.rs
+++ b/packages/crates/scene/src/light.rs
@@ -238,6 +238,7 @@ fn default_cascade_lambda() -> f32 {
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[derive(Eq, Hash, Copy)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum LightKind {
     Directional,
     Point,

--- a/packages/crates/scene/src/material.rs
+++ b/packages/crates/scene/src/material.rs
@@ -292,6 +292,7 @@ ext_struct!(/// `KHR_materials_iridescence` — thin-film interference (soap bub
 /// GPU texture at load time via `awsm-renderer-meshgen::procedural_texture::*`.
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum ProceduralTextureDef {
     Checker {
         width: u32,
@@ -363,6 +364,7 @@ impl TextureColorKind {
 /// Texture asset variants.
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum TextureDef {
     /// External raster file (PNG, JPEG, WebP) shipped alongside the
     /// project. `display_name` is the user-facing label + provides the

--- a/packages/frontend/editor/src/animation_mode/library.rs
+++ b/packages/frontend/editor/src/animation_mode/library.rs
@@ -28,7 +28,7 @@ pub fn render() -> Dom {
             }))
             .child(html!("div", { .style("flex", "1") }))
             .child(IconBtn::new("plus").title("New clip").size(15.0)
-                .on_click(|| dispatch(EditorCommand::AddClip { id: crate::engine::scene::AssetId::new() })).render())
+                .on_click(|| dispatch(EditorCommand::AddClip { id: crate::engine::scene::AssetId::new(), name: None })).render())
         }))
         // ── scrollable list (gap 5, padding 8) ───────────────────────────────
         .child(html!("div", {

--- a/packages/frontend/editor/src/controller/state.rs
+++ b/packages/frontend/editor/src/controller/state.rs
@@ -62,6 +62,7 @@ pub fn init() {
                 level: Some(level.to_string()),
                 message: Some(msg.to_string()),
                 nodes: None,
+                hidden: None,
             });
         }
     });
@@ -131,6 +132,10 @@ pub struct EditorController {
     pub custom_materials: MutableVec<Arc<CM>>,
     /// The material the Studio is currently editing.
     pub current_material: Mutable<Option<AssetId>>,
+    /// Report of the most recent model import (roots, counts, source asset) —
+    /// served by [`EditorQuery::LastImportReport`] and returned inline by the
+    /// MCP import tools. `None` until the first import of the session.
+    pub last_import_report: Mutable<Option<serde_json::Value>>,
     /// The animation clips authored in Animation mode (mirrors `custom_materials`).
     /// Reactive — the studio edits their tracks/keys live.
     pub custom_animations: MutableVec<Arc<CA>>,
@@ -269,6 +274,7 @@ impl EditorController {
             asset_selection: Mutable::new(None),
             custom_materials: MutableVec::new(),
             current_material: Mutable::new(None),
+            last_import_report: Mutable::new(None),
             custom_animations: MutableVec::new(),
             current_clip: Mutable::new(None),
             playhead: Mutable::new(0.0),
@@ -817,6 +823,7 @@ impl EditorController {
                     level: None,
                     message: None,
                     nodes: Some(ids.iter().map(|id| id.to_string()).collect()),
+                    hidden: None,
                 });
                 self.selected.set(ids);
                 Ok(None)
@@ -1000,6 +1007,46 @@ impl EditorController {
                     }
                     None => Ok(None),
                 }
+            }
+            EditorCommand::ResetToBindPose { id } => {
+                let Some(root) = mutate::find_by_id(&self.scene, id) else {
+                    return Err(crate::error::EditorError::msg(format!("no node {id}")));
+                };
+                let rest = crate::engine::bridge::bridge()
+                    .joint_rest
+                    .lock()
+                    .unwrap()
+                    .clone();
+                // Restore every joint in the subtree that has a recorded rest;
+                // collect per-node inverses so undo replays the prior pose.
+                fn walk(
+                    node: &std::sync::Arc<crate::engine::scene::node::Node>,
+                    rest: &std::collections::HashMap<NodeId, crate::engine::scene::Trs>,
+                    inverses: &mut Vec<EditorCommand>,
+                ) {
+                    if let Some(r) = rest.get(&node.id) {
+                        let prev = node.transform.get();
+                        if prev != *r {
+                            node.transform.set(*r);
+                            inverses.push(EditorCommand::SetTransform {
+                                id: node.id,
+                                transform: prev,
+                            });
+                        }
+                    }
+                    for child in node.children.lock_ref().iter() {
+                        walk(child, rest, inverses);
+                    }
+                }
+                let mut inverses = Vec::new();
+                walk(&root, &rest, &mut inverses);
+                if inverses.is_empty() {
+                    // Nothing was posed away from rest (or no joints under here).
+                    return Ok(None);
+                }
+                self.scene.bump_revision();
+                inverses.reverse();
+                Ok(Some(EditorCommand::Batch(inverses)))
             }
             EditorCommand::Rename { id, name } => match mutate::find_by_id(&self.scene, id) {
                 Some(node) => {
@@ -2067,17 +2114,22 @@ impl EditorController {
                          use the SetCustomMaterial* commands)"
                     )));
                 };
-                mat.builtin.set(Some(*def));
-                // Variant changed → refresh its card thumbnail + re-materialize
-                // every assigned mesh DIRECTLY. This used to ride a per-material
+                mat.builtin.set(Some((*def).clone()));
+                // Variant changed → refresh its card thumbnail + re-seed every
+                // assigned mesh's per-variant inline store DIRECTLY (which also
+                // re-materializes it). This used to ride a per-material
                 // `spawn_builtin_resync` observer, which only existed for
                 // materials created through `AddBuiltinMaterial` / project load —
                 // glTF-IMPORTED library materials never spawned one, so updating
                 // them (e.g. enabling a PBR extension over MCP) silently changed
-                // nothing on screen. A direct call can't have coverage holes.
+                // nothing on screen. And a bare re-materialize is not enough
+                // either: each variant renders from its own inline VALUE copy
+                // (seeded at import/assign), so without the field-wise re-seed a
+                // def edit re-applied the stale values and nothing visibly
+                // changed. Slots the mesh customized (≠ prior def) are kept.
                 crate::engine::thumbnail::invalidate(mat.id);
                 crate::engine::thumbnail::request(mat.clone());
-                crate::engine::bridge::rematerialize_for_material(id);
+                crate::engine::bridge::reseed_inline_for_material(id, &prior, &def);
                 // A variant edit changes which per-mesh controls exist on every
                 // node assigned this material (extension rows appear/disappear,
                 // texture slots gate on it) — rebuild the node inspector like
@@ -3071,7 +3123,21 @@ impl EditorController {
             EditorCommand::ImportModelFromUrl { url } => {
                 let _activity =
                     crate::engine::activity::begin_activity("Inserting model — uploading to GPU…");
-                self.finish_model_import(crate::engine::bridge::gltf::import(&url).await);
+                self.finish_model_import(crate::engine::bridge::gltf::import(&url).await)
+                    .map_err(|e| {
+                        // A cross-origin fetch the host didn't allow surfaces as a bare
+                        // "Failed to fetch" — the single most common silent-import
+                        // trap for MCP agents (e.g. `python3 -m http.server` sends no
+                        // CORS headers). Name the cause in the error the agent sees.
+                        let hint = if e.contains("Failed to fetch") {
+                            "\n(likely CORS: the editor is a browser app, so the file \
+                             server must send `Access-Control-Allow-Origin` — plain \
+                             `python3 -m http.server` does not)"
+                        } else {
+                            ""
+                        };
+                        crate::error::EditorError::msg(format!("import failed: {e}{hint}"))
+                    })?;
                 Ok(None)
             }
             EditorCommand::ImportModelFromFile { name, url } => {
@@ -3080,7 +3146,8 @@ impl EditorController {
                 let result = crate::engine::bridge::gltf::import_file(&name, &url).await;
                 // The blob: object URL was minted just for this load; release it.
                 let _ = web_sys::Url::revoke_object_url(&url);
-                self.finish_model_import(result);
+                self.finish_model_import(result)
+                    .map_err(|e| crate::error::EditorError::msg(format!("import failed: {e}")))?;
                 Ok(None)
             }
             // Import a PRE-BAKED nanite asset (awsm-renderer-lod-bake CLI output) as a
@@ -3239,12 +3306,15 @@ impl EditorController {
                 Ok(Some(EditorCommand::DeleteAsset { id }))
             }
             // ───────────────────── Animation: clip lifecycle ─────────────────
-            EditorCommand::AddClip { id } => {
+            EditorCommand::AddClip { id, name } => {
                 // Idempotent: a cross-tab relay replays this; if the clip id
                 // already exists (or a self-echo slips through) it's a no-op.
                 if find_clip(&self.custom_animations, id).is_none() {
-                    let n = self.custom_animations.lock_ref().len() + 1;
-                    let clip = CA::new(id, format!("Clip {n}"));
+                    let name = name.filter(|n| !n.trim().is_empty()).unwrap_or_else(|| {
+                        let n = self.custom_animations.lock_ref().len() + 1;
+                        format!("Clip {n}")
+                    });
+                    let clip = CA::new(id, name);
                     self.custom_animations.lock_mut().push_cloned(clip);
                     Toast::info("Created clip");
                 }
@@ -3527,6 +3597,64 @@ impl EditorController {
                 }
             }
             // ───────────────────── Animation: keyframes ──────────────────────
+            EditorCommand::SetTrackKeys {
+                clip,
+                track,
+                times,
+                values,
+                interp,
+                keys,
+            } => match find_track(&self.custom_animations, clip, track) {
+                Some(tr) => {
+                    // Build the replacement key list: full `keys` win (lossless
+                    // undo form), else one keyframe per (time, value) pair.
+                    let new_keys: Vec<animation::Keyframe> = if !keys.is_empty() {
+                        if keys.len() != times.len() {
+                            return Err(crate::error::EditorError::msg(format!(
+                                "set_track_keys: {} times but {} keys",
+                                times.len(),
+                                keys.len()
+                            )));
+                        }
+                        keys
+                    } else {
+                        if values.len() != times.len() {
+                            return Err(crate::error::EditorError::msg(format!(
+                                "set_track_keys: {} times but {} values",
+                                times.len(),
+                                values.len()
+                            )));
+                        }
+                        let interp = interp
+                            .unwrap_or_else(|| animation::sampler_to_interp(tr.sampler.get()));
+                        values
+                            .into_iter()
+                            .map(|v| animation::new_keyframe(v, interp))
+                            .collect()
+                    };
+                    // Sort by time (callers need not pre-sort).
+                    let mut paired: Vec<(f64, animation::Keyframe)> =
+                        times.into_iter().zip(new_keys).collect();
+                    paired.sort_by(|a, b| a.0.total_cmp(&b.0));
+                    let (sorted_times, sorted_keys): (Vec<f64>, Vec<animation::Keyframe>) =
+                        paired.into_iter().unzip();
+
+                    let prev_times = tr.times.lock_ref().to_vec();
+                    let prev_keys = tr.keys.lock_ref().to_vec();
+                    *tr.times.lock_mut() = sorted_times;
+                    *tr.keys.lock_mut() = sorted_keys;
+                    self.dirty.set_neq(true);
+                    Ok(Some(EditorCommand::SetTrackKeys {
+                        clip,
+                        track,
+                        times: prev_times,
+                        values: Vec::new(),
+                        interp: None,
+                        keys: prev_keys,
+                    }))
+                }
+                None => Ok(None),
+            },
             EditorCommand::AddKeyframe {
                 clip,
                 track,
@@ -3968,18 +4096,24 @@ impl EditorController {
     /// node template is cached under a freshly-minted source-file `AssetId` so
     /// each `Model` node can find + duplicate its meshes (see
     /// `node_sync::materialize_model`). On failure, surface the error.
-    fn finish_model_import(&self, result: Result<crate::engine::bridge::gltf::GltfImport, String>) {
+    /// Returns `Err` with the load/parse failure so command dispatch can surface
+    /// it to the caller (the MCP agent sees a real error instead of a silent
+    /// "ok"); the toast is kept so local UI flows still get visible feedback.
+    fn finish_model_import(
+        &self,
+        result: Result<crate::engine::bridge::gltf::GltfImport, String>,
+    ) -> Result<(), String> {
         let import = match result {
             Ok(i) => i,
             Err(e) => {
                 Toast::error(format!("Import failed: {e}"));
-                return;
+                return Err(e);
             }
         };
 
         if import.template.roots.is_empty() {
             Toast::error("This model contains no nodes to insert");
-            return;
+            return Err("this model contains no nodes to insert".to_string());
         }
 
         // Bring the imported materials into the **assignable library** (so they
@@ -4207,6 +4341,17 @@ impl EditorController {
             crate::engine::bridge::bridge().register_template_instances(asset_id, ids);
         }
 
+        // Captured for the import report (LastImportReport query / MCP return).
+        let report_roots: Vec<serde_json::Value> = roots
+            .iter()
+            .map(|r| {
+                serde_json::json!({
+                    "id": r.id.to_string(),
+                    "name": r.name.get_cloned(),
+                })
+            })
+            .collect();
+
         for root in roots {
             mutate::insert_under(&self.scene, None, root);
         }
@@ -4218,8 +4363,10 @@ impl EditorController {
         // per-frame `skin_bridge` copies the mirror's local onto the baked key so
         // animating/posing the bone deforms the skin (otherwise the mesh freezes:
         // the skin reads the baked copy, the animation drives the mirror).
+        let mut skin_joint_count = 0;
         {
             fn walk_skin_joints(
+                scene: &crate::engine::scene::Scene,
                 nodes: &[crate::engine::bridge::asset_template::AssetTemplateNode],
                 node_map: &std::collections::HashMap<u32, NodeId>,
                 count: &mut usize,
@@ -4229,14 +4376,24 @@ impl EditorController {
                     if n.is_skin_joint {
                         if let Some(node_id) = node_map.get(&n.gltf_node_index) {
                             bridge.register_skin_joint(*node_id, n.baked_transform_key);
+                            // The freshly-built editor node still carries the
+                            // glTF-parsed local — record it as this joint's
+                            // bind/rest pose for `ResetToBindPose`.
+                            if let Some(bone) = mutate::find_by_id(scene, *node_id) {
+                                bridge.register_joint_rest(*node_id, bone.transform.get());
+                            }
                             *count += 1;
                         }
                     }
-                    walk_skin_joints(&n.children, node_map, count);
+                    walk_skin_joints(scene, &n.children, node_map, count);
                 }
             }
-            let mut skin_joint_count = 0;
-            walk_skin_joints(&template.roots, &node_map, &mut skin_joint_count);
+            walk_skin_joints(
+                &self.scene,
+                &template.roots,
+                &node_map,
+                &mut skin_joint_count,
+            );
             tracing::debug!("skin bridge: registered {skin_joint_count} skin-joint mappings");
         }
 
@@ -4254,6 +4411,18 @@ impl EditorController {
         } else {
             Toast::info(format!("Imported {}", import.display_name));
         }
+
+        // Publish the import report (LastImportReport query / inline MCP return).
+        self.last_import_report.set(Some(serde_json::json!({
+            "display_name": import.display_name,
+            "source_asset": asset_id.to_string(),
+            "roots": report_roots,
+            "node_count": node_map.len(),
+            "materials": mat_ids.iter().map(|m| m.to_string()).collect::<Vec<_>>(),
+            "skin_joints": skin_joint_count,
+            "clips": clip_count,
+        })));
+        Ok(())
     }
 
     /// Remove animation clips that are now FULLY orphaned — every track targets
@@ -4727,6 +4896,19 @@ impl EditorController {
         use query::*;
         match q {
             EditorQuery::Snapshot => QueryResult::Snapshot(Box::new(self.snapshot())),
+            EditorQuery::LastImportReport => {
+                let mut entries = std::collections::BTreeMap::new();
+                entries.insert(
+                    "report".to_string(),
+                    self.last_import_report
+                        .get_cloned()
+                        .unwrap_or(serde_json::Value::Null),
+                );
+                QueryResult::Map(MapResult {
+                    kind: "import_report".to_string(),
+                    entries,
+                })
+            }
             EditorQuery::SampleClipTimeseries {
                 clip,
                 times,
@@ -5667,12 +5849,28 @@ impl EditorController {
             }
             EditorQuery::SkinData { nodes } => {
                 use serde_json::json;
-                // Rig discovery: every SkinnedMesh node's joint table, each joint
-                // resolved to its live editor bone node (name + current local TRS).
-                // Joints are ordinary scene nodes — SetTransform poses them and a
-                // Transform animation track animates them; this query is just the
-                // map that makes the rig reachable without walking the outliner.
+                // Rig discovery: every skin's joint table, each joint resolved to
+                // its live editor bone node (name + current local TRS). Joints are
+                // ordinary scene nodes — SetTransform poses them and a Transform
+                // animation track animates them; this query is just the map that
+                // makes the rig reachable without walking the outliner.
+                //
+                // Grouped BY SKIN (source asset), not by skinned-mesh node: a
+                // multi-material import splits into one skinned_mesh node per
+                // primitive, all sharing one joint table — the old per-node shape
+                // repeated the identical joint array once per primitive (4× the
+                // payload for a 4-material rig; handoff #7). Each entry lists the
+                // sharing mesh nodes instead.
                 let ids = self.resolve_node_ids(&nodes);
+                let bridge = crate::engine::bridge::bridge();
+                let baked_map = bridge.skin_joint_baked.lock().unwrap().clone();
+                // A bone is drivable through EITHER path: the legacy template
+                // populate (baked-copy skin bridge) or the rig-decode
+                // materializer, whose renderer skin reads the editor bone's own
+                // TransformKey directly — for the latter (e.g. every DUPLICATED
+                // rig) the bone just needs to be a live bridge node.
+                let live_nodes: std::collections::HashSet<NodeId> =
+                    bridge.nodes.lock().unwrap().keys().copied().collect();
                 let mut entries = std::collections::BTreeMap::new();
                 for id in ids {
                     let Some(n) = mutate::find_by_id(&self.scene, id) else {
@@ -5681,15 +5879,35 @@ impl EditorController {
                     let NodeKind::SkinnedMesh { skin, .. } = n.kind.get_cloned() else {
                         continue;
                     };
+                    let mesh_entry = json!({
+                        "node": id.to_string(),
+                        "name": n.name.get_cloned(),
+                        "primitive_index": skin.primitive_index,
+                    });
+                    // Group key: the first JOINT's node id — unique per rig
+                    // INSTANCE (a duplicated rig shares the original's `source`
+                    // asset but owns remapped joints), shared by all of one
+                    // rig's per-primitive meshes. Fall back to the source for a
+                    // joint-less skin.
+                    let key = skin
+                        .joints
+                        .first()
+                        .map(|j| j.node.to_string())
+                        .unwrap_or_else(|| skin.source.to_string());
+                    if let Some(existing) = entries.get_mut(&key) {
+                        // Same skin — just record the additional sharing mesh.
+                        let serde_json::Value::Object(map) = existing else {
+                            continue;
+                        };
+                        if let Some(serde_json::Value::Array(meshes)) = map.get_mut("meshes") {
+                            meshes.push(mesh_entry);
+                        }
+                        continue;
+                    }
                     // `live`: the skin bridge holds a mirror→baked mapping for
                     // this bone, i.e. posing it actually deforms the skin. False
                     // means the rig is display-only (registration failed/skipped)
                     // — surfaced so an agent (and we) can SEE a broken chain.
-                    let baked_map = crate::engine::bridge::bridge()
-                        .skin_joint_baked
-                        .lock()
-                        .unwrap()
-                        .clone();
                     let joints: Vec<serde_json::Value> = skin
                         .joints
                         .iter()
@@ -5707,7 +5925,8 @@ impl EditorController {
                                 "node": j.node.to_string(),
                                 "index": j.index,
                                 "name": name,
-                                "live": baked_map.contains_key(&j.node),
+                                "live": baked_map.contains_key(&j.node)
+                                    || live_nodes.contains(&j.node),
                                 "translation": trs.translation,
                                 "rotation": trs.rotation,
                                 "scale": trs.scale,
@@ -5715,10 +5934,10 @@ impl EditorController {
                         })
                         .collect();
                     entries.insert(
-                        id.to_string(),
+                        key,
                         json!({
                             "source": skin.source.to_string(),
-                            "primitive_index": skin.primitive_index,
+                            "meshes": vec![mesh_entry],
                             "joints": joints,
                         }),
                     );

--- a/packages/frontend/editor/src/engine/activity_feed.rs
+++ b/packages/frontend/editor/src/engine/activity_feed.rs
@@ -570,7 +570,10 @@ mod mode_tests {
             Some(EditorMode::Scene)
         );
         assert_eq!(
-            command_mode(&C::AddClip { id: AssetId::new() }),
+            command_mode(&C::AddClip {
+                id: AssetId::new(),
+                name: None
+            }),
             Some(EditorMode::Animation)
         );
         assert_eq!(command_mode(&C::AddLayer), Some(EditorMode::Animation));

--- a/packages/frontend/editor/src/engine/bridge/state.rs
+++ b/packages/frontend/editor/src/engine/bridge/state.rs
@@ -92,6 +92,13 @@ pub struct Bridge {
     /// transform; each frame [`skin_bridge`] copies the mirror's local onto the
     /// baked key so animation + posing actually deform the skin (#2).
     pub skin_joint_baked: Mutex<HashMap<NodeId, TransformKey>>,
+    /// Each skin-joint node's IMPORT-TIME local transform — the glTF rest/bind
+    /// pose. Captured once per import (alongside [`Self::skin_joint_baked`])
+    /// and read by `ResetToBindPose`, which is otherwise impossible after
+    /// direct `SetTransform` pose edits mutate the scene-base transforms
+    /// (handoff #8: `reset_pose` re-syncs FROM scene base, so it can't undo
+    /// them).
+    pub joint_rest: Mutex<HashMap<NodeId, crate::engine::scene::Trs>>,
 }
 
 impl Bridge {
@@ -105,6 +112,7 @@ impl Bridge {
             template_instances: Mutex::new(HashMap::new()),
             node_to_template: Mutex::new(HashMap::new()),
             skin_joint_baked: Mutex::new(HashMap::new()),
+            joint_rest: Mutex::new(HashMap::new()),
         }
     }
 
@@ -179,13 +187,20 @@ impl Bridge {
     pub fn register_skin_joint(&self, node: NodeId, baked: TransformKey) {
         self.skin_joint_baked.lock().unwrap().insert(node, baked);
     }
+    /// Record a skin-joint node's import-time local TRS — the bind/rest pose
+    /// `ResetToBindPose` restores.
+    pub fn register_joint_rest(&self, node: NodeId, rest: crate::engine::scene::Trs) {
+        self.joint_rest.lock().unwrap().insert(node, rest);
+    }
     /// Drop all skin-joint mappings (project reset).
     pub fn clear_skin_joints(&self) {
         self.skin_joint_baked.lock().unwrap().clear();
+        self.joint_rest.lock().unwrap().clear();
     }
     /// Drop a single skin-joint mapping (a skinned-model bone node deleted).
     pub fn unregister_skin_joint(&self, node: NodeId) {
         self.skin_joint_baked.lock().unwrap().remove(&node);
+        self.joint_rest.lock().unwrap().remove(&node);
     }
 
     /// Drop all cached import templates + their instance tracking (project reset).
@@ -206,6 +221,95 @@ impl Bridge {
     pub fn node_for_mesh(&self, mesh: MeshKey) -> Option<NodeId> {
         self.mesh_to_node.lock().unwrap().get(&mesh).copied()
     }
+}
+
+/// Propagate a BUILT-IN library material's def edit to every mesh variant that
+/// references it: each variant's per-mesh `instance.inline` store re-seeds
+/// **field-wise** — a slot that still MIRRORED the prior library def adopts the
+/// new def's value, while a slot the mesh customized (≠ prior def) is preserved.
+/// This is `assign_material`-style template→instance carry-over applied in
+/// place, and it is what makes `update_builtin_material`'s documented "assigned
+/// meshes re-materialize" true for VALUES, not just for shader variants: without
+/// it the re-trigger below re-applies the stale inline copy and nothing visibly
+/// changes (glTF-imported materials seeded every mesh's inline store at import).
+/// Every touched node's kind is re-`set`, which fires its observer and
+/// re-materializes it.
+pub fn reseed_inline_for_material(
+    id: crate::engine::scene::AssetId,
+    prior: &awsm_renderer_editor_protocol::MaterialDef,
+    new_def: &awsm_renderer_editor_protocol::MaterialDef,
+) {
+    use crate::engine::scene::node::Node;
+    use crate::engine::scene::AssetId;
+    use awsm_renderer_editor_protocol::MaterialDef;
+
+    /// Field-wise template→instance merge; `true` when anything changed.
+    fn reseed(inline: &mut MaterialDef, prior: &MaterialDef, new_def: &MaterialDef) -> bool {
+        let mut changed = false;
+        macro_rules! seed {
+            ($($path:ident).+) => {
+                if inline.$($path).+ == prior.$($path).+ && inline.$($path).+ != new_def.$($path).+ {
+                    inline.$($path).+ = new_def.$($path).+.clone();
+                    changed = true;
+                }
+            };
+        }
+        seed!(label);
+        seed!(base_color);
+        seed!(base_color_texture);
+        seed!(metallic);
+        seed!(roughness);
+        seed!(metallic_roughness_texture);
+        seed!(emissive);
+        seed!(emissive_texture);
+        seed!(normal_texture);
+        seed!(normal_scale);
+        seed!(occlusion_texture);
+        seed!(occlusion_strength);
+        seed!(double_sided);
+        seed!(vertex_colors_enabled);
+        seed!(alpha_mode);
+        seed!(shading);
+        // Extensions per-slot, so one customized extension doesn't pin the rest.
+        seed!(extensions.emissive_strength);
+        seed!(extensions.ior);
+        seed!(extensions.specular);
+        seed!(extensions.transmission);
+        seed!(extensions.diffuse_transmission);
+        seed!(extensions.volume);
+        seed!(extensions.clearcoat);
+        seed!(extensions.sheen);
+        seed!(extensions.dispersion);
+        seed!(extensions.anisotropy);
+        seed!(extensions.iridescence);
+        changed
+    }
+
+    fn walk(nodes: &[Arc<Node>], id: AssetId, prior: &MaterialDef, new_def: &MaterialDef) {
+        for node in nodes {
+            let mut kind = node.kind.get_cloned();
+            let mut touched = false;
+            if let Some(variants) = kind.material_variants_mut() {
+                for v in variants.iter_mut() {
+                    if v.instance.asset == id {
+                        reseed(&mut v.instance.inline, prior, new_def);
+                        // Re-set even when no field changed: the def edit may
+                        // still be a shader-variant change (extensions toggled)
+                        // the observer must pick up.
+                        touched = true;
+                    }
+                }
+            }
+            if touched {
+                node.kind.set(kind);
+            }
+            walk(&node.children.lock_ref(), id, prior, new_def);
+        }
+    }
+
+    let ctrl = crate::controller::controller();
+    let roots: Vec<Arc<Node>> = ctrl.scene.nodes.lock_ref().iter().cloned().collect();
+    walk(&roots, id, prior, new_def);
 }
 
 /// Re-materialize every mesh that references custom material `id` — called

--- a/packages/frontend/editor/src/engine/scene/mutate.rs
+++ b/packages/frontend/editor/src/engine/scene/mutate.rs
@@ -105,6 +105,30 @@ pub fn duplicate_by_id(scene: &Scene, id: NodeId, new_root_id: Option<NodeId>) -
         Some(rid) => original.deep_clone_with_root_id(rid),
         None => original.deep_clone_with_new_ids(),
     };
+    // The clone copied every node's `kind` verbatim, so intra-subtree NodeId
+    // references still point at the ORIGINAL's nodes — most importantly a
+    // skinned mesh's `skin.joints[].node` bone bindings (leaving those stale
+    // makes a duplicated rig deform to the original's skeleton, rendering
+    // superimposed on it while its own joints do nothing). Remap every
+    // reference that resolves inside the duplicated subtree onto the cloned
+    // ids; references to nodes OUTSIDE the subtree (e.g. an instances node
+    // whose curve lives elsewhere) are intentionally left pointing at the
+    // shared original.
+    let mut id_map = std::collections::HashMap::new();
+    collect_clone_id_map(&original, &clone, &mut id_map);
+    remap_cloned_node_refs(&clone, &id_map);
+    // Propagate per-joint bind/rest records onto the cloned bone ids so
+    // `ResetToBindPose` works on duplicated rigs too (rest is otherwise only
+    // registered at import, keyed by the ORIGINAL bone ids).
+    {
+        let bridge = crate::engine::bridge::bridge();
+        let mut rest = bridge.joint_rest.lock().unwrap();
+        let copies: Vec<_> = id_map
+            .iter()
+            .filter_map(|(old, new)| rest.get(old).map(|r| (*new, *r)))
+            .collect();
+        rest.extend(copies);
+    }
     let new_id = clone.id;
 
     // Insert as sibling after the original.
@@ -129,6 +153,59 @@ pub fn duplicate_by_id(scene: &Scene, id: NodeId, new_root_id: Option<NodeId>) -
     }
 
     Some(new_id)
+}
+
+/// Build the original→clone [`NodeId`] map by walking both trees in lockstep
+/// (a deep clone mirrors the original's child order exactly).
+fn collect_clone_id_map(
+    original: &Arc<Node>,
+    clone: &Arc<Node>,
+    map: &mut std::collections::HashMap<NodeId, NodeId>,
+) {
+    map.insert(original.id, clone.id);
+    let oc = original.children.lock_ref();
+    let cc = clone.children.lock_ref();
+    for (o, c) in oc.iter().zip(cc.iter()) {
+        collect_clone_id_map(o, c, map);
+    }
+}
+
+/// Rewrite intra-subtree [`NodeId`] references inside a freshly-cloned
+/// subtree's kinds (skin joint bindings, instances-along-curve node refs) onto
+/// the cloned ids. Ids absent from `map` reference nodes outside the
+/// duplicated subtree and are preserved. Runs before the clone is inserted
+/// into the scene, so no observer sees the intermediate state.
+fn remap_cloned_node_refs(clone: &Arc<Node>, map: &std::collections::HashMap<NodeId, NodeId>) {
+    use crate::engine::scene::NodeKind;
+    let mut kind = clone.kind.get_cloned();
+    let mut changed = false;
+    match &mut kind {
+        NodeKind::SkinnedMesh { skin, .. } => {
+            for joint in skin.joints.iter_mut() {
+                if let Some(new) = map.get(&joint.node) {
+                    joint.node = *new;
+                    changed = true;
+                }
+            }
+        }
+        NodeKind::InstancesAlongCurve(def) => {
+            if let Some(new) = map.get(&def.curve_node) {
+                def.curve_node = *new;
+                changed = true;
+            }
+            if let Some(new) = map.get(&def.source_node) {
+                def.source_node = *new;
+                changed = true;
+            }
+        }
+        _ => {}
+    }
+    if changed {
+        clone.kind.set(kind);
+    }
+    for child in clone.children.lock_ref().iter() {
+        remap_cloned_node_refs(child, map);
+    }
 }
 
 /// Move `id` to become a child of `new_parent_id` at `position` (or `None`

--- a/packages/frontend/editor/src/remote.rs
+++ b/packages/frontend/editor/src/remote.rs
@@ -82,6 +82,44 @@ thread_local! {
     /// the MCP server (with backoff) until [`disconnect`] clears it. Lets a server
     /// restart reconnect seamlessly without a manual page reload.
     static RECONNECT: Cell<bool> = const { Cell::new(false) };
+    /// Whether the `visibilitychange` push listener is installed (once per page —
+    /// it outlives individual link sessions; `notify_event` is a no-op when
+    /// disconnected).
+    static VISIBILITY_HOOKED: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Push the tab's current visibility to the server (`kind: "visibility"`). The
+/// server records it per connection so frame-bound requests can fail fast with a
+/// "tab hidden" error instead of burning the full request timeout, and surfaces
+/// it in `ping`/`pairing_status`. Sent on attach and on every `visibilitychange`.
+fn push_visibility() {
+    let hidden = web_sys::window()
+        .and_then(|w| w.document())
+        .map(|d| d.hidden())
+        .unwrap_or(false);
+    notify_event(EditorEvent {
+        kind: "visibility".to_string(),
+        level: None,
+        message: None,
+        nodes: None,
+        hidden: Some(hidden),
+    });
+}
+
+/// Install the page-level `visibilitychange` listener (idempotent). Lives for the
+/// page: reconnects reuse it, and pushes while disconnected are dropped by
+/// [`notify_event`].
+fn hook_visibility() {
+    if VISIBILITY_HOOKED.with(|h| h.replace(true)) {
+        return;
+    }
+    let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+    let cb = wasm_bindgen::closure::Closure::<dyn FnMut()>::new(push_visibility);
+    use wasm_bindgen::JsCast;
+    let _ = doc.add_event_listener_with_callback("visibilitychange", cb.as_ref().unchecked_ref());
+    cb.forget(); // page-lifetime listener
 }
 
 /// Reactive connection status (for the UI button).
@@ -294,6 +332,11 @@ async fn run(control_origin: String) -> Result<(), String> {
     status().set(RemoteStatus::Connected);
     notify_info("MCP connected");
     tracing::info!("mcp: attached");
+    // Seed the server with this tab's visibility (and keep it updated for the
+    // life of the page) so agents get fast, explicit "tab hidden" errors instead
+    // of full request timeouts when rAF is paused.
+    hook_visibility();
+    push_visibility();
 
     loop {
         futures::select! {

--- a/packages/frontend/editor/src/scene_mode/content_browser.rs
+++ b/packages/frontend/editor/src/scene_mode/content_browser.rs
@@ -164,7 +164,7 @@ fn toolbar(cat: Mutable<Cat>, query: Mutable<String>) -> Dom {
             .on_click(|| {
                 // "+ Clip" authors a fresh animation clip in the library (Animation
                 // category). Switch to Animation mode so the new clip is editable.
-                dispatch(EditorCommand::AddClip { id: AssetId::new() });
+                dispatch(EditorCommand::AddClip { id: AssetId::new(), name: None });
                 dispatch(EditorCommand::SwitchMode { mode: EditorMode::Animation });
             }).render())
     })

--- a/packages/frontend/editor/src/scene_mode/inspector.rs
+++ b/packages/frontend/editor/src/scene_mode/inspector.rs
@@ -206,7 +206,14 @@ fn kind_editor(node: &Arc<Node>) -> Dom {
             mesh, shadow, lod, ..
         } => {
             let selected = node_material_instance(node);
+            // Duplicates share the mesh ASSET — surface that before the
+            // geometry editor, since edits there change every sharer.
+            let shared = shared_geometry_note(&geometry_sharers(node.id, mesh.0, false), true);
             html!("div", {
+                .apply(|d| match shared {
+                    Some(note) => d.child(note),
+                    None => d,
+                })
                 .child(mesh_geometry_section(mesh.0))
                 .child(material_editor(node, &inline_of(&selected), selected.is_some()))
                 .child(mesh_shadow_editor(node, shadow))
@@ -217,9 +224,18 @@ fn kind_editor(node: &Arc<Node>) -> Dom {
         // weights can't survive topology edits). Shows the material + shadow
         // surface plus a "Drop Skinning" action that bakes the bind pose into a
         // static editable Mesh (terminal).
-        NodeKind::SkinnedMesh { shadow, lod, .. } => {
+        NodeKind::SkinnedMesh {
+            skin, shadow, lod, ..
+        } => {
             let node_id = node.id;
             let selected = node_material_instance(node);
+            // Duplicated rigs share the imported source asset (stored once in
+            // save/bundle) — surfaced as information, since skinned geometry
+            // isn't editable anyway. A rig's OWN per-primitive siblings (this
+            // import's other material meshes) share the source too and would
+            // be noise, so they are excluded.
+            let shared =
+                shared_geometry_note(&skinned_rig_sharers(node.id, skin.source), false);
             html!("div", {
                 .child(info_section(
                     "Skinned Mesh",
@@ -228,6 +244,10 @@ fn kind_editor(node: &Arc<Node>) -> Dom {
                      per-vertex skin weights can't survive topology-changing edits. \
                      Drop skinning to bake the bind pose into a static, editable mesh.",
                 ))
+                .apply(|d| match shared {
+                    Some(note) => d.child(note),
+                    None => d,
+                })
                 .child(material_editor(node, &inline_of(&selected), selected.is_some()))
                 .child(mesh_shadow_editor(node, shadow))
                 .child(mesh_lod_editor(node, lod))
@@ -690,6 +710,85 @@ fn info_section(title: &str, body: &str) -> Dom {
             .text(body)
         }))
         .render()
+}
+
+/// The OTHER nodes referencing the same geometry asset as `current` — i.e.
+/// duplicates sharing this mesh (`skinned = false` matches `Mesh.mesh`) or this
+/// rig import (`skinned = true` matches `SkinnedMesh.skin.source`).
+fn geometry_sharers(
+    current: NodeId,
+    asset: awsm_renderer_editor_protocol::AssetId,
+    skinned: bool,
+) -> Vec<(NodeId, String)> {
+    collect_kind_nodes(|k| match k {
+        NodeKind::Mesh { mesh, .. } if !skinned => mesh.0 == asset,
+        NodeKind::SkinnedMesh { skin, .. } if skinned => skin.source == asset,
+        _ => false,
+    })
+    .into_iter()
+    .filter(|(id, _)| *id != current)
+    .collect()
+}
+
+/// Sharers of a skinned rig's import source, EXCLUDING this import's own
+/// per-primitive sibling meshes (a multi-material rig splits into one
+/// skinned-mesh node per primitive under one group — those share the source
+/// by construction and are not duplicates). Siblings are identified by
+/// sharing `current`'s parent.
+fn skinned_rig_sharers(
+    current: NodeId,
+    source: awsm_renderer_editor_protocol::AssetId,
+) -> Vec<(NodeId, String)> {
+    let scene = &controller().scene;
+    let my_parent = crate::engine::scene::mutate::find_parent(scene, current).map(|p| p.id);
+    geometry_sharers(current, source, true)
+        .into_iter()
+        .filter(|(id, _)| {
+            crate::engine::scene::mutate::find_parent(scene, *id).map(|p| p.id) != my_parent
+        })
+        .collect()
+}
+
+/// "Shared geometry" note: shown ONLY when other nodes reference the same
+/// geometry asset (i.e. this node is/was duplicated). Names the sharers so
+/// they're findable in the Outliner. Without this there is no way to tell a
+/// duplicate from an independent mesh — and for editable meshes that matters:
+/// geometry edits mutate the SHARED asset, changing every sharer at once.
+fn shared_geometry_note(sharers: &[(NodeId, String)], editable: bool) -> Option<Dom> {
+    if sharers.is_empty() {
+        return None;
+    }
+    let names: Vec<String> = sharers.iter().map(|(_, n)| n.clone()).collect();
+    let body = if editable {
+        format!(
+            "Geometry shared with {} other node{}: {}. Geometry edits (modifiers, \
+             vertex ops) change ALL of them — materials and transforms stay \
+             per-node. The bundle stores the shared mesh once.",
+            sharers.len(),
+            if sharers.len() == 1 { "" } else { "s" },
+            names.join(", "),
+        )
+    } else {
+        format!(
+            "Rig geometry shared with {} other node{}: {} (same import source). \
+             Joints, pose, and materials are per-instance; the bundle stores the \
+             shared rig once.",
+            sharers.len(),
+            if sharers.len() == 1 { "" } else { "s" },
+            names.join(", "),
+        )
+    };
+    Some(
+        Section::new("Shared Geometry")
+            .dense(true)
+            .child(html!("div", {
+                .style("font-size", "12px")
+                .style("line-height", "1.5")
+                .style("color", if editable { "var(--warning, #e0af68)" } else { "var(--text-3)" })
+                .text(&body)
+            }))
+            .render(),
+    )
 }
 
 // ── Sweep / Instances curve-reference pickers ───────────────────────────────

--- a/packages/mcp/editor-protocol/src/anim_ui.rs
+++ b/packages/mcp/editor-protocol/src/anim_ui.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 /// not pure ephemeral UI.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum AnimView {
     #[default]
     Dope,
@@ -19,6 +20,7 @@ pub enum AnimView {
 /// A step-playhead direction (transport buttons).
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum StepKind {
     /// Jump to clip start (t = 0).
     Home,
@@ -33,6 +35,7 @@ pub enum StepKind {
 /// The selected timeline element (track / keyframe). Identified by track index
 /// within the active clip + optional keyframe index.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct AnimSel {
     /// Index of the selected track in the active clip's `tracks`.
     pub track: usize,

--- a/packages/mcp/editor-protocol/src/assets.rs
+++ b/packages/mcp/editor-protocol/src/assets.rs
@@ -22,6 +22,7 @@ use awsm_renderer_scene::{mesh_asset_filename, AssetId, MaterialDef, TextureDef}
 // player/editor match site for marginal benefit; assets are not stored in hot,
 // densely-packed arrays.
 #[allow(clippy::large_enum_variant)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum AssetSource {
     /// Editor on-disk file (glb / gltf / ktx). The inner String is the
     /// user's original filename, kept for UI labels and to derive the
@@ -52,6 +53,7 @@ pub enum AssetSource {
 /// what the UI / `get_node_details` want to show without loading the file.
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct BufferDef {
     /// Number of little-endian `u32` words in the buffer.
     #[serde(default)]
@@ -77,6 +79,7 @@ impl AssetSource {
 
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct AssetEntry {
     pub source: AssetSource,
     /// Editable `MaterialDef` asset ids extracted from a glTF file on

--- a/packages/mcp/editor-protocol/src/command.rs
+++ b/packages/mcp/editor-protocol/src/command.rs
@@ -32,6 +32,7 @@ use crate::node_spec::{InsertSpec, NodeSpec};
 /// Maps to `ProceduralTextureDef` with sensible defaults at apply-time.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum ProceduralKind {
     Checker,
     Gradient,
@@ -42,6 +43,7 @@ pub enum ProceduralKind {
 /// carries its alpha cutoff. Mirrors the editor's `AlphaMode` + cutoff pair.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum CustomAlphaMode {
     Opaque,
     Mask { cutoff: f64 },
@@ -53,6 +55,7 @@ pub enum CustomAlphaMode {
 /// default (comma-separated for vectors, e.g. `"0.6, 0.7, 1.0"`); `debug` is the
 /// texture/buffer debug-preview source. Used by `SetCustomMaterialLayout`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct SlotSpec {
     pub name: String,
     /// WGSL type, e.g. `"f32"`, `"vec3<f32>"`, `"texture_2d<f32>"`,
@@ -87,6 +90,7 @@ pub enum BuiltinTextureSlot {
 /// camera ends up on that axis looking back at the orbit target.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum CameraAxis {
     PosX,
     NegX,
@@ -99,6 +103,7 @@ pub enum CameraAxis {
 /// Top-level workspace mode (the Scene/Material switch in the top bar).
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum EditorMode {
     #[default]
     Scene,
@@ -122,6 +127,7 @@ pub struct SkinWeightEntry {
 /// Every editor mutation, as serializable data.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "cmd", rename_all = "snake_case")]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum EditorCommand {
     /// Switch the workspace mode. **Transient** — dispatched but not recorded in
     /// the undo log.
@@ -508,6 +514,15 @@ pub enum EditorCommand {
     /// view doesn't keep showing e.g. raised arms after `SetCurrentClip {}`.
     /// **Transient** (re-syncs renderer locals from the scene; no scene edit).
     ResetPose { node: NodeId },
+
+    /// Restore every SKIN-JOINT node in `id`'s subtree (including `id`) to its
+    /// import-time local transform — the glTF bind/rest pose. This is the way
+    /// back to T-pose after direct `SetTransform` pose edits, which MUTATE the
+    /// scene-base transforms and are therefore untouched by [`Self::ResetPose`]
+    /// (that only re-syncs the renderer FROM the scene). A real scene edit:
+    /// undoable (inverse restores the prior pose), and a no-op for nodes with
+    /// no recorded rest (non-joints, procedural meshes).
+    ResetToBindPose { id: NodeId },
 
     /// Pin the renderer's `frame_globals.time` to `seconds` (overrides the
     /// wall-clock). A temporal material (`sin(time*f)`) then screenshots the same
@@ -956,7 +971,13 @@ pub enum EditorCommand {
     /// `apply`) so the command is deterministic data — a cross-tab relay that
     /// replays it produces the *same* clip id in every tab. Idempotent: applying
     /// it when the id already exists is a no-op.
-    AddClip { id: AssetId },
+    AddClip {
+        id: AssetId,
+        /// Optional display name for the new clip; `None` ⇒ the default
+        /// "Clip N" numbering (prior behavior; saves the create+rename pair).
+        #[serde(default)]
+        name: Option<String>,
+    },
     /// Delete a clip from the library. Lifecycle.
     DeleteClip { id: AssetId },
     /// Duplicate a clip (deep copy, fresh id) and select it. Lifecycle.
@@ -1042,6 +1063,27 @@ pub enum EditorCommand {
         /// `Some` sets it in one step (no follow-up `SetKeyframe`).
         #[serde(default)]
         interp: Option<Interp>,
+    },
+    /// REPLACE a track's entire key list in one step — the bulk authoring path
+    /// (one command per track instead of one `AddKeyframe` per key; handoff F4).
+    /// `times` pairs index-wise with `values` (public form; per-key interp from
+    /// `interp` or the track's sampler) OR with `keys` (full-fidelity form —
+    /// non-empty `keys` wins; used by the inverse to restore tangents/interp
+    /// exactly). Inverse: another `SetTrackKeys` carrying the prior keys.
+    SetTrackKeys {
+        clip: AssetId,
+        track: usize,
+        /// Key times in seconds (need not be pre-sorted; sorted on apply).
+        times: Vec<f64>,
+        /// One value per time (ignored when `keys` is non-empty).
+        #[serde(default)]
+        values: Vec<TrackValue>,
+        /// Interpolation for every new key; `None` ⇒ the track sampler's.
+        #[serde(default)]
+        interp: Option<Interp>,
+        /// Full keyframes (one per time) — the lossless/internal form.
+        #[serde(default)]
+        keys: Vec<Keyframe>,
     },
     /// Delete a keyframe (by index). Inverse: `InsertKeyframe` of the captured key.
     DeleteKeyframe {
@@ -1224,6 +1266,7 @@ impl EditorCommand {
                 | EditorCommand::SetTrackSolo { .. }
                 // Keyframes.
                 | EditorCommand::AddKeyframe { .. }
+                | EditorCommand::SetTrackKeys { .. }
                 | EditorCommand::DeleteKeyframe { .. }
                 | EditorCommand::InsertKeyframe { .. }
                 | EditorCommand::SetKeyframe { .. }
@@ -1292,6 +1335,7 @@ impl EditorCommand {
             EditorCommand::PatchKind { .. } => "Patch properties",
             EditorCommand::SetParticleEmitter { .. } => "Configure emitter",
             EditorCommand::SetTransform { .. } => "Transform",
+            EditorCommand::ResetToBindPose { .. } => "Reset to bind pose",
             EditorCommand::Rename { .. } => "Rename",
             EditorCommand::SetVisible { .. } => "Toggle visibility",
             EditorCommand::SetLocked { .. } => "Toggle lock",
@@ -1392,6 +1436,7 @@ impl EditorCommand {
             EditorCommand::SetTrackMute { .. } => "Mute track",
             EditorCommand::SetTrackSolo { .. } => "Solo track",
             EditorCommand::AddKeyframe { .. } => "Add keyframe",
+            EditorCommand::SetTrackKeys { .. } => "Set track keys",
             EditorCommand::DeleteKeyframe { .. } | EditorCommand::InsertKeyframe { .. } => {
                 "Delete keyframe"
             }

--- a/packages/mcp/editor-protocol/src/mesh_def.rs
+++ b/packages/mcp/editor-protocol/src/mesh_def.rs
@@ -13,6 +13,7 @@ use awsm_renderer_scene::{AssetId, PrimitiveShape};
 /// having to find a source node in the tree.
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct MeshDef {
     pub label: String,
     #[serde(default)]
@@ -199,6 +200,7 @@ impl VertexOverrides {
 /// falls back to the legacy "pick a source from scene" picker.
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum CapturedSource {
     Primitive(PrimitiveShape),
     Sweep(SweepAlongCurveDef),
@@ -221,6 +223,7 @@ pub enum CapturedSource {
 /// The consuming crates own conversion helpers (editor bake → runtime MeshBlob).
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct CapturedMesh {
     pub positions: Vec<[f32; 3]>,
     pub normals: Option<Vec<[f32; 3]>>,

--- a/packages/mcp/editor-protocol/src/node_spec.rs
+++ b/packages/mcp/editor-protocol/src/node_spec.rs
@@ -19,6 +19,7 @@ use awsm_renderer_scene::{EditorNode, LightKind, NodeId, NodeKind, PrimitiveShap
 /// `build_insert` turns this into a reactive `Node`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum InsertSpec {
     Empty,
     Light(LightKind),
@@ -42,6 +43,7 @@ pub enum InsertSpec {
 
 /// A full serializable capture of a node subtree (preserves ids).
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct NodeSpec {
     pub id: NodeId,
     pub name: String,

--- a/packages/mcp/editor-protocol/src/query.rs
+++ b/packages/mcp/editor-protocol/src/query.rs
@@ -204,6 +204,12 @@ fn default_units() -> String {
 pub enum EditorQuery {
     /// The existing editor snapshot.
     Snapshot,
+    /// Report of the most recent model import (glTF url/file): created root
+    /// node ids + names, node/material/skin-joint/clip counts, and the source
+    /// asset id. `None`-shaped (empty report) when nothing was imported this
+    /// session. Answers "what did that import just create?" without diffing
+    /// snapshots (handoff #6/F2); the MCP import tools also return it inline.
+    LastImportReport,
     /// Sample a clip's targets across a set of pinned times — *video as numbers*.
     /// GPU-independent (reads CPU-side renderer state after `update_animations(0.0)`).
     SampleClipTimeseries {

--- a/packages/mcp/editor-protocol/src/transport.rs
+++ b/packages/mcp/editor-protocol/src/transport.rs
@@ -66,7 +66,7 @@ pub enum Request {
 /// can react to what a human (or async work) did.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EditorEvent {
-    /// Event kind: `"toast"` | `"selection"`.
+    /// Event kind: `"toast"` | `"selection"` | `"visibility"`.
     pub kind: String,
     /// Toast severity (`"info"` | `"warning"` | `"error"`) for `kind == "toast"`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -77,6 +77,14 @@ pub struct EditorEvent {
     /// Selected node ids for `kind == "selection"`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub nodes: Option<Vec<String>>,
+    /// Tab visibility for `kind == "visibility"`: `true` when the tab is hidden
+    /// (the browser pauses/throttles `requestAnimationFrame`, so frame-bound
+    /// requests — screenshots, settles — stall until it is visible again). The
+    /// editor pushes one on attach and one per `visibilitychange`; the server
+    /// tracks the latest value per connection so agents can fail fast instead
+    /// of burning the full request timeout.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hidden: Option<bool>,
 }
 
 /// Server → browser WebSocket frame.
@@ -221,7 +229,13 @@ mod wire_roundtrip_tests {
                     ids: vec![NodeId::new()],
                 },
             ),
-            ("add_clip", EditorCommand::AddClip { id: AssetId::new() }),
+            (
+                "add_clip",
+                EditorCommand::AddClip {
+                    id: AssetId::new(),
+                    name: None,
+                },
+            ),
             (
                 "delete_clip",
                 EditorCommand::DeleteClip { id: AssetId::new() },
@@ -553,6 +567,19 @@ mod wire_roundtrip_tests {
             level: Some("info".to_string()),
             message: Some("hi".to_string()),
             nodes: None,
+            hidden: None,
+        });
+        let j = serde_json::to_string(&event).unwrap();
+        let back: WsClientMsg = serde_json::from_str(&j).unwrap();
+        assert_eq!(j, serde_json::to_string(&back).unwrap());
+
+        // Visibility push (tab hidden/shown) round-trips.
+        let event = WsClientMsg::Event(EditorEvent {
+            kind: "visibility".to_string(),
+            level: None,
+            message: None,
+            nodes: None,
+            hidden: Some(true),
         });
         let j = serde_json::to_string(&event).unwrap();
         let back: WsClientMsg = serde_json::from_str(&j).unwrap();

--- a/packages/mcp/src/link.rs
+++ b/packages/mcp/src/link.rs
@@ -18,7 +18,7 @@
 //! session.
 
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -29,6 +29,14 @@ use awsm_renderer_editor_protocol::{EditorEvent, Request, Response, WsServerMsg}
 /// Upper bound on one request's round-trip (an offline render / settle is the
 /// slow case).
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Request timeout while the tab reports itself HIDDEN: the browser has paused
+/// `requestAnimationFrame`, so anything frame-bound (screenshots, settles,
+/// re-materializations that await a presented frame) will never complete — fail
+/// fast with a distinct error instead of burning the full [`REQUEST_TIMEOUT`].
+/// Kept generous enough for JS-only work (queries, pure state edits), which
+/// still completes when hidden (timers are throttled, not stopped).
+const HIDDEN_REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// Why a request couldn't be delivered.
 pub enum LinkError {
@@ -42,9 +50,23 @@ pub struct Connection {
     tx: mpsc::UnboundedSender<WsServerMsg>,
     pending: Mutex<HashMap<u64, oneshot::Sender<Response>>>,
     next_req_id: AtomicU64,
+    /// Latest tab visibility the editor pushed (`kind: "visibility"` event):
+    /// `true` ⇒ the tab is hidden and rAF is paused, so frame-bound requests
+    /// cannot complete. Drives the fast-fail timeout + the `ping` report.
+    hidden: AtomicBool,
 }
 
 impl Connection {
+    /// Latest visibility the tab reported (`true` = hidden, rAF paused).
+    pub fn is_hidden(&self) -> bool {
+        self.hidden.load(Ordering::Relaxed)
+    }
+
+    /// Record a visibility push from the tab.
+    pub fn set_hidden(&self, hidden: bool) {
+        self.hidden.store(hidden, Ordering::Relaxed);
+    }
+
     /// Send one request to this tab and await its response.
     async fn request(&self, req: &Request) -> Result<Response, String> {
         let id = self.next_req_id.fetch_add(1, Ordering::Relaxed);
@@ -56,7 +78,15 @@ impl Connection {
                 req: req.clone(),
             })
             .map_err(|_| "editor link closed".to_string())?;
-        match tokio::time::timeout(REQUEST_TIMEOUT, rx).await {
+        // A hidden tab has rAF paused: frame-bound work can never finish, and
+        // JS-only work still answers quickly — so use the short timeout and a
+        // distinct, actionable error.
+        let (limit, hidden_at_send) = if self.is_hidden() {
+            (HIDDEN_REQUEST_TIMEOUT, true)
+        } else {
+            (REQUEST_TIMEOUT, false)
+        };
+        match tokio::time::timeout(limit, rx).await {
             Ok(Ok(resp)) => Ok(resp),
             Ok(Err(_)) => {
                 self.pending.lock().unwrap().remove(&id);
@@ -64,13 +94,24 @@ impl Connection {
             }
             Err(_) => {
                 self.pending.lock().unwrap().remove(&id);
-                Err(
-                    "editor request timed out — is the editor tab foregrounded? \
-                     A screenshot/render needs a live requestAnimationFrame frame, \
-                     which browsers throttle or pause in a backgrounded/hidden tab. \
-                     Foreground the tab (or keep it visible) and retry."
-                        .into(),
-                )
+                if hidden_at_send || self.is_hidden() {
+                    Err("editor tab is HIDDEN — the browser has paused rendering \
+                         (requestAnimationFrame), so frame-bound operations \
+                         (screenshots, render settles, material re-materialization) \
+                         cannot complete until the tab is visible again. Make the \
+                         tab visible (foreground it / wake the display) and retry. \
+                         JS-only queries (get_snapshot, get_mode, …) still work \
+                         while hidden."
+                        .into())
+                } else {
+                    Err(
+                        "editor request timed out — is the editor tab foregrounded? \
+                         A screenshot/render needs a live requestAnimationFrame frame, \
+                         which browsers throttle or pause in a backgrounded/hidden tab. \
+                         Foreground the tab (or keep it visible) and retry."
+                            .into(),
+                    )
+                }
             }
         }
     }
@@ -151,6 +192,7 @@ impl EditorLink {
             tx,
             pending: Mutex::new(HashMap::new()),
             next_req_id: AtomicU64::new(1),
+            hidden: AtomicBool::new(false),
         });
         let mut conns = self.inner.connections.lock().unwrap();
         // Evict every prior tab — one server, one tab.
@@ -223,6 +265,18 @@ impl EditorLink {
     /// The id of the tab requests currently route to (for the event forwarder).
     pub fn current_conn_id(&self) -> Option<u64> {
         self.inner.connections.lock().unwrap().last().map(|c| c.id)
+    }
+
+    /// Latest visibility the attached tab reported: `Some(true)` = hidden (rAF
+    /// paused, frame-bound requests will fail fast), `Some(false)` = visible,
+    /// `None` = no tab attached. Surfaced by `ping` / `pairing_status`.
+    pub fn current_visibility(&self) -> Option<bool> {
+        self.inner
+            .connections
+            .lock()
+            .unwrap()
+            .last()
+            .map(|c| c.is_hidden())
     }
 
     /// Send a request from `agent` to the attached tab.

--- a/packages/mcp/src/mcp.rs
+++ b/packages/mcp/src/mcp.rs
@@ -1242,6 +1242,36 @@ pub struct AddKeyframeParams {
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct SetTrackKeysParams {
+    pub clip: String,
+    pub track: u32,
+    /// Key times in seconds (paired index-wise with `values`; need not be sorted).
+    pub times: Vec<f64>,
+    /// One value per time.
+    pub values: Vec<TrackValueArg>,
+    /// Interpolation for every key: step | linear | cubic, optional. Omit to
+    /// derive from the track's sampler.
+    #[serde(default)]
+    pub interp: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct ListCommandsParams {
+    /// Exact command tag (e.g. "reparent") for that command's full JSON Schema;
+    /// omit for the compact list of all commands.
+    #[serde(default)]
+    pub cmd: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct AddClipParams {
+    /// Optional display name for the new clip (e.g. "robot_wave"); omit for the
+    /// default "Clip N" numbering.
+    #[serde(default)]
+    pub name: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct SetKeyframeParams {
     pub clip: String,
     pub track: u32,
@@ -1421,11 +1451,20 @@ impl EditorMcp {
 
     #[tool(
         annotations(read_only_hint = true),
-        description = "Health check: confirms an editor is attached (fails fast with 'no editor attached' if not). Returns the current mode."
+        description = "Health check: confirms an editor is attached (fails fast with 'no editor attached' if not). Returns the current mode and the tab's visibility — `tab=HIDDEN` means the browser paused rendering (rAF), so frame-bound tools (screenshots, wait_render_settled, re-materializations) will fail fast until the tab is visible again; JS-only queries still work."
     )]
     async fn ping(&self) -> Result<CallToolResult, McpError> {
         match self.req(Request::Mode).await? {
-            Response::Mode(m) => Ok(text(format!("pong — editor attached (mode={m:?})"))),
+            Response::Mode(m) => {
+                let vis = match self.link.current_visibility() {
+                    Some(true) => "HIDDEN — rendering paused; frame-bound tools will fail fast",
+                    Some(false) => "visible",
+                    None => "unknown",
+                };
+                Ok(text(format!(
+                    "pong — editor attached (mode={m:?}, tab={vis})"
+                )))
+            }
             other => Err(unexpected(other)),
         }
     }
@@ -1438,22 +1477,31 @@ impl EditorMcp {
         let editors = self.link.connection_count();
         let connected = editors > 0;
         let origin = self.link.self_origin();
-        Ok(text(
-            serde_json::json!({
-                "status": if connected {
-                    "connected (an editor tab is attached)"
-                } else {
-                    "waiting for an editor tab to connect"
-                },
-                "editor_connected": connected,
-                "editors_connected": editors,
-                "how_to_connect": format!(
-                    "open the awsm-renderer editor with `?mcp={origin}` appended to its URL, \
-                     or enter this server's address in its MCP connect modal"
-                ),
-            })
-            .to_string(),
-        ))
+        let mut body = serde_json::json!({
+            "status": if connected {
+                "connected (an editor tab is attached)"
+            } else {
+                "waiting for an editor tab to connect"
+            },
+            "editor_connected": connected,
+            "editors_connected": editors,
+            "how_to_connect": format!(
+                "open the awsm-renderer editor with `?mcp={origin}` appended to its URL, \
+                 or enter this server's address in its MCP connect modal"
+            ),
+        });
+        if let Some(hidden) = self.link.current_visibility() {
+            body["tab_hidden"] = serde_json::json!(hidden);
+            if hidden {
+                body["tab_hidden_note"] = serde_json::json!(
+                    "the tab reported itself HIDDEN: the browser paused rendering \
+                     (requestAnimationFrame), so frame-bound tools (screenshots, \
+                     wait_render_settled, re-materializations) fail fast until the \
+                     tab is visible again; JS-only queries still work"
+                );
+            }
+        }
+        Ok(text(body.to_string()))
     }
 
     #[tool(
@@ -2217,13 +2265,26 @@ impl EditorMcp {
         .await
     }
 
-    #[tool(description = "Import a glTF/glb model from a URL.")]
+    #[tool(
+        description = "Import a glTF/glb model from a URL and return the import report (created root node ids/names, node/material/skin-joint/clip counts, source asset id). Fails with the load error when the fetch/parse fails — note the URL's server must send CORS headers (`Access-Control-Allow-Origin`): the editor is a browser app, and e.g. plain `python3 -m http.server` will fail."
+    )]
     async fn import_model_from_url(
         &self,
         Parameters(p): Parameters<UrlParams>,
     ) -> Result<CallToolResult, McpError> {
+        // Dispatch first (errors — e.g. CORS fetch failures — propagate here),
+        // then return WHAT the import created instead of a bare "ok".
         self.dispatch(EditorCommand::ImportModelFromUrl { url: p.url })
-            .await
+            .await?;
+        self.query(EditorQuery::LastImportReport).await
+    }
+
+    #[tool(
+        annotations(read_only_hint = true),
+        description = "Report of the most recent model import this session: created root node ids/names, node/material/skin-joint/clip counts, and the source asset id. `report: null` when nothing has been imported. The import tools also return this inline; use this to re-read it later without re-importing."
+    )]
+    async fn get_last_import_report(&self) -> Result<CallToolResult, McpError> {
+        self.query(EditorQuery::LastImportReport).await
     }
 
     #[tool(
@@ -3391,7 +3452,7 @@ impl EditorMcp {
 
     #[tool(
         annotations(read_only_hint = true),
-        description = "Rig discovery per skinned node: { source, primitive_index, joints:[{node,index,name,translation,rotation,scale}] }. Joints ARE ordinary scene nodes — POSE one with set_node_transform on its `node` id (the skin deforms live), ANIMATE one with add_track targeting it (transform). Pass node UUIDs, or empty for all skinned nodes."
+        description = "Rig discovery, grouped PER SKIN (keyed by source asset id): { source, meshes:[{node,name,primitive_index}], joints:[{node,index,name,live,translation,rotation,scale}] }. One joint table per rig — the skinned-mesh nodes sharing it are listed in `meshes` (a multi-material rig is one entry, not one copy per primitive). Joints ARE ordinary scene nodes — POSE one with set_node_transform on its `node` id (the skin deforms live), ANIMATE one with add_track targeting it (transform), or restore the whole rig with reset_to_bind_pose. Pass skinned-mesh node UUIDs, or empty for all."
     )]
     async fn get_skin_data(
         &self,
@@ -3763,21 +3824,67 @@ impl EditorMcp {
         .await
     }
 
+    #[tool(
+        description = "Restore every SKIN-JOINT node under `node` (pass a rig root) to its import-time transform — the glTF bind/rest pose (T-pose). This is the way back after posing joints with set_node_transform / solve_ik, which EDIT the scene base transforms and are therefore untouched by reset_pose (that only reverts clip-preview poses). A real scene edit: single-step undoable. No-op for nodes without recorded rest data (non-joints)."
+    )]
+    async fn reset_to_bind_pose(
+        &self,
+        Parameters(p): Parameters<NodeArg>,
+    ) -> Result<CallToolResult, McpError> {
+        self.dispatch(EditorCommand::ResetToBindPose {
+            id: parse_node(&p.node)?,
+        })
+        .await
+    }
+
     // ── animation (lifecycle + transport) ───────────────────────────────────
 
     #[tool(
-        description = "Create a fresh empty animation clip and make it current. Returns the new clip id."
+        description = "Create a fresh empty animation clip (optionally named) and make it current. Returns the new clip id."
     )]
-    async fn add_clip(&self) -> Result<CallToolResult, McpError> {
+    async fn add_clip(
+        &self,
+        Parameters(p): Parameters<AddClipParams>,
+    ) -> Result<CallToolResult, McpError> {
         let id = AssetId::new();
         match self
-            .req(Request::Dispatch(EditorCommand::AddClip { id }))
+            .req(Request::Dispatch(EditorCommand::AddClip {
+                id,
+                name: p.name,
+            }))
             .await?
         {
             Response::Ok => Ok(text(id.to_string())),
             Response::Err(e) => Err(McpError::internal_error(e, None)),
             other => Err(unexpected(other)),
         }
+    }
+
+    #[tool(
+        description = "REPLACE a track's entire key list in one call — the bulk authoring path (one call per track instead of one add_keyframe per key). `times` pairs index-wise with `values`; unsorted input is sorted by time. Single-step undoable (undo restores the prior keys exactly)."
+    )]
+    async fn set_track_keys(
+        &self,
+        Parameters(p): Parameters<SetTrackKeysParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let values = p
+            .values
+            .iter()
+            .map(build_track_value)
+            .collect::<Result<Vec<_>, _>>()?;
+        let interp = match p.interp.as_deref() {
+            Some(s) => Some(parse_enum(s, "interp")?),
+            None => None,
+        };
+        self.dispatch(EditorCommand::SetTrackKeys {
+            clip: parse_asset(&p.clip)?,
+            track: p.track as usize,
+            times: p.times,
+            values,
+            interp,
+            keys: Vec::new(),
+        })
+        .await
     }
 
     #[tool(description = "Delete an animation clip by id.")]
@@ -4096,7 +4203,7 @@ impl EditorMcp {
     }
 
     #[tool(
-        description = "Dispatch a list of raw EditorCommands as ONE atomic step (applied in order, collapsed into a single undo entry, one round-trip). Cuts latency for multi-step edits (e.g. building a rig). Each command is internally tagged by \"cmd\"."
+        description = "Dispatch a list of raw EditorCommands as ONE atomic step (applied in order, collapsed into a single undo entry, one round-trip). Cuts latency for multi-step edits (e.g. building a rig). Each command is internally tagged by \"cmd\" — discover tags + payload shapes with list_commands."
     )]
     async fn dispatch_batch(
         &self,
@@ -4112,6 +4219,84 @@ impl EditorMcp {
             Response::Err(e) => Err(McpError::internal_error(e, None)),
             other => Err(unexpected(other)),
         }
+    }
+
+    #[tool(
+        annotations(read_only_hint = true),
+        description = "Discover the raw EditorCommand vocabulary for dispatch_command / dispatch_batch (handoff #5/#12). No args: a compact list of every command tag with its field names ('*' marks required). With `cmd` (e.g. \"reparent\"): that command's FULL JSON Schema (exact payload shape + referenced $defs). Local — no editor round-trip."
+    )]
+    async fn list_commands(
+        &self,
+        Parameters(p): Parameters<ListCommandsParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let root = serde_json::to_value(schemars::schema_for!(EditorCommand))
+            .map_err(|e| McpError::internal_error(format!("schema: {e}"), None))?;
+        let variants = root
+            .get("oneOf")
+            .or_else(|| root.get("anyOf"))
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+        // The variant's tag: properties.cmd is `{"const": "..."}` (or a 1-enum).
+        fn tag_of(variant: &serde_json::Value) -> Option<String> {
+            let c = variant.get("properties")?.get("cmd")?;
+            c.get("const")
+                .and_then(|v| v.as_str())
+                .or_else(|| c.get("enum")?.get(0)?.as_str())
+                .map(str::to_string)
+        }
+        if let Some(want) = p.cmd.as_deref() {
+            for v in &variants {
+                if tag_of(v).as_deref() == Some(want) {
+                    let body = serde_json::json!({
+                        "cmd": want,
+                        "schema": v,
+                        "$defs": root.get("$defs").cloned().unwrap_or(serde_json::json!({})),
+                    });
+                    return Ok(text(body.to_string()));
+                }
+            }
+            return Err(McpError::invalid_params(
+                format!("unknown command tag `{want}` — call list_commands with no args for the full list"),
+                None,
+            ));
+        }
+        let mut list = Vec::new();
+        for v in &variants {
+            let Some(tag) = tag_of(v) else { continue };
+            let required: std::collections::HashSet<&str> = v
+                .get("required")
+                .and_then(|r| r.as_array())
+                .map(|a| a.iter().filter_map(|x| x.as_str()).collect())
+                .unwrap_or_default();
+            let fields: Vec<String> = v
+                .get("properties")
+                .and_then(|p| p.as_object())
+                .map(|props| {
+                    props
+                        .keys()
+                        .filter(|k| k.as_str() != "cmd")
+                        .map(|k| {
+                            if required.contains(k.as_str()) {
+                                format!("{k}*")
+                            } else {
+                                k.clone()
+                            }
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            list.push(serde_json::json!({ "cmd": tag, "fields": fields }));
+        }
+        list.sort_by(|a, b| a["cmd"].as_str().cmp(&b["cmd"].as_str()));
+        Ok(text(
+            serde_json::json!({
+                "count": list.len(),
+                "note": "fields marked * are required; call list_commands{cmd} for a command's full JSON Schema",
+                "commands": list,
+            })
+            .to_string(),
+        ))
     }
 }
 
@@ -4987,6 +5172,21 @@ mod tests {
             }
             other => panic!("expected SetVertexOverrides, got {other:?}"),
         }
+    }
+
+    /// Regression (handoff #11): `set_current_clip` called with NO `clip`
+    /// argument must deserialize to `clip: None` (⇒ `SetCurrentClip { id: None }`
+    /// = CLEAR the current clip). A deployed build once left the previous clip
+    /// active on the no-arg form, so later animation re-lowers silently re-posed
+    /// the rig mid-scene-edit.
+    #[test]
+    fn clip_opt_params_omitted_clip_is_clear() {
+        let p: ClipOptParams = serde_json::from_value(serde_json::json!({})).unwrap();
+        assert!(p.clip.is_none());
+        assert!(parse_asset_opt(&p.clip).unwrap().is_none());
+
+        let p: ClipOptParams = serde_json::from_value(serde_json::json!({ "clip": null })).unwrap();
+        assert!(p.clip.is_none());
     }
 
     /// The String-wrapped form (a JSON-encoded string arg) must still work.

--- a/packages/mcp/src/ws.rs
+++ b/packages/mcp/src/ws.rs
@@ -43,7 +43,22 @@ pub async fn handle_socket(socket: WebSocket, link: EditorLink) {
         match msg {
             Message::Text(txt) => match serde_json::from_str::<WsClientMsg>(txt.as_str()) {
                 Ok(WsClientMsg::Response { id, resp }) => conn.complete(id, resp),
-                Ok(WsClientMsg::Event(ev)) => link.publish_event(conn.id, ev),
+                Ok(WsClientMsg::Event(ev)) => {
+                    // Visibility pushes update the per-connection state that
+                    // drives fast-fail timeouts + the `ping` report (and are
+                    // still relayed to the agent like any other event).
+                    if ev.kind == "visibility" {
+                        if let Some(hidden) = ev.hidden {
+                            conn.set_hidden(hidden);
+                            tracing::info!(
+                                "connection {}: tab visibility → {}",
+                                conn.id,
+                                if hidden { "hidden" } else { "visible" }
+                            );
+                        }
+                    }
+                    link.publish_event(conn.id, ev)
+                }
                 Err(e) => tracing::warn!("connection {}: bad ws frame: {e}", conn.id),
             },
             Message::Close(_) => break,


### PR DESCRIPTION
Everything found while an agent drove a full scene build end-to-end over MCP (the DANCE-OFF overnight session): rig import, material authoring, animation clips, prefab duplication, player-bundle export — plus the API gaps that run exposed. Bumps workspace to **0.16.0**.

## Fixes
- **Silent import failures** → `import_model_from_url` / `FromFile` now propagate the load error (with a CORS hint for the browser-fetch trap) instead of reporting ok. Live-tested: no-CORS server errors loudly; CORS server imports.
- **`update_builtin_material` no-op on assigned meshes** → field-wise re-seed of every assigned variant's inline store (slots mirroring the prior def adopt the new def; per-mesh customizations preserved; extensions per-slot). Live-tested: def→red repaints every assigned mesh, other materials untouched.
- **`duplicate` broke skinned rigs** → intra-subtree NodeId refs (skin joint bindings, instances-along-curve) remap onto the cloned ids; bind-pose records propagate. Live-tested: duplicated rig shares zero joint ids with the original, deforms via its own joints, 25/25 live.
- **Hidden-tab timeouts were indistinguishable from a dead editor** → editor pushes `visibilitychange` over the link; server tracks per-connection, fails frame-bound requests fast (15s) with an actionable message; `ping`/`pairing_status` report tab state. (Motivated by an 8-hour overnight stall with a closed lid.)

## API additions
- `list_commands` — `EditorCommand` (+ ~30 nested types) derive `JsonSchema`; compact tag+fields list (136 commands) or full per-command schema. Makes `dispatch_command`/`dispatch_batch` payloads discoverable instead of guess-from-error.
- Import report — `LastImportReport` query, returned inline by the import tools (created roots, node/material/skin-joint/clip counts) + `get_last_import_report`.
- `get_skin_data` grouped per rig instance (one joint table + `meshes` list, not one copy per primitive; ~¼ payload for a 4-material rig); `live` recognizes the rig-decode path.
- `reset_to_bind_pose` — undoable restore of a subtree's joints to import-time rest; the missing way back to T-pose after direct pose edits. Works on duplicates.
- `add_clip { name }`; `set_track_keys` — bulk replace of a track's keys in one undoable step (a dance clip's track went from ~9 calls to 1).
- Inspector: **Shared Geometry** note on Mesh/SkinnedMesh nodes whose geometry asset is referenced by other nodes — warns (for editable meshes) that geometry edits change all sharers, and names them; rig sharing shown as info with the rig's own per-primitive siblings excluded.

## Docs
- `docs/plans/offscreen-editor-screenshots.md` — the one deliberately-unimplemented item (rendering/screenshots while the tab is hidden), with the motivating incident and a recommended on-demand capture design.

## Verification
- `task lint` green (rustfmt + clippy `-D warnings`, all features, tests — 71+ tests).
- Every behavior above additionally live-tested against a dev editor (trunk :9085) + MCP server (:9186) driven via `/debug`, real rmcp sessions, and chrome-devtools screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UnhN8DdPJCpRb6Cbt3t8U1