### PR TITLE
Lazy pipeline compiles + branchless material texture slots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,6 +290,7 @@ dependencies = [
  "awsm-renderer-materials",
  "awsm-renderer-meshgen",
  "awsm-renderer-particles",
+ "awsm-renderer-scene",
  "awsm-renderer-scene-loader",
  "awsm-renderer-web-shared",
  "awsm_web 0.45.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "askama",
@@ -229,7 +229,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-core"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "binpack2d",
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-curves"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "glam 0.32.1",
  "serde",
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-debugging"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -277,7 +277,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-editor"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -325,7 +325,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-editor-protocol"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "awsm-renderer-meshgen",
  "awsm-renderer-scene",
@@ -339,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-geometry"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "glam 0.32.1",
  "serde",
@@ -347,7 +347,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-glb-export"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "awsm-renderer-meshgen",
  "awsm-renderer-tangents",
@@ -362,7 +362,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-gltf"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -390,7 +390,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-gltf-convert"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "awsm-renderer-glb-export",
  "awsm-renderer-meshgen",
@@ -404,7 +404,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-lod-bake"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "glam 0.32.1",
  "serde",
@@ -413,7 +413,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-lod-bake-cli"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "awsm-renderer-glb-export",
@@ -426,7 +426,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-materials"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "awsm-renderer-core",
  "thiserror 2.0.18",
@@ -435,7 +435,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-meshgen"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "awsm-renderer-curves",
  "awsm-renderer-geometry",
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-model-tests"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -483,7 +483,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-multithreaded-example"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "awsm-renderer",
  "awsm-renderer-core",
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-particles"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "awsm-renderer-curves",
  "awsm-renderer-geometry",
@@ -517,7 +517,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-render-worker-example"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -537,7 +537,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-scene"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "bitcode",
  "glam 0.32.1",
@@ -551,7 +551,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-scene-loader"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-scene-mcp"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "awsm-renderer-editor-protocol",
@@ -596,14 +596,14 @@ dependencies = [
 
 [[package]]
 name = "awsm-renderer-tangents"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "bevy_mikktspace",
 ]
 
 [[package]]
 name = "awsm-renderer-web-shared"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "awsm-renderer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ resolver = "2"
 [workspace.package]
 description = "awsm renderer"
 edition = "2021"
-version = "0.18.0"
+version = "0.19.0"
 license = "MIT OR Apache-2.0"
 authors = ["David Komer"]
 # 1.85 floor: rmcp 1.x (the MCP server SDK) is edition-2024, which requires
@@ -118,23 +118,23 @@ opt-level = 1
 # `workspace.package.version` so the published crates carry concrete
 # version requirements on each other (crates.io rejects path-only deps).
 # Bump this block together with the version above on every release.
-awsm-renderer-curves = { path = "packages/crates/curves", version = "0.18.0" }
-awsm-renderer-geometry = { path = "packages/crates/geometry", version = "0.18.0" }
-awsm-renderer-scene = { path = "packages/crates/scene", version = "0.18.0" }
-awsm-renderer-scene-loader = { path = "packages/crates/scene-loader", version = "0.18.0" }
-awsm-renderer-editor-protocol = { path = "packages/mcp/editor-protocol", version = "0.18.0" }
-awsm-renderer-core = { path = "packages/crates/renderer-core", version = "0.18.0" }
-awsm-renderer-meshgen = { path = "packages/crates/meshgen", version = "0.18.0" }
-awsm-renderer-glb-export = { path = "packages/crates/glb-export", version = "0.18.0" }
-awsm-renderer-gltf-convert = { path = "packages/crates/gltf-convert", version = "0.18.0" }
-awsm-renderer-tangents = { path = "packages/crates/tangents", version = "0.18.0" }
-awsm-renderer-lod-bake = { path = "packages/crates/lod-bake", version = "0.18.0" }
-awsm-renderer-particles = { path = "packages/crates/particles", version = "0.18.0" }
-awsm-renderer-materials = { path = "packages/crates/materials", version = "0.18.0" }
-awsm-renderer = { path = "packages/crates/renderer", version = "0.18.0" }
-awsm-renderer-gltf = { path = "packages/crates/renderer-gltf", version = "0.18.0" }
+awsm-renderer-curves = { path = "packages/crates/curves", version = "0.19.0" }
+awsm-renderer-geometry = { path = "packages/crates/geometry", version = "0.19.0" }
+awsm-renderer-scene = { path = "packages/crates/scene", version = "0.19.0" }
+awsm-renderer-scene-loader = { path = "packages/crates/scene-loader", version = "0.19.0" }
+awsm-renderer-editor-protocol = { path = "packages/mcp/editor-protocol", version = "0.19.0" }
+awsm-renderer-core = { path = "packages/crates/renderer-core", version = "0.19.0" }
+awsm-renderer-meshgen = { path = "packages/crates/meshgen", version = "0.19.0" }
+awsm-renderer-glb-export = { path = "packages/crates/glb-export", version = "0.19.0" }
+awsm-renderer-gltf-convert = { path = "packages/crates/gltf-convert", version = "0.19.0" }
+awsm-renderer-tangents = { path = "packages/crates/tangents", version = "0.19.0" }
+awsm-renderer-lod-bake = { path = "packages/crates/lod-bake", version = "0.19.0" }
+awsm-renderer-particles = { path = "packages/crates/particles", version = "0.19.0" }
+awsm-renderer-materials = { path = "packages/crates/materials", version = "0.19.0" }
+awsm-renderer = { path = "packages/crates/renderer", version = "0.19.0" }
+awsm-renderer-gltf = { path = "packages/crates/renderer-gltf", version = "0.19.0" }
 # Frontend-only (not published); workspace dep keeps consumers path-agnostic.
-awsm-renderer-web-shared = { path = "packages/frontend/web-shared", version = "0.18.0" }
+awsm-renderer-web-shared = { path = "packages/frontend/web-shared", version = "0.19.0" }
 
 # Misc
 cfg-if = "1.0.4"

--- a/docs/ASSET_WORKFLOWS.md
+++ b/docs/ASSET_WORKFLOWS.md
@@ -61,19 +61,30 @@ Notes:
 
 ## 2. Textures → built-in PBR material slots
 
+The rule: **the material asset owns the pipeline, the node owns data.** A slot must
+be a CAPABILITY of the library material before nodes can bind images into it;
+capable-slot binds are pure data (no recompile, ever).
+
 1. Author + host the image (PNG/JPEG). Generate normal/roughness/occlusion maps as
    needed (they're `linear` data, not sRGB).
 2. `import_texture_from_url { url }` → returns a texture asset id. (Persists on Save.)
-3. Assign it to a slot on a mesh's **built-in** material:
+3. Make the slot capable on the node's **library material** (skip if the material
+   already binds a default image there — that implies the capability):
+   `update_builtin_material { id, def: { …, texture_capabilities: { normal: true, … } } }`.
+4. Bind per-node:
    `set_node_texture { node, slot: base_color|metallic_roughness|normal|occlusion|emissive, texture: <id> }`
-   (writes the node's per-mesh inline slot). In the editor UI, the mesh inspector's
-   material section now shows a picker for all five core slots (empty or not).
-4. Tune sampling: `set_node_texture_transform { node, slot, offset|scale|rotation|flow|
+   (writes the node's per-mesh inline slot; rejected if the slot isn't a capability).
+   In the editor UI, the mesh inspector shows pickers for the capable slots.
+5. Tune sampling: `set_node_texture_transform { node, slot, offset|scale|rotation|flow|
    wrap_u|wrap_v|mag_filter|min_filter|mipmap_filter|uv_set }` (patch-style; slot must
    already have a texture bound).
-5. Scalars/colors: `set_builtin_param { node, param: base_color|metallic|roughness|
-   emissive|normal_scale|occlusion_strength|…, value:[…] }`;
-   `set_builtin_alpha_mode` for opaque/mask/blend.
+6. Scalars/colors (per node): `set_builtin_param { node, param: base_color|metallic|roughness|
+   emissive|normal_scale|occlusion_strength|…, value:[…] }`.
+   Alpha MODE (opaque/mask/blend) is pipeline routing and lives on the MATERIAL:
+   `set_builtin_alpha_mode { material, mode }` — per glTF, opaque ignores base-color
+   alpha (no silent blend promotion); the mask cutoff VALUE stays per-node tunable.
+   Extension ENABLES likewise live on the material (`update_builtin_material`);
+   per-node inline extensions only carry parameters.
 
 ---
 

--- a/docs/ASSET_WORKFLOWS.md
+++ b/docs/ASSET_WORKFLOWS.md
@@ -61,24 +61,24 @@ Notes:
 
 ## 2. Textures → built-in PBR material slots
 
-The rule: **the material asset owns the pipeline, the node owns data.** A slot must
-be a CAPABILITY of the library material before nodes can bind images into it;
-capable-slot binds are pure data (no recompile, ever).
+The rule: **the material asset owns the pipeline, the node owns data.** Texture
+binds are pure data: every core slot's sampling code is always compiled (an
+unbound slot samples a shared 1×1 neutral — glTF's defined no-texture result),
+so binding an image to any slot on any node never recompiles anything.
 
 1. Author + host the image (PNG/JPEG). Generate normal/roughness/occlusion maps as
    needed (they're `linear` data, not sRGB).
 2. `import_texture_from_url { url }` → returns a texture asset id. (Persists on Save.)
-3. Make the slot capable on the node's **library material** (skip if the material
-   already binds a default image there — that implies the capability):
-   `update_builtin_material { id, def: { …, texture_capabilities: { normal: true, … } } }`.
-4. Bind per-node:
+3. Bind per-node (any of the five slots, freely):
    `set_node_texture { node, slot: base_color|metallic_roughness|normal|occlusion|emissive, texture: <id> }`
-   (writes the node's per-mesh inline slot; rejected if the slot isn't a capability).
-   In the editor UI, the mesh inspector shows pickers for the capable slots.
-5. Tune sampling: `set_node_texture_transform { node, slot, offset|scale|rotation|flow|
+   (writes the node's per-mesh inline slot). Or bind a default image on the
+   library material (`update_builtin_material`) to give every user of the
+   material a starting texture that nodes can override. The mesh inspector
+   shows pickers for all five core slots.
+4. Tune sampling: `set_node_texture_transform { node, slot, offset|scale|rotation|flow|
    wrap_u|wrap_v|mag_filter|min_filter|mipmap_filter|uv_set }` (patch-style; slot must
    already have a texture bound).
-6. Scalars/colors (per node): `set_builtin_param { node, param: base_color|metallic|roughness|
+5. Scalars/colors (per node): `set_builtin_param { node, param: base_color|metallic|roughness|
    emissive|normal_scale|occlusion_strength|…, value:[…] }`.
    Alpha MODE (opaque/mask/blend) is pipeline routing and lives on the MATERIAL:
    `set_builtin_alpha_mode { material, mode }` — per glTF, opaque ignores base-color

--- a/packages/crates/materials/src/flipbook.rs
+++ b/packages/crates/materials/src/flipbook.rs
@@ -12,7 +12,7 @@
 
 use crate::{
     shader::MaterialShader,
-    writer::{write, write_material_texture},
+    writer::{write, write_material_texture_or_skip},
     MaterialAlphaMode, MaterialShaderId, MaterialTexture, TextureContext,
 };
 
@@ -256,7 +256,7 @@ impl MaterialShader for FlipBookMaterial {
         write(data, self.alpha_mode.variant_as_u32().into());
         write(data, self.alpha_cutoff().unwrap_or(0.0f32).into());
 
-        write_material_texture(data, self.atlas_tex.as_ref(), ctx);
+        write_material_texture_or_skip(data, self.atlas_tex.as_ref(), ctx);
 
         write(data, self.tint[0].into());
         write(data, self.tint[1].into());

--- a/packages/crates/materials/src/lib.rs
+++ b/packages/crates/materials/src/lib.rs
@@ -36,7 +36,7 @@ pub use shader::MaterialShader;
 pub use shader_id::MaterialShaderId;
 pub use shader_includes::{FragmentInputs, ShaderIncludes};
 pub use texture::MaterialTexture;
-pub use texture_context::TextureContext;
+pub use texture_context::{NeutralTexture, TextureContext};
 
 #[cfg(test)]
 mod uniform_packing_tests;

--- a/packages/crates/materials/src/pbr.rs
+++ b/packages/crates/materials/src/pbr.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     shader::MaterialShader,
-    writer::{write, write_material_texture},
+    writer::{write, write_material_texture, write_material_texture_or_skip},
     MaterialAlphaMode, MaterialShaderId, MaterialTexture, TextureContext,
 };
 
@@ -35,17 +35,6 @@ pub struct PbrMaterial {
     pub emissive_tex: Option<MaterialTexture>,
     pub emissive_factor: [f32; 3],
 
-    /// Texture-slot CAPABILITIES: which of the five core slots the compiled
-    /// shader can sample even when this material carries no bound image. A
-    /// capable slot compiles its sampling path in, guarded by the per-slot
-    /// runtime `exists` flag (already packed unconditionally by
-    /// `write_material_texture`), so instances sharing the bucket can bind or
-    /// omit images as pure data. The EFFECTIVE feature bit is
-    /// `capability || bound` — see [`PbrFeatures::from_material`] — so
-    /// constructors that never touch this field keep today's usage-derived
-    /// buckets exactly.
-    pub texture_capabilities: PbrTextureCapabilities,
-
     /// Debug settings.
     pub debug: PbrMaterialDebug,
 
@@ -69,31 +58,19 @@ pub struct PbrMaterial {
     double_sided: bool,
 }
 
-/// Which of the five core texture slots a [`PbrMaterial`]'s shader can
-/// sample — the compile-time half of the capability/usage split. Usage (a
-/// bound image) is per-instance data behind the runtime `exists` flag;
-/// capability is bucket identity. All-false by default: a slot then only
-/// compiles in when the material itself binds an image (the legacy
-/// usage-derived behavior).
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
-pub struct PbrTextureCapabilities {
-    pub base_color: bool,
-    pub metallic_roughness: bool,
-    pub normal: bool,
-    pub occlusion: bool,
-    pub emissive: bool,
-}
-
 /// Compile-time feature set of a PBR material: which optional code paths
 /// its specialized shader actually needs. The five core texture-slot bits
-/// are CAPABILITY-derived (`declared || bound` — see
-/// [`PbrMaterial::texture_capabilities`]); the extension bits are STRICT
-/// (derived from the `Option` fields: an enabled extension's code runs
+/// are RETIRED (permanently false): slot sampling is always compiled and an
+/// unbound slot packs the shared 1×1 NEUTRAL, so texture binds are pure
+/// data and never key a pipeline. The extension bits are STRICT (derived
+/// from the `Option` fields: an enabled extension's code runs
 /// unconditionally for every instance). This is the input to:
 ///
-/// 1. **Compile-time gating** — the Askama `{% if features.<x> %}` checks
-///    in the PBR shader (opaque compute + transparent fragment), so a
-///    material with (say) no normal map compiles no normal-map code.
+/// 1. **Compile-time gating** — the Askama `{% if pbr_features.<x> %}`
+///    checks in the PBR shader (opaque compute + transparent fragment) for
+///    the EXTENSION features, so a material without (say) clearcoat compiles
+///    no clearcoat code. (Texture-slot sampling is NOT gated — it is always
+///    present and unbound slots sample the 1×1 neutral.)
 /// 2. **Bucket identity** — [`Self::bits`] is the stable feature-hash that
 ///    maps a feature-set to its own `shader_id` / bucket, so two materials
 ///    with the same feature-set share one specialized pipeline.
@@ -151,20 +128,18 @@ impl PbrFeatures {
     /// The number of distinct feature bits (≤ 32 so [`Self::bits`] fits a u32).
     pub const COUNT: u32 = 17;
 
-    /// Derives the feature set from a material. Texture-slot bits are
-    /// capability-derived (`declared || bound`): a capable-but-unbound slot
-    /// still compiles its (runtime-`exists`-guarded) sampling path so
-    /// instances can bind images later without a new pipeline. Extension
-    /// bits remain presence-derived (strict).
+    /// Derives the feature set from a material. The five texture-slot bits
+    /// are RETIRED — always `false` (bit positions kept for the stable
+    /// append-only layout): slot sampling code is unconditionally present
+    /// and unbound slots sample the 1×1 NEUTRAL, so texture presence never
+    /// splits buckets. Extension bits remain presence-derived (strict).
     pub fn from_material(m: &PbrMaterial) -> Self {
-        let caps = &m.texture_capabilities;
         Self {
-            base_color_tex: caps.base_color || m.base_color_tex.is_some(),
-            metallic_roughness_tex: caps.metallic_roughness
-                || m.metallic_roughness_tex.is_some(),
-            normal_tex: caps.normal || m.normal_tex.is_some(),
-            occlusion_tex: caps.occlusion || m.occlusion_tex.is_some(),
-            emissive_tex: caps.emissive || m.emissive_tex.is_some(),
+            base_color_tex: false,
+            metallic_roughness_tex: false,
+            normal_tex: false,
+            occlusion_tex: false,
+            emissive_tex: false,
             vertex_color: m.vertex_color_info.is_some(),
             emissive_strength: m.emissive_strength.is_some(),
             ior: m.ior.is_some(),
@@ -416,7 +391,6 @@ impl PbrMaterial {
     /// Creates a PBR material with default parameters.
     pub fn new(alpha_mode: MaterialAlphaMode, double_sided: bool) -> Self {
         Self {
-            texture_capabilities: PbrTextureCapabilities::default(),
             base_color_tex: None,
             base_color_factor: [1.0, 1.0, 1.0, 1.0],
             metallic_roughness_tex: None,
@@ -549,23 +523,48 @@ impl MaterialShader for PbrMaterial {
         write(data, self.alpha_mode.variant_as_u32().into());
         write(data, self.alpha_cutoff().unwrap_or(0.0f32).into());
 
-        write_material_texture(data, self.base_color_tex.as_ref(), ctx);
+        write_material_texture(
+            data,
+            self.base_color_tex.as_ref(),
+            ctx,
+            crate::NeutralTexture::White,
+        );
         write(data, self.base_color_factor[0].into());
         write(data, self.base_color_factor[1].into());
         write(data, self.base_color_factor[2].into());
         write(data, self.base_color_factor[3].into());
 
-        write_material_texture(data, self.metallic_roughness_tex.as_ref(), ctx);
+        write_material_texture(
+            data,
+            self.metallic_roughness_tex.as_ref(),
+            ctx,
+            crate::NeutralTexture::White,
+        );
         write(data, self.metallic_factor.into());
         write(data, self.roughness_factor.into());
 
-        write_material_texture(data, self.normal_tex.as_ref(), ctx);
+        write_material_texture(
+            data,
+            self.normal_tex.as_ref(),
+            ctx,
+            crate::NeutralTexture::FlatNormal,
+        );
         write(data, self.normal_scale.into());
 
-        write_material_texture(data, self.occlusion_tex.as_ref(), ctx);
+        write_material_texture(
+            data,
+            self.occlusion_tex.as_ref(),
+            ctx,
+            crate::NeutralTexture::White,
+        );
         write(data, self.occlusion_strength.into());
 
-        write_material_texture(data, self.emissive_tex.as_ref(), ctx);
+        write_material_texture(
+            data,
+            self.emissive_tex.as_ref(),
+            ctx,
+            crate::NeutralTexture::White,
+        );
         write(data, self.emissive_factor[0].into());
         write(data, self.emissive_factor[1].into());
         write(data, self.emissive_factor[2].into());
@@ -645,10 +644,10 @@ impl MaterialShader for PbrMaterial {
         {
             feature_indices.specular = current_index(data);
 
-            write_material_texture(data, tex.as_ref(), ctx);
+            write_material_texture_or_skip(data, tex.as_ref(), ctx);
             write(data, factor.into());
 
-            write_material_texture(data, color_tex.as_ref(), ctx);
+            write_material_texture_or_skip(data, color_tex.as_ref(), ctx);
             write(data, color_factor[0].into());
             write(data, color_factor[1].into());
             write(data, color_factor[2].into());
@@ -657,7 +656,7 @@ impl MaterialShader for PbrMaterial {
         if let Some(PbrMaterialTransmission { tex, factor }) = &self.transmission {
             feature_indices.transmission = current_index(data);
 
-            write_material_texture(data, tex.as_ref(), ctx);
+            write_material_texture_or_skip(data, tex.as_ref(), ctx);
             write(data, factor.into());
         }
 
@@ -670,10 +669,10 @@ impl MaterialShader for PbrMaterial {
         {
             feature_indices.diffuse_transmission = current_index(data);
 
-            write_material_texture(data, tex.as_ref(), ctx);
+            write_material_texture_or_skip(data, tex.as_ref(), ctx);
             write(data, factor.into());
 
-            write_material_texture(data, color_tex.as_ref(), ctx);
+            write_material_texture_or_skip(data, color_tex.as_ref(), ctx);
             write(data, color_factor[0].into());
             write(data, color_factor[1].into());
             write(data, color_factor[2].into());
@@ -688,7 +687,7 @@ impl MaterialShader for PbrMaterial {
         {
             feature_indices.volume = current_index(data);
 
-            write_material_texture(data, thickness_tex.as_ref(), ctx);
+            write_material_texture_or_skip(data, thickness_tex.as_ref(), ctx);
             write(data, thickness_factor.into());
             write(data, attenuation_distance.into());
             write(data, attenuation_color[0].into());
@@ -707,13 +706,13 @@ impl MaterialShader for PbrMaterial {
         {
             feature_indices.clearcoat = current_index(data);
 
-            write_material_texture(data, tex.as_ref(), ctx);
+            write_material_texture_or_skip(data, tex.as_ref(), ctx);
             write(data, factor.into());
 
-            write_material_texture(data, roughness_tex.as_ref(), ctx);
+            write_material_texture_or_skip(data, roughness_tex.as_ref(), ctx);
             write(data, roughness_factor.into());
 
-            write_material_texture(data, normal_tex.as_ref(), ctx);
+            write_material_texture_or_skip(data, normal_tex.as_ref(), ctx);
             write(data, normal_scale.into());
         }
 
@@ -726,10 +725,10 @@ impl MaterialShader for PbrMaterial {
         {
             feature_indices.sheen = current_index(data);
 
-            write_material_texture(data, roughness_tex.as_ref(), ctx);
+            write_material_texture_or_skip(data, roughness_tex.as_ref(), ctx);
             write(data, roughness_factor.into());
 
-            write_material_texture(data, color_tex.as_ref(), ctx);
+            write_material_texture_or_skip(data, color_tex.as_ref(), ctx);
             write(data, color_factor[0].into());
             write(data, color_factor[1].into());
             write(data, color_factor[2].into());
@@ -748,7 +747,7 @@ impl MaterialShader for PbrMaterial {
         {
             feature_indices.anisotropy = current_index(data);
 
-            write_material_texture(data, tex.as_ref(), ctx);
+            write_material_texture_or_skip(data, tex.as_ref(), ctx);
             write(data, strength.into());
             write(data, rotation.into());
         }
@@ -764,11 +763,11 @@ impl MaterialShader for PbrMaterial {
         {
             feature_indices.iridescence = current_index(data);
 
-            write_material_texture(data, tex.as_ref(), ctx);
+            write_material_texture_or_skip(data, tex.as_ref(), ctx);
             write(data, factor.into());
             write(data, ior.into());
 
-            write_material_texture(data, thickness_tex.as_ref(), ctx);
+            write_material_texture_or_skip(data, thickness_tex.as_ref(), ctx);
             write(data, thickness_min.into());
             write(data, thickness_max.into());
         }

--- a/packages/crates/materials/src/pbr.rs
+++ b/packages/crates/materials/src/pbr.rs
@@ -35,6 +35,17 @@ pub struct PbrMaterial {
     pub emissive_tex: Option<MaterialTexture>,
     pub emissive_factor: [f32; 3],
 
+    /// Texture-slot CAPABILITIES: which of the five core slots the compiled
+    /// shader can sample even when this material carries no bound image. A
+    /// capable slot compiles its sampling path in, guarded by the per-slot
+    /// runtime `exists` flag (already packed unconditionally by
+    /// `write_material_texture`), so instances sharing the bucket can bind or
+    /// omit images as pure data. The EFFECTIVE feature bit is
+    /// `capability || bound` — see [`PbrFeatures::from_material`] — so
+    /// constructors that never touch this field keep today's usage-derived
+    /// buckets exactly.
+    pub texture_capabilities: PbrTextureCapabilities,
+
     /// Debug settings.
     pub debug: PbrMaterialDebug,
 
@@ -58,10 +69,27 @@ pub struct PbrMaterial {
     double_sided: bool,
 }
 
+/// Which of the five core texture slots a [`PbrMaterial`]'s shader can
+/// sample — the compile-time half of the capability/usage split. Usage (a
+/// bound image) is per-instance data behind the runtime `exists` flag;
+/// capability is bucket identity. All-false by default: a slot then only
+/// compiles in when the material itself binds an image (the legacy
+/// usage-derived behavior).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct PbrTextureCapabilities {
+    pub base_color: bool,
+    pub metallic_roughness: bool,
+    pub normal: bool,
+    pub occlusion: bool,
+    pub emissive: bool,
+}
+
 /// Compile-time feature set of a PBR material: which optional code paths
-/// its specialized shader actually needs. Derived from a [`PbrMaterial`]'s
-/// present texture slots + extensions (the `Option` fields). This is the
-/// input to:
+/// its specialized shader actually needs. The five core texture-slot bits
+/// are CAPABILITY-derived (`declared || bound` — see
+/// [`PbrMaterial::texture_capabilities`]); the extension bits are STRICT
+/// (derived from the `Option` fields: an enabled extension's code runs
+/// unconditionally for every instance). This is the input to:
 ///
 /// 1. **Compile-time gating** — the Askama `{% if features.<x> %}` checks
 ///    in the PBR shader (opaque compute + transparent fragment), so a
@@ -123,14 +151,20 @@ impl PbrFeatures {
     /// The number of distinct feature bits (≤ 32 so [`Self::bits`] fits a u32).
     pub const COUNT: u32 = 17;
 
-    /// Derives the feature set actually used by a material.
+    /// Derives the feature set from a material. Texture-slot bits are
+    /// capability-derived (`declared || bound`): a capable-but-unbound slot
+    /// still compiles its (runtime-`exists`-guarded) sampling path so
+    /// instances can bind images later without a new pipeline. Extension
+    /// bits remain presence-derived (strict).
     pub fn from_material(m: &PbrMaterial) -> Self {
+        let caps = &m.texture_capabilities;
         Self {
-            base_color_tex: m.base_color_tex.is_some(),
-            metallic_roughness_tex: m.metallic_roughness_tex.is_some(),
-            normal_tex: m.normal_tex.is_some(),
-            occlusion_tex: m.occlusion_tex.is_some(),
-            emissive_tex: m.emissive_tex.is_some(),
+            base_color_tex: caps.base_color || m.base_color_tex.is_some(),
+            metallic_roughness_tex: caps.metallic_roughness
+                || m.metallic_roughness_tex.is_some(),
+            normal_tex: caps.normal || m.normal_tex.is_some(),
+            occlusion_tex: caps.occlusion || m.occlusion_tex.is_some(),
+            emissive_tex: caps.emissive || m.emissive_tex.is_some(),
             vertex_color: m.vertex_color_info.is_some(),
             emissive_strength: m.emissive_strength.is_some(),
             ior: m.ior.is_some(),
@@ -382,6 +416,7 @@ impl PbrMaterial {
     /// Creates a PBR material with default parameters.
     pub fn new(alpha_mode: MaterialAlphaMode, double_sided: bool) -> Self {
         Self {
+            texture_capabilities: PbrTextureCapabilities::default(),
             base_color_tex: None,
             base_color_factor: [1.0, 1.0, 1.0, 1.0],
             metallic_roughness_tex: None,

--- a/packages/crates/materials/src/texture_context.rs
+++ b/packages/crates/materials/src/texture_context.rs
@@ -21,7 +21,12 @@ use awsm_renderer_core::{
 pub enum NeutralTexture {
     /// 1×1 white — base color / metallic-roughness / occlusion / emissive.
     White,
-    /// 1×1 flat normal `(0.5, 0.5, 1.0)` in a float format (exact 0.5).
+    /// 1×1 flat normal, packed rgba8 `[128, 128, 255]` — the same encoding
+    /// (and the same ~0.2° quantization off exact `(0.5, 0.5, 1.0)`) that every
+    /// authored normal map carries in its flat regions. Unpacks to tangent
+    /// `≈(0, 0, 1)`, so `TBN · tangent ≈` the geometry normal. Note the residual
+    /// `128/255 ≈ 0.502` on x/y is scaled by `normal_scale`, so a large
+    /// `normal_scale` with no bound normal map tilts the normal very slightly.
     FlatNormal,
 }
 

--- a/packages/crates/materials/src/texture_context.rs
+++ b/packages/crates/materials/src/texture_context.rs
@@ -12,12 +12,39 @@ use awsm_renderer_core::{
     texture::texture_pool::{TexturePoolArray, TexturePoolEntryInfo},
 };
 
+/// Which shared 1×1 NEUTRAL a built-in material slot packs when no image is
+/// bound. The five core PBR slots always compile their sampling path, so an
+/// unbound slot must still resolve to a real pool entry; sampling the neutral
+/// reproduces glTF's defined no-texture result exactly (white = identity
+/// multiply; flat normal = the geometry normal through the TBN math).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum NeutralTexture {
+    /// 1×1 white — base color / metallic-roughness / occlusion / emissive.
+    White,
+    /// 1×1 flat normal `(0.5, 0.5, 1.0)` in a float format (exact 0.5).
+    FlatNormal,
+}
+
 /// Renderer-side context that lets a material's `write_uniform_buffer` resolve
 /// pooled texture / sampler / texture-transform keys to the on-GPU layout the
 /// shader will read.
 ///
 /// `awsm-renderer::Textures` implements this trait.
 pub trait TextureContext {
+    /// Resolves a NEUTRAL's pool placement: `(array, entry)` for the shared
+    /// 1×1 white / flat-normal entries the renderer registers at boot, plus
+    /// the default sampler's shader-visible index. `None` only in contexts
+    /// with no pool at all (tests); packers then fall back to the zero
+    /// sentinel, which is fine anywhere no shader actually samples.
+    fn neutral_texture(
+        &self,
+        kind: NeutralTexture,
+    ) -> Option<(
+        &TexturePoolArray<TextureKey>,
+        &TexturePoolEntryInfo<TextureKey>,
+        u32,
+    )>;
+
     /// Returns the array slot for a pooled texture, if it exists.
     fn pool_array_by_index(&self, index: usize) -> Option<&TexturePoolArray<TextureKey>>;
 

--- a/packages/crates/materials/src/toon.rs
+++ b/packages/crates/materials/src/toon.rs
@@ -135,13 +135,23 @@ impl MaterialShader for ToonMaterial {
         write(data, self.alpha_mode.variant_as_u32().into());
         write(data, self.alpha_cutoff().unwrap_or(0.0f32).into());
 
-        write_material_texture(data, self.base_color_tex.as_ref(), ctx);
+        write_material_texture(
+            data,
+            self.base_color_tex.as_ref(),
+            ctx,
+            crate::NeutralTexture::White,
+        );
         write(data, self.base_color_factor[0].into());
         write(data, self.base_color_factor[1].into());
         write(data, self.base_color_factor[2].into());
         write(data, self.base_color_factor[3].into());
 
-        write_material_texture(data, self.emissive_tex.as_ref(), ctx);
+        write_material_texture(
+            data,
+            self.emissive_tex.as_ref(),
+            ctx,
+            crate::NeutralTexture::White,
+        );
         write(data, self.emissive_factor[0].into());
         write(data, self.emissive_factor[1].into());
         write(data, self.emissive_factor[2].into());

--- a/packages/crates/materials/src/uniform_packing_tests.rs
+++ b/packages/crates/materials/src/uniform_packing_tests.rs
@@ -20,6 +20,16 @@ use crate::{MaterialAlphaMode, MaterialShader, MaterialShaderId, TextureContext}
 struct NullTextureContext;
 
 impl TextureContext for NullTextureContext {
+    fn neutral_texture(
+        &self,
+        _kind: crate::NeutralTexture,
+    ) -> Option<(
+        &TexturePoolArray<TextureKey>,
+        &TexturePoolEntryInfo<TextureKey>,
+        u32,
+    )> {
+        None
+    }
     fn pool_array_by_index(&self, _index: usize) -> Option<&TexturePoolArray<TextureKey>> {
         None
     }

--- a/packages/crates/materials/src/unlit.rs
+++ b/packages/crates/materials/src/unlit.rs
@@ -105,13 +105,23 @@ impl MaterialShader for UnlitMaterial {
         write(data, self.alpha_mode.variant_as_u32().into());
         write(data, self.alpha_cutoff().unwrap_or(0.0f32).into());
 
-        write_material_texture(data, self.base_color_tex.as_ref(), ctx);
+        write_material_texture(
+            data,
+            self.base_color_tex.as_ref(),
+            ctx,
+            crate::NeutralTexture::White,
+        );
         write(data, self.base_color_factor[0].into());
         write(data, self.base_color_factor[1].into());
         write(data, self.base_color_factor[2].into());
         write(data, self.base_color_factor[3].into());
 
-        write_material_texture(data, self.emissive_tex.as_ref(), ctx);
+        write_material_texture(
+            data,
+            self.emissive_tex.as_ref(),
+            ctx,
+            crate::NeutralTexture::White,
+        );
         write(data, self.emissive_factor[0].into());
         write(data, self.emissive_factor[1].into());
         write(data, self.emissive_factor[2].into());

--- a/packages/crates/materials/src/writer.rs
+++ b/packages/crates/materials/src/writer.rs
@@ -100,10 +100,49 @@ pub fn write(data: &mut Vec<u8>, value: Value) {
     }
 }
 
-/// Convenience: write the `MaterialTexture` if present, else `SkipTexture`.
+/// Write a BUILT-IN core slot: the `MaterialTexture` if present + resolvable,
+/// else the slot's shared 1×1 NEUTRAL. The five core slots always compile
+/// their sampling path (no feature gate, no exists branch), so an unbound
+/// slot must still point at a real pool entry — the neutral makes the sample
+/// an identity operation (glTF's defined no-texture result).
 ///
-/// Returns `()` so callers can fold it into a sequence of `write(...)` calls.
+/// Falls back to the zero sentinel only when the context has no neutral
+/// (test contexts without a pool) — nothing samples there.
+///
+/// CUSTOM dynamic-material slots do NOT use this — their layouts detect
+/// unbound declared slots via the zero sentinel (`write_material_texture_or_skip`).
 pub fn write_material_texture(
+    data: &mut Vec<u8>,
+    tex: Option<&MaterialTexture>,
+    ctx: &dyn TextureContext,
+    neutral: crate::NeutralTexture,
+) {
+    match tex.and_then(|t| map_texture(t, ctx)) {
+        Some(v) => write(data, v),
+        None => match ctx.neutral_texture(neutral) {
+            Some((array, entry_info, sampler_index)) => {
+                let packed = pack_texture_info_raw(
+                    array,
+                    entry_info,
+                    0, // uv set 0 — a 1×1 sample is UV-independent
+                    sampler_index,
+                    encode_address_mode(None),
+                    encode_address_mode(None),
+                    ctx.texture_transform_identity_offset(),
+                );
+                for word in packed {
+                    data.extend_from_slice(&word.to_le_bytes());
+                }
+            }
+            None => write(data, Value::SkipTexture),
+        },
+    }
+}
+
+/// Write the `MaterialTexture` if present, else the zero sentinel — the
+/// CUSTOM dynamic-material slot path, whose layouts key "unbound" off the
+/// zero first word (see `dynamic_layout.rs`).
+pub fn write_material_texture_or_skip(
     data: &mut Vec<u8>,
     tex: Option<&MaterialTexture>,
     ctx: &dyn TextureContext,

--- a/packages/crates/renderer-core/src/brdf_lut/generate.rs
+++ b/packages/crates/renderer-core/src/brdf_lut/generate.rs
@@ -56,6 +56,33 @@ impl Default for BrdfLutOptions {
 }
 
 impl BrdfLut {
+    /// A 1×1 zero-initialized placeholder — no shader, no pipeline, no draw.
+    /// For deferred-boot renderers: a structurally-valid LUT that satisfies
+    /// every bind-group layout, swapped for the real bake
+    /// ([`Self::new`]) before the first content frame samples it.
+    pub async fn placeholder(gpu: &AwsmRendererWebGpu) -> Result<Self> {
+        let texture = gpu.create_texture(
+            &TextureDescriptor::new(
+                TextureFormat::Rgba16float,
+                Extent3d::new(1, Some(1), None),
+                TextureUsage::new()
+                    .with_copy_dst()
+                    .with_render_attachment()
+                    .with_texture_binding(),
+            )
+            .into(),
+        )?;
+        let view = texture
+            .create_view()
+            .map_err(|e| AwsmCoreError::TextureView(format!("{e:?}")))?;
+        let sampler = get_sampler(gpu).await?;
+        Ok(Self {
+            texture,
+            view,
+            sampler,
+        })
+    }
+
     /// Generates a BRDF LUT texture.
     pub async fn new(gpu: &AwsmRendererWebGpu, options: BrdfLutOptions) -> Result<Self> {
         let render_pipeline = get_pipeline(gpu).await?;

--- a/packages/crates/renderer/src/anti_alias.rs
+++ b/packages/crates/renderer/src/anti_alias.rs
@@ -342,11 +342,10 @@ impl AwsmRenderer {
         //    piece within the branch — resolves as a hit.
         let prep_edge_resolve = new_msaa_on && crate::edge_resolve_supported(&self.gpu);
         let prep_denoise = self.prep_config.denoise;
-        let prep_branch_missing = self
-            .render_passes
-            .material_prep
-            .as_ref()
-            .is_some_and(|p| !p.pipelines.has_branch_for(new_msaa_on, prep_edge_resolve, prep_denoise));
+        let prep_branch_missing = self.render_passes.material_prep.as_ref().is_some_and(|p| {
+            !p.pipelines
+                .has_branch_for(new_msaa_on, prep_edge_resolve, prep_denoise)
+        });
         if prep_branch_missing {
             use crate::render_passes::material_prep::render_pass::MaterialPrepPipelines;
             // Phase 4c.i: shader batch for the branch (megashader module +

--- a/packages/crates/renderer/src/anti_alias.rs
+++ b/packages/crates/renderer/src/anti_alias.rs
@@ -72,6 +72,11 @@ impl AwsmRenderer {
         if self.anti_aliasing == aa {
             return Ok(());
         }
+        // Deferred-boot: drain any still-reserved boot-pool slots first, so
+        // the branch guards below (`has_branch_for`) reflect COMPILED reality
+        // — a reserved-but-pending branch must not be mistaken for a ready
+        // one. No-op after the first commit_load / ensure_config_pipelines.
+        self.compile_pending_pipelines().await?;
         let prev_msaa_on = self.anti_aliasing.has_msaa_checked()?;
         self.anti_aliasing = aa;
         let new_msaa_on = self.anti_aliasing.has_msaa_checked()?;

--- a/packages/crates/renderer/src/anti_alias.rs
+++ b/packages/crates/renderer/src/anti_alias.rs
@@ -135,6 +135,29 @@ impl AwsmRenderer {
             self.material_edge_layout_uniform = None;
         }
 
+        // The prep pass's compact edge-shadow texture (~8 MB) follows the
+        // same MSAA lifecycle: allocated on the off→on flip (the opaque MSAA
+        // main bind group binds its view at binding 27 — unconditionally
+        // under MSAA, independent of `edge_resolve_supported`), dropped on
+        // on→off. The `TextureViewRecreate` mark below re-clones the view
+        // into the dependent bind groups next frame.
+        if let Some(prep) = self.render_passes.material_prep.as_mut() {
+            if new_msaa_on {
+                let max_edge_budget = self
+                    .material_edge_buffers
+                    .as_ref()
+                    .map(|b| b.max_edge_budget)
+                    .unwrap_or(crate::render_passes::material_opaque::edge_buffers::DEFAULT_MAX_EDGE_BUDGET_DESKTOP);
+                prep.ensure_edge_shadow(
+                    &self.gpu,
+                    max_edge_budget,
+                    self.prep_config.shadow_visibility_layers(),
+                )?;
+            } else {
+                prep.drop_edge_shadow();
+            }
+        }
+
         self.bind_groups
             .mark_create(BindGroupCreate::AntiAliasingChange);
         self.bind_groups
@@ -304,6 +327,79 @@ impl AwsmRenderer {
                 .geometry
                 .pipelines
                 .merge_resolved(&geometry_descs, geometry_pipeline_keys)?;
+        }
+
+        // ── Phase 4c: material-prep MSAA branch recompile (lazy-pool,
+        //    mirrors Phase 4b). Boot compiled only the then-active branch;
+        //    fill the incoming branch's cs_prep (+ cs_prep_edge under MSAA on
+        //    a supporting device, + the blur pair while denoise is on) if any
+        //    of it is missing. Cache-keyed, so a flip-back — or a redundant
+        //    piece within the branch — resolves as a hit.
+        let prep_edge_resolve = new_msaa_on && crate::edge_resolve_supported(&self.gpu);
+        let prep_denoise = self.prep_config.denoise;
+        let prep_branch_missing = self
+            .render_passes
+            .material_prep
+            .as_ref()
+            .is_some_and(|p| !p.pipelines.has_branch_for(new_msaa_on, prep_edge_resolve, prep_denoise));
+        if prep_branch_missing {
+            use crate::render_passes::material_prep::render_pass::MaterialPrepPipelines;
+            // Phase 4c.i: shader batch for the branch (megashader module +
+            // blur module). Warm already when only e.g. the blur pair is
+            // missing — ensure_keys is cache-keyed.
+            self.shaders
+                .ensure_keys(
+                    &self.gpu,
+                    MaterialPrepPipelines::shader_cache_keys(new_msaa_on, &self.prep_config),
+                )
+                .await?;
+
+            // Phase 4c.ii: build the branch's pipeline cache keys. Same
+            // RenderPassInitContext shape as Phase 4b; `render_passes` is not
+            // part of the ctx, so borrowing the prep bind groups alongside is
+            // disjoint.
+            let mut ctx = crate::render_passes::RenderPassInitContext {
+                gpu: &self.gpu,
+                bind_group_layouts: &mut self.bind_group_layouts,
+                pipeline_layouts: &mut self.pipeline_layouts,
+                pipelines: &mut self.pipelines,
+                shaders: &mut self.shaders,
+                render_texture_formats: &mut self.render_textures.formats,
+                textures: &mut self.textures,
+                features: &self.features,
+                anti_aliasing: &self.anti_aliasing,
+                post_processing: &self.post_processing,
+                prep_config: &self.prep_config,
+                max_edge_budget: self.material_edge_buffers.as_ref().map(|b| b.max_edge_budget).unwrap_or(crate::render_passes::material_opaque::edge_buffers::DEFAULT_MAX_EDGE_BUDGET_DESKTOP),
+            };
+            let prep = self
+                .render_passes
+                .material_prep
+                .as_ref()
+                .expect("checked is_some_and above");
+            let prep_descs = MaterialPrepPipelines::build_descriptors_for_config(
+                &mut ctx,
+                &prep.bind_groups,
+                new_msaa_on,
+                prep_edge_resolve,
+            )
+            .await?;
+
+            // Phase 4c.iii: batched compute compile + merge (preserves the
+            // other branch's already-resolved keys).
+            let prep_keys = self
+                .pipelines
+                .compute
+                .ensure_keys(
+                    &self.gpu,
+                    &self.shaders,
+                    &self.pipeline_layouts,
+                    prep_descs.pipeline_cache_keys.clone(),
+                )
+                .await?;
+            if let Some(prep) = self.render_passes.material_prep.as_mut() {
+                prep.pipelines.merge_resolved(&prep_descs.slots, prep_keys);
+            }
         }
 
         // ── Phase 5: transparent pipelines depend on per-mesh

--- a/packages/crates/renderer/src/bind_groups.rs
+++ b/packages/crates/renderer/src/bind_groups.rs
@@ -712,4 +712,7 @@ impl BindGroups {
 pub enum AwsmBindGroupError {
     #[error("[bind group] bind group not found for {0}")]
     NotFound(String),
+
+    #[error("[bind group] texture pool placeholder {0} missing (neutrals not uploaded yet)")]
+    TexturePoolPlaceholderMissing(&'static str),
 }

--- a/packages/crates/renderer/src/bind_groups.rs
+++ b/packages/crates/renderer/src/bind_groups.rs
@@ -656,12 +656,18 @@ impl BindGroups {
                         .recreate_main(&ctx)?;
                 }
                 FunctionToCall::MaterialDecalComposite => {
-                    render_passes
+                    // Deferred-boot: composite may not be compiled yet — its
+                    // eventual `new()` builds bind groups against the
+                    // then-current views, so skipping here loses nothing.
+                    if let Some(composite) = render_passes
                         .material_decal
                         .as_mut()
                         .expect("Decal pass missing despite decals feature on")
                         .composite
-                        .recreate(&ctx)?;
+                        .as_mut()
+                    {
+                        composite.recreate(&ctx)?;
+                    }
                 }
                 FunctionToCall::MaterialDecalClassify => {
                     render_passes

--- a/packages/crates/renderer/src/environment.rs
+++ b/packages/crates/renderer/src/environment.rs
@@ -16,6 +16,7 @@ impl AwsmRenderer {
     /// Sets the active skybox.
     pub fn set_skybox(&mut self, skybox: Skybox) {
         self.environment.skybox = skybox;
+        self.mark_skybox_real();
         self.bind_groups
             .mark_create(BindGroupCreate::EnvironmentSkyboxCreate);
     }
@@ -132,7 +133,17 @@ impl Skybox {
         gpu: &AwsmRendererWebGpu,
         default_colors: CubemapBitmapColors,
     ) -> Result<SkyboxResources> {
-        let (texture, view, mip_count) = CubemapImage::new_colors(default_colors, 256, 256)
+        Self::prepare_resources_sized(gpu, default_colors, 256).await
+    }
+
+    /// [`Self::prepare_resources`] at an explicit face size. `size = 1`
+    /// produces the deferred-boot placeholder (see `IblTexture`).
+    pub async fn prepare_resources_sized(
+        gpu: &AwsmRendererWebGpu,
+        default_colors: CubemapBitmapColors,
+        size: u32,
+    ) -> Result<SkyboxResources> {
+        let (texture, view, mip_count) = CubemapImage::new_colors(default_colors, size, size)
             .await?
             .create_texture_and_view(gpu, Some("Skybox Cubemap"))
             .await?;

--- a/packages/crates/renderer/src/lights.rs
+++ b/packages/crates/renderer/src/lights.rs
@@ -38,12 +38,14 @@ impl AwsmRenderer {
     /// Sets the BRDF LUT texture used for IBL.
     pub fn set_brdf_lut(&mut self, brdf_lut: BrdfLut) {
         self.lights.brdf_lut = brdf_lut;
+        self.mark_brdf_lut_real();
         self.bind_groups
             .mark_create(BindGroupCreate::BrdfLutTextures);
     }
     /// Sets image-based lighting textures.
     pub fn set_ibl(&mut self, ibl: Ibl) {
         self.lights.ibl = ibl;
+        self.mark_ibl_real();
         self.bind_groups.mark_create(BindGroupCreate::IblTextures);
         self.lights.lighting_info_gpu_dirty = true;
     }

--- a/packages/crates/renderer/src/lights/ibl.rs
+++ b/packages/crates/renderer/src/lights/ibl.rs
@@ -88,7 +88,18 @@ impl IblTexture {
         gpu: &AwsmRendererWebGpu,
         default_colors: CubemapBitmapColors,
     ) -> Result<IblTextureResources> {
-        let (texture, view, mip_count) = CubemapImage::new_colors(default_colors, 256, 256)
+        Self::prepare_resources_sized(gpu, default_colors, 256).await
+    }
+
+    /// [`Self::prepare_resources`] at an explicit face size. `size = 1`
+    /// produces the deferred-boot placeholder (structurally valid, swapped
+    /// for the real default before any content frame samples it).
+    pub async fn prepare_resources_sized(
+        gpu: &AwsmRendererWebGpu,
+        default_colors: CubemapBitmapColors,
+        size: u32,
+    ) -> Result<IblTextureResources> {
+        let (texture, view, mip_count) = CubemapImage::new_colors(default_colors, size, size)
             .await?
             .create_texture_and_view(gpu, Some("IBL Cubemap"))
             .await?;

--- a/packages/crates/renderer/src/pipeline_scheduler/launch.rs
+++ b/packages/crates/renderer/src/pipeline_scheduler/launch.rs
@@ -406,7 +406,7 @@ impl crate::AwsmRenderer {
         )?;
         let opaque_bg = &self.render_passes.material_opaque.bind_groups;
         let texture_pool_arrays_len = opaque_bg.texture_pool_arrays_len;
-        let texture_pool_samplers_len = opaque_bg.texture_pool_sampler_keys.len() as u32;
+        let texture_pool_samplers_len = opaque_bg.texture_pool_samplers_len;
         let opaque_layout_msaa = self.pipeline_layouts.get_key(
             &self.gpu,
             &self.bind_group_layouts,

--- a/packages/crates/renderer/src/pipelines/compute_pipeline.rs
+++ b/packages/crates/renderer/src/pipelines/compute_pipeline.rs
@@ -27,7 +27,11 @@ use crate::{
 
 /// Cache of compute pipelines by key.
 pub struct ComputePipelines {
-    lookup: SlotMap<ComputePipelineKey, web_sys::GpuComputePipeline>,
+    // `None` = a RESERVED slot: the key was handed out (build()'s deferred
+    // boot pool) but the pipeline hasn't compiled yet. `compile_pending`
+    // drains every reserved slot in one batch; `get_key`/`ensure_keys` treat
+    // a reserved cache hit as a miss that fills the reserved slot in place.
+    lookup: SlotMap<ComputePipelineKey, Option<web_sys::GpuComputePipeline>>,
     cache: HashMap<ComputePipelineCacheKey, ComputePipelineKey>,
 }
 
@@ -176,9 +180,11 @@ impl ComputePipelines {
         pipeline_layouts: &PipelineLayouts,
         cache_key: ComputePipelineCacheKey,
     ) -> Result<ComputePipelineKey> {
-        // Fast path: cache hit, no allocation, no async.
-        if let Some(key) = self.cache.get(&cache_key) {
-            return Ok(*key);
+        // Fast path: RESOLVED cache hit, no allocation, no async. A reserved
+        // (pending) hit falls through to `ensure_keys`, which compiles into
+        // the reserved slot.
+        if let Some(key) = self.resolved_cache_hit(&cache_key) {
+            return Ok(key);
         }
         let keys = self
             .ensure_keys(gpu, shaders, pipeline_layouts, std::iter::once(cache_key))
@@ -227,8 +233,8 @@ impl ComputePipelines {
         let mut unique_miss_targets: Vec<Vec<usize>> = Vec::new();
         let mut unique_miss_index_for_key: HashMap<ComputePipelineCacheKey, usize> = HashMap::new();
         for (i, k) in inputs.iter().enumerate() {
-            if let Some(key) = self.cache.get(k) {
-                slot[i] = Some(*key);
+            if let Some(key) = self.resolved_cache_hit(k) {
+                slot[i] = Some(key);
             } else if let Some(&u_idx) = unique_miss_index_for_key.get(k) {
                 unique_miss_targets[u_idx].push(i);
             } else {
@@ -444,25 +450,39 @@ impl ComputePipelines {
             .zip(results)
             .zip(pending_targets)
         {
-            // Cache-hit early-rejoin path: if the cache already has the
-            // key (e.g. a parallel-submit raced to install first), skip
-            // the duplicate install.
+            // Cache-hit early-rejoin path: if the cache already has a
+            // RESOLVED key (e.g. a parallel-submit raced to install first),
+            // skip the duplicate install. A RESERVED entry instead receives
+            // this pipeline into its existing slot, so every holder of the
+            // reserved key sees it resolve.
             let cache_key_ref = inputs_owned[input_idx]
                 .as_ref()
                 .expect("pending input slot must own its key");
             if let Some(existing) = self.cache.get(cache_key_ref).copied() {
+                if self.lookup.get(existing).is_some_and(Option::is_some) {
+                    for i in input_targets {
+                        slot[i] = Some(existing);
+                    }
+                    // Drop the now-unused descriptor result if it was Ok;
+                    // the cache hit wins (the racing promise's pipeline is
+                    // discarded silently).
+                    let _ = result;
+                    continue;
+                }
+                let pipeline: web_sys::GpuComputePipeline = result.map_err(|e| {
+                    AwsmComputePipelineError::Core(AwsmCoreError::pipeline_creation(e))
+                })?;
+                if let Some(entry) = self.lookup.get_mut(existing) {
+                    *entry = Some(pipeline);
+                }
                 for i in input_targets {
                     slot[i] = Some(existing);
                 }
-                // Drop the now-unused descriptor result if it was Ok;
-                // the cache hit wins (the racing promise's pipeline is
-                // discarded silently).
-                let _ = result;
                 continue;
             }
             let pipeline: web_sys::GpuComputePipeline = result
                 .map_err(|e| AwsmComputePipelineError::Core(AwsmCoreError::pipeline_creation(e)))?;
-            let key = self.lookup.insert(pipeline);
+            let key = self.lookup.insert(Some(pipeline));
             let cache_key = inputs_owned[input_idx]
                 .take()
                 .expect("pending input slot must own its key");
@@ -481,7 +501,77 @@ impl ComputePipelines {
     /// (Block D.1 PART 2) to skip already-installed sub-pipelines
     /// before kicking off a new compile.
     pub fn cache_lookup(&self, cache_key: &ComputePipelineCacheKey) -> Option<&ComputePipelineKey> {
-        self.cache.get(cache_key)
+        // A RESERVED (pending) entry is not "installed" — callers use this to
+        // skip compiles, so reporting it would leave the slot empty forever.
+        self.cache
+            .get(cache_key)
+            .filter(|key| self.lookup.get(**key).is_some_and(Option::is_some))
+    }
+
+    /// RESOLVED-only cache probe: `Some(key)` iff the cache key maps to a slot
+    /// whose pipeline has actually compiled. Reserved (pending) entries return
+    /// `None` so compile paths treat them as misses that fill the slot.
+    fn resolved_cache_hit(&self, cache_key: &ComputePipelineCacheKey) -> Option<ComputePipelineKey> {
+        self.cache
+            .get(cache_key)
+            .copied()
+            .filter(|key| self.lookup.get(*key).is_some_and(Option::is_some))
+    }
+
+    /// Allocate keys for a batch of cache keys WITHOUT compiling — the
+    /// deferred boot pool. Each miss gets a reserved (empty) slot that
+    /// `compile_pending` (or any later `ensure_keys`/`get_key` on the same
+    /// cache key) fills in place; hits (resolved or reserved) return the
+    /// existing key. Sync: no Dawn work at all.
+    pub fn reserve_keys<I>(&mut self, cache_keys: I) -> Vec<ComputePipelineKey>
+    where
+        I: IntoIterator<Item = ComputePipelineCacheKey>,
+    {
+        cache_keys
+            .into_iter()
+            .map(|cache_key| {
+                if let Some(key) = self.cache.get(&cache_key) {
+                    *key
+                } else {
+                    let key = self.lookup.insert(None);
+                    self.cache.insert(cache_key, key);
+                    key
+                }
+            })
+            .collect()
+    }
+
+    /// Number of reserved slots still awaiting their compile.
+    pub fn pending_count(&self) -> usize {
+        self.lookup.values().filter(|v| v.is_none()).count()
+    }
+
+    /// Compile every reserved slot in one batched pass (the deferred boot
+    /// pool's drain — `AwsmRenderer::ensure_config_pipelines`). Idempotent:
+    /// no-op when nothing is pending. Returns how many pipelines compiled.
+    pub async fn compile_pending(
+        &mut self,
+        gpu: &AwsmRendererWebGpu,
+        shaders: &Shaders,
+        pipeline_layouts: &PipelineLayouts,
+    ) -> Result<usize> {
+        let pending: Vec<ComputePipelineCacheKey> = self
+            .cache
+            .iter()
+            .filter(|(_, key)| self.lookup.get(**key).is_some_and(|v| v.is_none()))
+            .map(|(cache_key, _)| cache_key.clone())
+            .collect();
+        if pending.is_empty() {
+            return Ok(0);
+        }
+        let n = pending.len();
+        let mut prepped = Self::ensure_keys_prepare(gpu, shaders, pipeline_layouts, pending)?;
+        let promises = std::mem::take(&mut prepped.promises);
+        let results = futures::future::join_all(promises).await;
+        // Install fills the reserved slots via the early-rejoin path (the
+        // cache already maps every input to its reserved key).
+        self.ensure_keys_install(prepped.prep, results)?;
+        Ok(n)
     }
 
     /// Sync install of a resolved `GpuComputePipeline` — inserts into
@@ -497,18 +587,27 @@ impl ComputePipelines {
         pipeline: web_sys::GpuComputePipeline,
         cache_key: ComputePipelineCacheKey,
     ) -> ComputePipelineKey {
-        if let Some(existing) = self.cache.get(&cache_key) {
-            return *existing;
+        if let Some(existing) = self.cache.get(&cache_key).copied() {
+            // A reserved slot receives the pipeline in place; a resolved one
+            // wins the race and the parameter pipeline is dropped.
+            if let Some(entry @ None) = self.lookup.get_mut(existing) {
+                *entry = Some(pipeline);
+            }
+            return existing;
         }
-        let key = self.lookup.insert(pipeline);
+        let key = self.lookup.insert(Some(pipeline));
         self.cache.insert(cache_key, key);
         key
     }
 
-    /// Returns a compute pipeline for a key.
+    /// Returns a compute pipeline for a key. A reserved-but-uncompiled slot
+    /// reports `NotFound` — dispatch paths never see one once the commit /
+    /// config-ensure invariant holds (`commit_load` drains reserved slots
+    /// before `scene_committed` flips true).
     pub fn get(&self, key: ComputePipelineKey) -> Result<&web_sys::GpuComputePipeline> {
         self.lookup
             .get(key)
+            .and_then(Option::as_ref)
             .ok_or(AwsmComputePipelineError::NotFound(key))
     }
 }

--- a/packages/crates/renderer/src/pipelines/compute_pipeline.rs
+++ b/packages/crates/renderer/src/pipelines/compute_pipeline.rs
@@ -511,7 +511,10 @@ impl ComputePipelines {
     /// RESOLVED-only cache probe: `Some(key)` iff the cache key maps to a slot
     /// whose pipeline has actually compiled. Reserved (pending) entries return
     /// `None` so compile paths treat them as misses that fill the slot.
-    fn resolved_cache_hit(&self, cache_key: &ComputePipelineCacheKey) -> Option<ComputePipelineKey> {
+    fn resolved_cache_hit(
+        &self,
+        cache_key: &ComputePipelineCacheKey,
+    ) -> Option<ComputePipelineKey> {
         self.cache
             .get(cache_key)
             .copied()

--- a/packages/crates/renderer/src/pipelines/render_pipeline.rs
+++ b/packages/crates/renderer/src/pipelines/render_pipeline.rs
@@ -32,7 +32,9 @@ use crate::{
 
 /// Cache of render pipelines by key.
 pub struct RenderPipelines {
-    lookup: SlotMap<RenderPipelineKey, web_sys::GpuRenderPipeline>,
+    // `None` = a RESERVED slot (see `ComputePipelines::lookup` — same
+    // deferred-boot-pool mechanism).
+    lookup: SlotMap<RenderPipelineKey, Option<web_sys::GpuRenderPipeline>>,
     cache: HashMap<RenderPipelineCacheKey, RenderPipelineKey>,
 }
 
@@ -100,9 +102,11 @@ impl RenderPipelines {
         pipeline_layouts: &PipelineLayouts,
         cache_key: RenderPipelineCacheKey,
     ) -> Result<RenderPipelineKey> {
-        // Fast path: cache hit, no allocation, no async.
-        if let Some(key) = self.cache.get(&cache_key) {
-            return Ok(*key);
+        // Fast path: RESOLVED cache hit, no allocation, no async. A reserved
+        // (pending) hit falls through to `ensure_keys`, which compiles into
+        // the reserved slot.
+        if let Some(key) = self.resolved_cache_hit(&cache_key) {
+            return Ok(key);
         }
         let keys = self
             .ensure_keys(gpu, shaders, pipeline_layouts, std::iter::once(cache_key))
@@ -154,8 +158,8 @@ impl RenderPipelines {
         let mut unique_miss_targets: Vec<Vec<usize>> = Vec::new();
         let mut unique_miss_index_for_key: HashMap<RenderPipelineCacheKey, usize> = HashMap::new();
         for (i, k) in inputs.iter().enumerate() {
-            if let Some(key) = self.cache.get(k) {
-                slot[i] = Some(*key);
+            if let Some(key) = self.resolved_cache_hit(k) {
+                slot[i] = Some(key);
             } else if let Some(&u_idx) = unique_miss_index_for_key.get(k) {
                 unique_miss_targets[u_idx].push(i);
             } else {
@@ -334,15 +338,28 @@ impl RenderPipelines {
                 .as_ref()
                 .expect("pending input slot must own its key");
             if let Some(existing) = self.cache.get(cache_key_ref).copied() {
+                if self.lookup.get(existing).is_some_and(Option::is_some) {
+                    for i in input_targets {
+                        slot[i] = Some(existing);
+                    }
+                    let _ = result;
+                    continue;
+                }
+                // RESERVED entry — this compile fills the existing slot.
+                let pipeline: web_sys::GpuRenderPipeline = result.map_err(|e| {
+                    AwsmRenderPipelineError::Core(AwsmCoreError::pipeline_creation(e))
+                })?;
+                if let Some(entry) = self.lookup.get_mut(existing) {
+                    *entry = Some(pipeline);
+                }
                 for i in input_targets {
                     slot[i] = Some(existing);
                 }
-                let _ = result;
                 continue;
             }
             let pipeline: web_sys::GpuRenderPipeline = result
                 .map_err(|e| AwsmRenderPipelineError::Core(AwsmCoreError::pipeline_creation(e)))?;
-            let key = self.lookup.insert(pipeline);
+            let key = self.lookup.insert(Some(pipeline));
             let cache_key = inputs_owned[input_idx]
                 .take()
                 .expect("pending input slot must own its key");
@@ -356,17 +373,76 @@ impl RenderPipelines {
     }
 
     /// Sync cache peek: returns the already-resolved key for a cache
-    /// key, or `None` if it was never compiled. Used by the per-frame
-    /// HUD-resolve kick to install already-cached variants immediately
-    /// and only issue `createRenderPipelineAsync` for genuine misses.
+    /// key, or `None` if it was never compiled (reserved-but-pending
+    /// entries also report `None` — callers use this to skip compiles).
     pub fn get_cached_key(&self, cache_key: &RenderPipelineCacheKey) -> Option<RenderPipelineKey> {
-        self.cache.get(cache_key).copied()
+        self.resolved_cache_hit(cache_key)
     }
 
-    /// Returns a render pipeline for a key.
+    /// RESOLVED-only cache probe (see `ComputePipelines::resolved_cache_hit`).
+    fn resolved_cache_hit(&self, cache_key: &RenderPipelineCacheKey) -> Option<RenderPipelineKey> {
+        self.cache
+            .get(cache_key)
+            .copied()
+            .filter(|key| self.lookup.get(*key).is_some_and(Option::is_some))
+    }
+
+    /// Allocate keys for a batch of cache keys WITHOUT compiling — the
+    /// deferred boot pool (see `ComputePipelines::reserve_keys`).
+    pub fn reserve_keys<I>(&mut self, cache_keys: I) -> Vec<RenderPipelineKey>
+    where
+        I: IntoIterator<Item = RenderPipelineCacheKey>,
+    {
+        cache_keys
+            .into_iter()
+            .map(|cache_key| {
+                if let Some(key) = self.cache.get(&cache_key) {
+                    *key
+                } else {
+                    let key = self.lookup.insert(None);
+                    self.cache.insert(cache_key, key);
+                    key
+                }
+            })
+            .collect()
+    }
+
+    /// Number of reserved slots still awaiting their compile.
+    pub fn pending_count(&self) -> usize {
+        self.lookup.values().filter(|v| v.is_none()).count()
+    }
+
+    /// Compile every reserved slot in one batched pass (the deferred boot
+    /// pool's drain). Idempotent; returns how many pipelines compiled.
+    pub async fn compile_pending(
+        &mut self,
+        gpu: &AwsmRendererWebGpu,
+        shaders: &Shaders,
+        pipeline_layouts: &PipelineLayouts,
+    ) -> Result<usize> {
+        let pending: Vec<RenderPipelineCacheKey> = self
+            .cache
+            .iter()
+            .filter(|(_, key)| self.lookup.get(**key).is_some_and(|v| v.is_none()))
+            .map(|(cache_key, _)| cache_key.clone())
+            .collect();
+        if pending.is_empty() {
+            return Ok(0);
+        }
+        let n = pending.len();
+        let mut prepped = Self::ensure_keys_prepare(gpu, shaders, pipeline_layouts, pending)?;
+        let promises = std::mem::take(&mut prepped.promises);
+        let results = futures::future::join_all(promises).await;
+        self.ensure_keys_install(prepped.prep, results)?;
+        Ok(n)
+    }
+
+    /// Returns a render pipeline for a key. A reserved-but-uncompiled slot
+    /// reports `NotFound` (see `ComputePipelines::get`).
     pub fn get(&self, key: RenderPipelineKey) -> Result<&web_sys::GpuRenderPipeline> {
         self.lookup
             .get(key)
+            .and_then(Option::as_ref)
             .ok_or(AwsmRenderPipelineError::NotFound(key))
     }
 }

--- a/packages/crates/renderer/src/render.rs
+++ b/packages/crates/renderer/src/render.rs
@@ -1177,12 +1177,17 @@ impl AwsmRenderer {
             // resize, AA flip, T2.5 mip-chain grow, T2.6 HUD-depth
             // grow) so the cache stays paired with the right
             // `GpuTexture` identity.
-            if ctx.render_texture_views.views_recreated {
-                self.opaque_mipgen.invalidate();
-            }
-            if let Some((texture, mip_count)) = opaque_info {
-                self.opaque_mipgen
-                    .record(&self.gpu, &ctx.command_encoder, &texture, mip_count)?;
+            // Deferred-boot: `None` only between a runtime material change to
+            // transmission and the next commit's config ensure — skip the mip
+            // chain that frame (transmission samples mip 0, slightly sharper
+            // refraction, never wrong data).
+            if let Some(mipgen) = self.opaque_mipgen.as_ref() {
+                if ctx.render_texture_views.views_recreated {
+                    mipgen.invalidate();
+                }
+                if let Some((texture, mip_count)) = opaque_info {
+                    mipgen.record(&self.gpu, &ctx.command_encoder, &texture, mip_count)?;
+                }
             }
         }
 

--- a/packages/crates/renderer/src/render.rs
+++ b/packages/crates/renderer/src/render.rs
@@ -1864,8 +1864,11 @@ impl AwsmRenderer {
 
         let bind_groups = &self.render_passes.material_transparent.bind_groups;
         let sig = HudResolveSig {
+            // Both counts are the PADDED TIER values (see
+            // `pool_binding_tier`) stored on the bind groups, so the
+            // fingerprint only changes at tier crossings.
             pool_arrays_len: bind_groups.texture_pool_arrays_len,
-            pool_samplers_len: bind_groups.texture_pool_sampler_keys.len(),
+            pool_samplers_len: bind_groups.texture_pool_samplers_len as usize,
             msaa: self.anti_aliasing.msaa_sample_count,
             hud_revision: self.meshes.hud_revision(),
             unkeyed_world,

--- a/packages/crates/renderer/src/render_passes.rs
+++ b/packages/crates/renderer/src/render_passes.rs
@@ -727,15 +727,11 @@ impl RenderPasses {
             compute_pool.len()..compute_pool.len() + opaque_descs.pipeline_cache_keys.len();
         compute_pool.extend(opaque_descs.pipeline_cache_keys.iter().cloned());
 
-        // Decal composite — only the typed handle, no cache keys to
-        // pool. The composite uses inline WGSL and internal
-        // `try_join` for its 2 pipelines; building it here keeps the
-        // construction ordering identical to the pre-refactor flow.
-        let material_decal_composite = if bindings.decal_bg.is_some() {
-            Some(material_decal::composite::MaterialDecalComposite::new(ctx).await?)
-        } else {
-            None
-        };
+        // Decal composite — deferred-boot: NOT built here anymore. Its two
+        // inline-WGSL pipelines compile in `ensure_config_pipelines`
+        // (`ensure_decal_composite_compiled`), so build() stays compile-free.
+        let material_decal_composite: Option<material_decal::composite::MaterialDecalComposite> =
+            None;
 
         // HZB texture — tiny initial allocation, recreated against
         // the live viewport on the first frame. Allocated here
@@ -955,7 +951,6 @@ impl RenderPasses {
             decal_classify_bg,
             ranges.decal_classify,
             per_pass_descs.decal_is_msaa,
-            material_decal_composite,
         ) {
             (
                 Some(decal_bg),
@@ -963,14 +958,14 @@ impl RenderPasses {
                 Some(decal_classify_bg),
                 Some(decal_classify_range),
                 Some(decal_is_msaa),
-                Some(composite),
             ) => Some(MaterialDecalRenderPass {
                 bind_groups: decal_bg,
                 pipelines: MaterialDecalPipelines::from_resolved(
                     decal_is_msaa,
                     compute_keys[decal_range].to_vec(),
                 ),
-                composite,
+                // Deferred-boot: compiled by `ensure_decal_composite_compiled`.
+                composite: material_decal_composite,
                 classify_pass: material_decal::classify::render_pass::DecalClassifyRenderPass {
                     bind_groups: decal_classify_bg,
                     pipelines: DecalClassifyPipelines::from_resolved(

--- a/packages/crates/renderer/src/render_passes.rs
+++ b/packages/crates/renderer/src/render_passes.rs
@@ -37,8 +37,10 @@ use crate::{
     pipeline_layouts::PipelineLayouts,
     pipelines::Pipelines,
     render_passes::{
-        coverage::render_pass::CoverageRenderPass, display::render_pass::DisplayRenderPass,
-        geometry::render_pass::GeometryRenderPass, hzb::render_pass::HzbRenderPass,
+        coverage::render_pass::CoverageRenderPass,
+        display::render_pass::DisplayRenderPass,
+        geometry::render_pass::GeometryRenderPass,
+        hzb::render_pass::HzbRenderPass,
         light_culling::bind_group::LightCullingBindGroups,
         light_culling::pipeline::{LightCullingPipelines, LightCullingPrewarmDescriptors},
         light_culling::render_pass::LightCullingRenderPass,
@@ -51,7 +53,8 @@ use crate::{
             MaterialPrepPipelines, MaterialPrepPrewarmDescriptors, MaterialPrepRenderPass,
         },
         material_transparent::render_pass::MaterialTransparentRenderPass,
-        occlusion::compaction::CompactionRenderPass, occlusion::render_pass::OcclusionRenderPass,
+        occlusion::compaction::CompactionRenderPass,
+        occlusion::render_pass::OcclusionRenderPass,
     },
     render_textures::RenderTextureFormats,
     shaders::Shaders,
@@ -643,16 +646,15 @@ impl RenderPasses {
         // Light culling: 2 keys (cs_main + cs_tile), one shared module.
         let light_culling_descs =
             LightCullingPipelines::build_descriptors(ctx, &bindings.light_culling_bg).await?;
-        let light_culling_range = compute_pool.len()
-            ..compute_pool.len() + light_culling_descs.pipeline_cache_keys.len();
+        let light_culling_range =
+            compute_pool.len()..compute_pool.len() + light_culling_descs.pipeline_cache_keys.len();
         compute_pool.extend(light_culling_descs.pipeline_cache_keys.iter().cloned());
 
         // Material prep: ACTIVE MSAA branch only (the other branch fills on the
         // first set_anti_aliasing flip); cs_prep_edge + the compact edge-shadow
         // texture only when the MSAA edge-resolve path is actually live; the
         // blur pair only while denoise is configured on.
-        let edge_resolve_enabled =
-            multisampled_geometry && crate::edge_resolve_supported(ctx.gpu);
+        let edge_resolve_enabled = multisampled_geometry && crate::edge_resolve_supported(ctx.gpu);
         let material_prep_descs = MaterialPrepPipelines::build_descriptors_for_config(
             ctx,
             &bindings.material_prep_bg,
@@ -660,8 +662,8 @@ impl RenderPasses {
             edge_resolve_enabled,
         )
         .await?;
-        let material_prep_range = compute_pool.len()
-            ..compute_pool.len() + material_prep_descs.pipeline_cache_keys.len();
+        let material_prep_range =
+            compute_pool.len()..compute_pool.len() + material_prep_descs.pipeline_cache_keys.len();
         compute_pool.extend(material_prep_descs.pipeline_cache_keys.iter().cloned());
         // Allocated here (gpu handle in scope; `from_resolved` is sync).
         // Gated on MSAA alone — NOT on `edge_resolve_supported` — because the

--- a/packages/crates/renderer/src/render_passes.rs
+++ b/packages/crates/renderer/src/render_passes.rs
@@ -39,11 +39,17 @@ use crate::{
     render_passes::{
         coverage::render_pass::CoverageRenderPass, display::render_pass::DisplayRenderPass,
         geometry::render_pass::GeometryRenderPass, hzb::render_pass::HzbRenderPass,
+        light_culling::bind_group::LightCullingBindGroups,
+        light_culling::pipeline::{LightCullingPipelines, LightCullingPrewarmDescriptors},
         light_culling::render_pass::LightCullingRenderPass,
         material_classify::render_pass::MaterialClassifyRenderPass,
         material_decal::render_pass::MaterialDecalRenderPass,
         material_opaque::render_pass::MaterialOpaqueRenderPass,
-        material_prep::render_pass::MaterialPrepRenderPass,
+        material_prep::bind_group::MaterialPrepBindGroups,
+        material_prep::buffers::EdgeShadowBuffer,
+        material_prep::render_pass::{
+            MaterialPrepPipelines, MaterialPrepPrewarmDescriptors, MaterialPrepRenderPass,
+        },
         material_transparent::render_pass::MaterialTransparentRenderPass,
         occlusion::compaction::CompactionRenderPass, occlusion::render_pass::OcclusionRenderPass,
     },
@@ -160,14 +166,12 @@ struct RenderPassesBindings {
     hzb_bg: Option<hzb::bind_group::HzbBindGroups>,
     occlusion_bg: Option<occlusion::bind_group::OcclusionBindGroups>,
     compaction_bg: Option<occlusion::compaction::CompactionBindGroups>,
-    light_culling: LightCullingRenderPass,
+    light_culling_bg: LightCullingBindGroups,
     /// Built eagerly + gated by `virtual_geometry`; passed straight through to
     /// `from_resolved`.
     #[cfg(feature = "lod")]
     cluster_lod: Option<ClusterLodRenderPass>,
-    /// Built eagerly (like `light_culling`) and passed straight through to
-    /// `from_resolved`. Always `Some` (prep is unconditional).
-    material_prep: Option<MaterialPrepRenderPass>,
+    material_prep_bg: MaterialPrepBindGroups,
     classify_bg: material_classify::bind_group::MaterialClassifyBindGroups,
     decal_bg: Option<material_decal::bind_group::MaterialDecalBindGroups>,
     decal_classify_bg: Option<material_decal::classify::bind_group::DecalClassifyBindGroups>,
@@ -246,6 +250,8 @@ struct RenderPassesRanges {
     occlusion: Option<Range<usize>>,
     compaction: Option<Range<usize>>,
     classify: Range<usize>,
+    light_culling: Range<usize>,
+    material_prep: Range<usize>,
     decal: Option<Range<usize>>,
     decal_classify: Option<Range<usize>>,
     opaque: Range<usize>,
@@ -257,6 +263,12 @@ struct RenderPassesRanges {
 /// `slots`, or the decal pass's `is_msaa`).
 struct RenderPassesPerPassDescs {
     geometry: crate::render_passes::geometry::pipeline::GeometryPrewarmDescriptors,
+    light_culling: LightCullingPrewarmDescriptors,
+    material_prep: MaterialPrepPrewarmDescriptors,
+    /// Stage 5b-shadow: the compact edge-shadow texture, allocated in
+    /// `describe_pipelines` (which has a gpu handle) only when MSAA is on and
+    /// the device supports edge resolve — `from_resolved` is sync.
+    prep_edge_shadow: Option<EdgeShadowBuffer>,
     opaque_slots: Vec<crate::render_passes::material_opaque::pipeline::OpaquePipelineSlot>,
     /// One slot per entry in the classify pass's pipeline pool —
     /// records the `msaa_sample_count` so `from_resolved` can route
@@ -414,7 +426,12 @@ impl RenderPasses {
         } else {
             None
         };
-        let light_culling = LightCullingRenderPass::new(ctx).await?;
+        // Light culling + material prep: bind groups only here — their
+        // shader/pipeline cache keys join the cross-renderer pool below
+        // (phase 2), like every other pooled pass. Previously both compiled
+        // eagerly inside their `new()` (sequential single-pipeline awaits);
+        // the prep megashader alone was ~2.6s of cold boot.
+        let light_culling_bg = LightCullingBindGroups::new(ctx).await?;
         // Cluster-LOD cut pass (Phase B). Eager + gated; creating its pipeline
         // validates `cluster_cut.wgsl` on-device. Buffers/bind-group instance
         // come when a cluster mesh loads.
@@ -424,11 +441,7 @@ impl RenderPasses {
         } else {
             None
         };
-        // Shared material-prep compute pass (Plan B). The shared prep pass is
-        // unconditional now — always built (both MSAA variants). Kept as an
-        // `Option` (always-`Some`) so the `if let Some(prep)` dispatch sites
-        // stay valid.
-        let material_prep = Some(MaterialPrepRenderPass::new(ctx).await?);
+        let material_prep_bg = MaterialPrepBindGroups::new(ctx).await?;
         let classify_bg =
             material_classify::bind_group::MaterialClassifyBindGroups::new(ctx).await?;
         let (decal_bg, decal_classify_bg) = if features.decals {
@@ -473,6 +486,15 @@ impl RenderPasses {
         // set_anti_aliasing flip.
         let multisampled_geometry = ctx.anti_aliasing.has_msaa_checked()?;
         shader_cache_keys.extend(GeometryPipelines::shader_cache_keys(multisampled_geometry));
+        // Light culling: one module, two entry points, MSAA-agnostic.
+        shader_cache_keys.extend(LightCullingPipelines::shader_cache_keys());
+        // Material prep: active MSAA branch only (the megashader module also
+        // covers cs_prep_edge); the blur module rides along while denoise is
+        // configured on.
+        shader_cache_keys.extend(MaterialPrepPipelines::shader_cache_keys(
+            multisampled_geometry,
+            ctx.prep_config,
+        ));
         if features.gpu_culling {
             shader_cache_keys.extend(HzbPipelines::shader_cache_keys(ctx.anti_aliasing));
             shader_cache_keys.extend(OcclusionPipelines::shader_cache_keys());
@@ -522,10 +544,10 @@ impl RenderPasses {
                 hzb_bg,
                 occlusion_bg,
                 compaction_bg,
-                light_culling,
+                light_culling_bg,
                 #[cfg(feature = "lod")]
                 cluster_lod,
-                material_prep,
+                material_prep_bg,
                 classify_bg,
                 decal_bg,
                 decal_classify_bg,
@@ -618,6 +640,44 @@ impl RenderPasses {
             compute_pool.len()..compute_pool.len() + classify_descs.pipeline_cache_keys.len();
         compute_pool.extend(classify_descs.pipeline_cache_keys.iter().cloned());
 
+        // Light culling: 2 keys (cs_main + cs_tile), one shared module.
+        let light_culling_descs =
+            LightCullingPipelines::build_descriptors(ctx, &bindings.light_culling_bg).await?;
+        let light_culling_range = compute_pool.len()
+            ..compute_pool.len() + light_culling_descs.pipeline_cache_keys.len();
+        compute_pool.extend(light_culling_descs.pipeline_cache_keys.iter().cloned());
+
+        // Material prep: ACTIVE MSAA branch only (the other branch fills on the
+        // first set_anti_aliasing flip); cs_prep_edge + the compact edge-shadow
+        // texture only when the MSAA edge-resolve path is actually live; the
+        // blur pair only while denoise is configured on.
+        let edge_resolve_enabled =
+            multisampled_geometry && crate::edge_resolve_supported(ctx.gpu);
+        let material_prep_descs = MaterialPrepPipelines::build_descriptors_for_config(
+            ctx,
+            &bindings.material_prep_bg,
+            multisampled_geometry,
+            edge_resolve_enabled,
+        )
+        .await?;
+        let material_prep_range = compute_pool.len()
+            ..compute_pool.len() + material_prep_descs.pipeline_cache_keys.len();
+        compute_pool.extend(material_prep_descs.pipeline_cache_keys.iter().cloned());
+        // Allocated here (gpu handle in scope; `from_resolved` is sync).
+        // Gated on MSAA alone — NOT on `edge_resolve_supported` — because the
+        // opaque MSAA main bind group binds this view (binding 27)
+        // unconditionally under MSAA; only the cs_prep_edge pipeline is
+        // additionally support-gated. Single-sampled sessions skip the ~8 MB.
+        let prep_edge_shadow = if multisampled_geometry {
+            Some(EdgeShadowBuffer::new(
+                ctx.gpu,
+                ctx.max_edge_budget,
+                ctx.prep_config.shadow_visibility_layers(),
+            )?)
+        } else {
+            None
+        };
+
         let coverage_single_range = if let Some(bg) = bindings.coverage_bg_single.as_ref() {
             let descs = CoveragePipelines::build_descriptors(ctx, bg).await?;
             let start = compute_pool.len();
@@ -699,12 +759,17 @@ impl RenderPasses {
                 occlusion: occlusion_range,
                 compaction: compaction_range,
                 classify: classify_range,
+                light_culling: light_culling_range,
+                material_prep: material_prep_range,
                 decal: decal_range,
                 decal_classify: decal_classify_range,
                 opaque: opaque_range,
             },
             per_pass_descs: RenderPassesPerPassDescs {
                 geometry: geometry_descs,
+                light_culling: light_culling_descs,
+                material_prep: material_prep_descs,
+                prep_edge_shadow,
                 opaque_slots: opaque_descs.slots,
                 classify_slot_msaa: classify_descs.slot_msaa,
                 hzb_slot,
@@ -761,10 +826,10 @@ impl RenderPasses {
             hzb_bg,
             occlusion_bg,
             compaction_bg,
-            light_culling,
+            light_culling_bg,
             #[cfg(feature = "lod")]
             cluster_lod,
-            material_prep,
+            material_prep_bg,
             classify_bg,
             decal_bg,
             decal_classify_bg,
@@ -859,6 +924,29 @@ impl RenderPasses {
         let material_classify = MaterialClassifyRenderPass {
             bind_groups: classify_bg,
             pipeline_cache: std::cell::RefCell::new(std::collections::HashMap::new()),
+        };
+
+        let light_culling = LightCullingRenderPass {
+            bind_groups: light_culling_bg,
+            pipelines: LightCullingPipelines::from_resolved(
+                &per_pass_descs.light_culling,
+                compute_keys[ranges.light_culling].to_vec(),
+            )?,
+        };
+
+        let material_prep = {
+            let mut pipelines = MaterialPrepPipelines::default();
+            pipelines.merge_resolved(
+                &per_pass_descs.material_prep.slots,
+                compute_keys[ranges.material_prep].to_vec(),
+            );
+            // Kept as an always-`Some` `Option` so the `if let Some(prep)`
+            // dispatch sites stay valid (prep is unconditional).
+            Some(MaterialPrepRenderPass::from_resolved(
+                material_prep_bg,
+                pipelines,
+                per_pass_descs.prep_edge_shadow,
+            ))
         };
 
         let material_decal = match (

--- a/packages/crates/renderer/src/render_passes/geometry/custom_vertex_pipeline.rs
+++ b/packages/crates/renderer/src/render_passes/geometry/custom_vertex_pipeline.rs
@@ -144,7 +144,7 @@ impl GeometryCustomVertexPipelines {
             shader_id: variant.shader_id,
             dynamic_vertex: variant.dynamic_vertex.clone(),
             texture_pool_arrays_len: masked_bind_group.texture_pool_arrays_len,
-            texture_pool_samplers_len: masked_bind_group.texture_pool_sampler_keys.len() as u32,
+            texture_pool_samplers_len: masked_bind_group.texture_pool_samplers_len,
             msaa_samples,
             instancing_transforms: variant.instancing_transforms,
             // The reused masked bind groups declare the uniform meta binding, so

--- a/packages/crates/renderer/src/render_passes/geometry/masked_bind_group.rs
+++ b/packages/crates/renderer/src/render_passes/geometry/masked_bind_group.rs
@@ -40,6 +40,7 @@ const MASKED_GROUP0_BUFFER_BINDINGS: u32 = 6;
 pub struct GeometryMaskedBindGroup {
     pub bind_group_layout_key: BindGroupLayoutKey,
     pub texture_pool_arrays_len: u32,
+    pub texture_pool_samplers_len: u32,
     pub texture_pool_sampler_keys: IndexSet<SamplerKey>,
     _bind_group: Option<web_sys::GpuBindGroup>,
 }
@@ -52,6 +53,7 @@ impl GeometryMaskedBindGroup {
         Ok(Self {
             bind_group_layout_key,
             texture_pool_arrays_len: pool.arrays_len,
+            texture_pool_samplers_len: pool.samplers_len,
             texture_pool_sampler_keys: pool.sampler_keys,
             _bind_group: None,
         })
@@ -69,6 +71,7 @@ impl GeometryMaskedBindGroup {
         Ok(Self {
             bind_group_layout_key,
             texture_pool_arrays_len: pool.arrays_len,
+            texture_pool_samplers_len: pool.samplers_len,
             texture_pool_sampler_keys: pool.sampler_keys,
             _bind_group: None,
         })
@@ -122,11 +125,40 @@ impl GeometryMaskedBindGroup {
                 BindGroupResource::TextureView(Cow::Borrowed(view)),
             ));
         }
+        // Pad texture slots up to the layout's tier with the placeholder
+        // view — the layout declares the tier, so every slot must bind.
+        let placeholder_view = ctx
+            .textures
+            .pool_placeholder_view()
+            .ok_or(AwsmBindGroupError::TexturePoolPlaceholderMissing("view"))?;
+        while entries.len()
+            < (MASKED_GROUP0_BUFFER_BINDINGS + self.texture_pool_arrays_len) as usize
+        {
+            entries.push(BindGroupEntry::new(
+                entries.len() as u32,
+                BindGroupResource::TextureView(Cow::Borrowed(placeholder_view)),
+            ));
+        }
         for sampler_key in self.texture_pool_sampler_keys.iter() {
             let sampler = ctx.textures.get_sampler(*sampler_key)?;
             entries.push(BindGroupEntry::new(
                 entries.len() as u32,
                 BindGroupResource::Sampler(sampler),
+            ));
+        }
+        // Pad sampler slots up to the tier with the placeholder sampler.
+        let placeholder_sampler = ctx
+            .textures
+            .pool_placeholder_sampler()
+            .ok_or(AwsmBindGroupError::TexturePoolPlaceholderMissing("sampler"))?;
+        while entries.len()
+            < (MASKED_GROUP0_BUFFER_BINDINGS
+                + self.texture_pool_arrays_len
+                + self.texture_pool_samplers_len) as usize
+        {
+            entries.push(BindGroupEntry::new(
+                entries.len() as u32,
+                BindGroupResource::Sampler(placeholder_sampler),
             ));
         }
 
@@ -157,9 +189,10 @@ fn build_layout_key(
     ctx: &mut RenderPassInitContext<'_>,
     arrays_len: u32,
 ) -> Result<BindGroupLayoutKey> {
-    // Re-read the sampler set so the layout matches what `recreate` will bind.
+    // Re-read the pool deps so the layout matches what `recreate` will bind
+    // (tier-padded sampler count).
     let pool = TexturePoolDeps::new(ctx, TexturePoolVisibility::Render)?;
-    let samplers_len = pool.sampler_keys.len() as u32;
+    let samplers_len = pool.samplers_len;
 
     let uniform_vf = || BindGroupLayoutCacheKeyEntry {
         resource: BindGroupLayoutResource::Buffer(

--- a/packages/crates/renderer/src/render_passes/geometry/masked_custom_vertex_pipeline.rs
+++ b/packages/crates/renderer/src/render_passes/geometry/masked_custom_vertex_pipeline.rs
@@ -129,7 +129,7 @@ impl GeometryMaskedCustomVertexPipelines {
             dynamic_vertex: variant.dynamic_vertex.clone(),
             dynamic_alpha: variant.dynamic_alpha.clone(),
             texture_pool_arrays_len: masked_bind_group.texture_pool_arrays_len,
-            texture_pool_samplers_len: masked_bind_group.texture_pool_sampler_keys.len() as u32,
+            texture_pool_samplers_len: masked_bind_group.texture_pool_samplers_len,
             msaa_samples,
         };
         ctx.shaders

--- a/packages/crates/renderer/src/render_passes/geometry/masked_pipeline.rs
+++ b/packages/crates/renderer/src/render_passes/geometry/masked_pipeline.rs
@@ -73,6 +73,22 @@ impl GeometryMaskedPipelines {
         })
     }
 
+    /// True when a masked variant for `(msaa, shader_id)` is already compiled
+    /// (any cull — [`Self::ensure_variant`] inserts all three together). The
+    /// texture-finalize gate probes this so a material that ROUTES masked with
+    /// no texture change (e.g. the editor flipping a builtin's alpha mode to
+    /// Mask) still gets its variant compiled instead of silently falling back
+    /// to the solid pipeline forever.
+    pub fn has_variant(
+        &self,
+        msaa_sample_count: Option<u32>,
+        shader_id: MaterialShaderId,
+    ) -> bool {
+        self.main
+            .keys()
+            .any(|k| k.msaa_sample_count == msaa_sample_count && k.shader_id == shader_id)
+    }
+
     /// Re-resolves the pipeline layout after the masked group-0 layout changed
     /// (texture-pool growth). Existing pool entries are cleared — the caller
     /// recompiles the live variants against the new layout.

--- a/packages/crates/renderer/src/render_passes/geometry/masked_pipeline.rs
+++ b/packages/crates/renderer/src/render_passes/geometry/masked_pipeline.rs
@@ -118,7 +118,7 @@ impl GeometryMaskedPipelines {
 
         let shader_cache = ShaderCacheKeyGeometryMasked {
             texture_pool_arrays_len: masked_bind_group.texture_pool_arrays_len,
-            texture_pool_samplers_len: masked_bind_group.texture_pool_sampler_keys.len() as u32,
+            texture_pool_samplers_len: masked_bind_group.texture_pool_samplers_len,
             shader_id: variant.shader_id,
             base: variant.base,
             dynamic_alpha: variant.dynamic_alpha.clone(),

--- a/packages/crates/renderer/src/render_passes/geometry/masked_pipeline.rs
+++ b/packages/crates/renderer/src/render_passes/geometry/masked_pipeline.rs
@@ -79,11 +79,7 @@ impl GeometryMaskedPipelines {
     /// no texture change (e.g. the editor flipping a builtin's alpha mode to
     /// Mask) still gets its variant compiled instead of silently falling back
     /// to the solid pipeline forever.
-    pub fn has_variant(
-        &self,
-        msaa_sample_count: Option<u32>,
-        shader_id: MaterialShaderId,
-    ) -> bool {
+    pub fn has_variant(&self, msaa_sample_count: Option<u32>, shader_id: MaterialShaderId) -> bool {
         self.main
             .keys()
             .any(|k| k.msaa_sample_count == msaa_sample_count && k.shader_id == shader_id)

--- a/packages/crates/renderer/src/render_passes/light_culling/pipeline.rs
+++ b/packages/crates/renderer/src/render_passes/light_culling/pipeline.rs
@@ -15,6 +15,14 @@ use crate::render_passes::light_culling::{
     shader::cache_key::ShaderCacheKeyLightCulling,
 };
 use crate::render_passes::RenderPassInitContext;
+use crate::shaders::ShaderCacheKey;
+
+/// Phase-2 output of [`LightCullingPipelines::build_descriptors`]: the two
+/// pooled compute cache keys, in the fixed order `[cs_main, cs_tile]`.
+pub struct LightCullingPrewarmDescriptors {
+    pub pipeline_cache_keys: Vec<ComputePipelineCacheKey>,
+    pub slice_count: u32,
+}
 
 /// Compiled compute pipelines for the cull shader plus the `slice_count`
 /// they were compiled against. Per-froxel capacity is deliberately not
@@ -31,21 +39,25 @@ pub struct LightCullingPipelines {
 }
 
 impl LightCullingPipelines {
-    /// Builds the cull pipelines at the default `DEFAULT_SLICE_COUNT`.
-    /// `LightCullingBuffers::new` is allocated at the matching slice
-    /// count so the consumer / cull shaders agree on the WGSL constants.
-    pub async fn new(
-        ctx: &mut RenderPassInitContext<'_>,
-        bind_groups: &LightCullingBindGroups,
-    ) -> Result<Self> {
-        Self::build(ctx, bind_groups, DEFAULT_SLICE_COUNT).await
+    /// The cull shader's cache key (one module for both entry points) —
+    /// pooled into the cross-renderer `Shaders::ensure_keys` batch.
+    pub fn shader_cache_keys() -> Vec<ShaderCacheKey> {
+        vec![ShaderCacheKeyLightCulling {
+            slice_count: DEFAULT_SLICE_COUNT,
+        }
+        .into()]
     }
 
-    async fn build(
+    /// Build the two pooled pipeline cache keys (`cs_main` + `cs_tile`) at
+    /// the default `DEFAULT_SLICE_COUNT`. `LightCullingBuffers::new` is
+    /// allocated at the matching slice count so the consumer / cull shaders
+    /// agree on the WGSL constants. Sync apart from the cache-hit
+    /// `shaders.get_key` await (the pooled shader batch ran first).
+    pub async fn build_descriptors(
         ctx: &mut RenderPassInitContext<'_>,
         bind_groups: &LightCullingBindGroups,
-        slice_count: u32,
-    ) -> Result<Self> {
+    ) -> Result<LightCullingPrewarmDescriptors> {
+        let slice_count = DEFAULT_SLICE_COUNT;
         let pipeline_layout_key = ctx.pipeline_layouts.get_key(
             ctx.gpu,
             ctx.bind_group_layouts,
@@ -55,32 +67,32 @@ impl LightCullingPipelines {
             .shaders
             .get_key(ctx.gpu, ShaderCacheKeyLightCulling { slice_count })
             .await?;
-        let pipeline_key = ctx
-            .pipelines
-            .compute
-            .get_key(
-                ctx.gpu,
-                ctx.shaders,
-                ctx.pipeline_layouts,
+        Ok(LightCullingPrewarmDescriptors {
+            pipeline_cache_keys: vec![
                 ComputePipelineCacheKey::new(shader_key, pipeline_layout_key)
                     .with_entry_point("cs_main"),
-            )
-            .await?;
-        let tile_pipeline_key = ctx
-            .pipelines
-            .compute
-            .get_key(
-                ctx.gpu,
-                ctx.shaders,
-                ctx.pipeline_layouts,
                 ComputePipelineCacheKey::new(shader_key, pipeline_layout_key)
                     .with_entry_point("cs_tile"),
-            )
-            .await?;
+            ],
+            slice_count,
+        })
+    }
+
+    /// Fold the resolved pool slice (order `[cs_main, cs_tile]`) back into
+    /// the typed pipelines. Sync; no Dawn / GPU calls.
+    pub fn from_resolved(
+        descs: &LightCullingPrewarmDescriptors,
+        keys: Vec<ComputePipelineKey>,
+    ) -> Result<Self> {
+        let [pipeline_key, tile_pipeline_key] = keys[..] else {
+            return Err(crate::error::AwsmError::PipelineVariantNotCompiled(
+                "light culling expected exactly 2 resolved pipelines (cs_main + cs_tile)",
+            ));
+        };
         Ok(Self {
             pipeline_key,
             tile_pipeline_key,
-            slice_count,
+            slice_count: descs.slice_count,
         })
     }
 }

--- a/packages/crates/renderer/src/render_passes/light_culling/render_pass.rs
+++ b/packages/crates/renderer/src/render_passes/light_culling/render_pass.rs
@@ -17,34 +17,24 @@ use awsm_renderer_core::command::compute_pass::ComputePassDescriptor;
 use crate::{
     error::Result,
     render::RenderContext,
-    render_passes::{
-        light_culling::{bind_group::LightCullingBindGroups, pipeline::LightCullingPipelines},
-        RenderPassInitContext,
+    render_passes::light_culling::{
+        bind_group::LightCullingBindGroups, pipeline::LightCullingPipelines,
     },
 };
 
-/// Light culling pass bind groups and pipelines.
+/// Light culling pass bind groups and pipelines. Constructed through the
+/// staged `describe → from_resolved` flow in `render_passes.rs` — bind
+/// groups in phase 1, the two pipelines through the cross-renderer pool.
+/// The cull dispatch itself is gated on `live_light_count() > 0` at frame
+/// time (see `render()`): it must run for directional-only scenes too, to
+/// clear the froxel counts the consumers still read; only truly light-free
+/// frames skip it.
 pub struct LightCullingRenderPass {
     pub bind_groups: LightCullingBindGroups,
     pub pipelines: LightCullingPipelines,
 }
 
 impl LightCullingRenderPass {
-    /// Creates the light culling render pass resources. Eager compile
-    /// — matches the existing scaffold and every other compute pass in
-    /// this codebase. The cull dispatch itself is gated on
-    /// `live_light_count() > 0` at frame time (see `render()`): it must
-    /// run for directional-only scenes too, to clear the froxel counts
-    /// the consumers still read; only truly light-free frames skip it.
-    pub async fn new(ctx: &mut RenderPassInitContext<'_>) -> Result<Self> {
-        let bind_groups = LightCullingBindGroups::new(ctx).await?;
-        let pipelines = LightCullingPipelines::new(ctx, &bind_groups).await?;
-        Ok(Self {
-            bind_groups,
-            pipelines,
-        })
-    }
-
     /// Executes the light culling pass.
     ///
     /// The dispatch may only be skipped when there are **no lights at

--- a/packages/crates/renderer/src/render_passes/material_decal/bind_group.rs
+++ b/packages/crates/renderer/src/render_passes/material_decal/bind_group.rs
@@ -35,7 +35,8 @@ impl MaterialDecalBindGroups {
         let TexturePoolDeps {
             bind_group_layout_key: texture_pool_layout_key,
             arrays_len: texture_pool_arrays_len,
-            sampler_keys,
+            samplers_len: texture_pool_samplers_len,
+            sampler_keys: _,
         } = TexturePoolDeps::new(ctx, TexturePoolVisibility::Compute)?;
 
         Ok(Self {
@@ -43,7 +44,7 @@ impl MaterialDecalBindGroups {
             main_layout_key_singlesampled,
             texture_pool_layout_key,
             texture_pool_arrays_len,
-            texture_pool_samplers_len: sampler_keys.len() as u32,
+            texture_pool_samplers_len,
             main_bind_group: None,
             texture_pool_bind_group: None,
         })
@@ -61,7 +62,8 @@ impl MaterialDecalBindGroups {
         let TexturePoolDeps {
             bind_group_layout_key: texture_pool_layout_key,
             arrays_len: texture_pool_arrays_len,
-            sampler_keys,
+            samplers_len: texture_pool_samplers_len,
+            sampler_keys: _,
         } = TexturePoolDeps::new(ctx, TexturePoolVisibility::Compute)?;
 
         Ok(Self {
@@ -69,7 +71,7 @@ impl MaterialDecalBindGroups {
             main_layout_key_singlesampled: self.main_layout_key_singlesampled,
             texture_pool_layout_key,
             texture_pool_arrays_len,
-            texture_pool_samplers_len: sampler_keys.len() as u32,
+            texture_pool_samplers_len,
             main_bind_group: self.main_bind_group.clone(),
             texture_pool_bind_group: None,
         })
@@ -177,11 +179,36 @@ impl MaterialDecalBindGroups {
                 BindGroupResource::TextureView(Cow::Borrowed(view)),
             ));
         }
+        // Pad texture slots up to the layout's tier with the placeholder
+        // view — the layout declares the tier, so every slot must bind.
+        let placeholder_view = ctx
+            .textures
+            .pool_placeholder_view()
+            .ok_or(AwsmBindGroupError::TexturePoolPlaceholderMissing("view"))?;
+        while entries.len() < self.texture_pool_arrays_len as usize {
+            entries.push(BindGroupEntry::new(
+                entries.len() as u32,
+                BindGroupResource::TextureView(Cow::Borrowed(placeholder_view)),
+            ));
+        }
         for sampler_key in ctx.textures.pool_sampler_set.iter() {
             let sampler = ctx.textures.get_sampler(*sampler_key)?;
             entries.push(BindGroupEntry::new(
                 entries.len() as u32,
                 BindGroupResource::Sampler(sampler),
+            ));
+        }
+        // Pad sampler slots up to the tier with the placeholder sampler.
+        let placeholder_sampler = ctx
+            .textures
+            .pool_placeholder_sampler()
+            .ok_or(AwsmBindGroupError::TexturePoolPlaceholderMissing("sampler"))?;
+        while entries.len()
+            < (self.texture_pool_arrays_len + self.texture_pool_samplers_len) as usize
+        {
+            entries.push(BindGroupEntry::new(
+                entries.len() as u32,
+                BindGroupResource::Sampler(placeholder_sampler),
             ));
         }
         let descriptor = BindGroupDescriptor::new(

--- a/packages/crates/renderer/src/render_passes/material_decal/render_pass.rs
+++ b/packages/crates/renderer/src/render_passes/material_decal/render_pass.rs
@@ -20,7 +20,10 @@ use crate::{
 pub struct MaterialDecalRenderPass {
     pub bind_groups: MaterialDecalBindGroups,
     pub pipelines: MaterialDecalPipelines,
-    pub composite: MaterialDecalComposite,
+    /// Deferred-boot: `None` until `ensure_config_pipelines` compiles the
+    /// two inline-WGSL composite pipelines (they're not part of the pooled
+    /// shader cache by design). Dispatch warn-skips while missing.
+    pub composite: Option<MaterialDecalComposite>,
     pub classify_pass: DecalClassifyRenderPass,
 }
 
@@ -28,7 +31,7 @@ impl MaterialDecalRenderPass {
     pub async fn new(ctx: &mut RenderPassInitContext<'_>) -> Result<Self> {
         let bind_groups = MaterialDecalBindGroups::new(ctx).await?;
         let pipelines = MaterialDecalPipelines::new(ctx, &bind_groups).await?;
-        let composite = MaterialDecalComposite::new(ctx).await?;
+        let composite = Some(MaterialDecalComposite::new(ctx).await?);
         let classify_pass = DecalClassifyRenderPass::new(ctx).await?;
         Ok(Self {
             bind_groups,
@@ -84,8 +87,12 @@ impl MaterialDecalRenderPass {
 
         // Composite pass — blit decal_color onto transparent. Cheap
         // fullscreen-tri with per-fragment discard; per-frame cost is
-        // negligible vs the compute that just ran.
-        self.composite.render(ctx)?;
+        // negligible vs the compute that just ran. `None` only between a
+        // runtime decal insert and the next commit's config ensure — skip
+        // (the decal simply doesn't composite that frame).
+        if let Some(composite) = self.composite.as_ref() {
+            composite.render(ctx)?;
+        }
 
         Ok(())
     }

--- a/packages/crates/renderer/src/render_passes/material_opaque/bind_group.rs
+++ b/packages/crates/renderer/src/render_passes/material_opaque/bind_group.rs
@@ -32,6 +32,7 @@ pub struct MaterialOpaqueBindGroups {
     pub texture_pool_textures_bind_group_layout_key: BindGroupLayoutKey,
     pub shadows_bind_group_layout_key: BindGroupLayoutKey,
     pub texture_pool_arrays_len: u32,
+    pub texture_pool_samplers_len: u32,
     pub texture_pool_sampler_keys: IndexSet<SamplerKey>,
     // this is set via `recreate` mechanism
     _main_bind_group: Option<web_sys::GpuBindGroup>,
@@ -118,6 +119,7 @@ impl MaterialOpaqueBindGroups {
         let TexturePoolDeps {
             bind_group_layout_key: texture_pool_textures_bind_group_layout_key,
             arrays_len: texture_pool_arrays_len,
+            samplers_len: texture_pool_samplers_len,
             sampler_keys: texture_pool_sampler_keys,
         } = TexturePoolDeps::new(ctx, TexturePoolVisibility::Compute)?;
 
@@ -128,6 +130,7 @@ impl MaterialOpaqueBindGroups {
             texture_pool_textures_bind_group_layout_key,
             shadows_bind_group_layout_key,
             texture_pool_arrays_len,
+            texture_pool_samplers_len,
             texture_pool_sampler_keys,
             _main_bind_group: None,
             _lights_bind_group: None,
@@ -144,6 +147,7 @@ impl MaterialOpaqueBindGroups {
         let TexturePoolDeps {
             bind_group_layout_key: texture_pool_textures_bind_group_layout_key,
             arrays_len: texture_pool_arrays_len,
+            samplers_len: texture_pool_samplers_len,
             sampler_keys: texture_pool_sampler_keys,
         } = TexturePoolDeps::new(ctx, TexturePoolVisibility::Compute)?;
 
@@ -154,6 +158,7 @@ impl MaterialOpaqueBindGroups {
             texture_pool_textures_bind_group_layout_key,
             shadows_bind_group_layout_key: self.shadows_bind_group_layout_key,
             texture_pool_arrays_len,
+            texture_pool_samplers_len,
             texture_pool_sampler_keys,
             _main_bind_group: self._main_bind_group.clone(),
             _lights_bind_group: self._lights_bind_group.clone(),
@@ -504,12 +509,39 @@ impl MaterialOpaqueBindGroups {
             ));
         }
 
+        // Pad texture slots up to the layout's tier with the placeholder
+        // view — the layout declares the tier, so every slot must bind.
+        let placeholder_view = ctx
+            .textures
+            .pool_placeholder_view()
+            .ok_or(AwsmBindGroupError::TexturePoolPlaceholderMissing("view"))?;
+        while entries.len() < self.texture_pool_arrays_len as usize {
+            entries.push(BindGroupEntry::new(
+                entries.len() as u32,
+                BindGroupResource::TextureView(Cow::Borrowed(placeholder_view)),
+            ));
+        }
+
         for sampler_key in self.texture_pool_sampler_keys.iter() {
             let sampler = ctx.textures.get_sampler(*sampler_key)?;
 
             entries.push(BindGroupEntry::new(
                 entries.len() as u32,
                 BindGroupResource::Sampler(sampler),
+            ));
+        }
+
+        // Pad sampler slots up to the tier with the placeholder sampler.
+        let placeholder_sampler = ctx
+            .textures
+            .pool_placeholder_sampler()
+            .ok_or(AwsmBindGroupError::TexturePoolPlaceholderMissing("sampler"))?;
+        while entries.len()
+            < (self.texture_pool_arrays_len + self.texture_pool_samplers_len) as usize
+        {
+            entries.push(BindGroupEntry::new(
+                entries.len() as u32,
+                BindGroupResource::Sampler(placeholder_sampler),
             ));
         }
 

--- a/packages/crates/renderer/src/render_passes/material_opaque/edge_pipeline.rs
+++ b/packages/crates/renderer/src/render_passes/material_opaque/edge_pipeline.rs
@@ -274,7 +274,7 @@ impl MaterialEdgePipelines {
         }
 
         let texture_pool_arrays_len = opaque_bind_groups.texture_pool_arrays_len;
-        let texture_pool_samplers_len = opaque_bind_groups.texture_pool_sampler_keys.len() as u32;
+        let texture_pool_samplers_len = opaque_bind_groups.texture_pool_samplers_len;
         let mipmaps = anti_aliasing.mipmap;
 
         // Build per-shader-id edge-resolve pipeline layout (reused

--- a/packages/crates/renderer/src/render_passes/material_opaque/pipeline.rs
+++ b/packages/crates/renderer/src/render_passes/material_opaque/pipeline.rs
@@ -229,7 +229,7 @@ impl MaterialOpaquePipelines {
         )?;
 
         let texture_pool_arrays_len = bind_groups.texture_pool_arrays_len;
-        let texture_pool_samplers_len = bind_groups.texture_pool_sampler_keys.len() as u32;
+        let texture_pool_samplers_len = bind_groups.texture_pool_samplers_len;
 
         let mut shader_descs: Vec<OpaqueShaderDesc> = Vec::with_capacity(OPAQUE_SHADER_IDS.len());
 

--- a/packages/crates/renderer/src/render_passes/material_opaque/shader/material_opaque_wgsl/helpers/material_color_calc.wgsl
+++ b/packages/crates/renderer/src/render_passes/material_opaque/shader/material_opaque_wgsl/helpers/material_color_calc.wgsl
@@ -395,17 +395,11 @@ fn _pbr_material_base_color{{ mipmap.suffix() }}(
     {% if mipmap.is_gradient() %}uv_derivs: UvDerivs,{% endif %}
 ) -> vec4<f32> {
     var color = material.base_color_factor;
-    // Compile-time feature gate: a feature-set without
-    // a base-color texture emits NO sampler load here, so the whole
-    // sample → multiply chain dead-code-eliminates (lower register
-    // pressure → higher occupancy). Pixel-equivalent: a material lacking
-    // the slot has `.exists == false` anyway.
-    {% if pbr_features.base_color_tex %}
-    if material.base_color_tex_info.exists {
-        let tex_sample = {{ mipmap.sample_fn() }}(material.base_color_tex_info, attribute_uv{% if mipmap.is_gradient() %}, uv_derivs{% endif %});
-        color *= tex_sample;
-    }
-    {% endif %}
+    // Branchless: an unbound slot packs the shared 1x1 NEUTRAL (white), so
+    // sampling always runs and multiplies by identity — exactly glTF's
+    // defined no-texture result. No feature gate, no exists check: texture
+    // binds are pure data and never re-key the pipeline.
+    color *= {{ mipmap.sample_fn() }}(material.base_color_tex_info, attribute_uv{% if mipmap.is_gradient() %}, uv_derivs{% endif %});
     // compute pass only deals with fully opaque
     // mask and blend are handled in the fragment shader
     color.a = 1.0;
@@ -419,13 +413,11 @@ fn _pbr_material_metallic_roughness_color{{ mipmap.suffix() }}(
     {% if mipmap.is_gradient() %}uv_derivs: UvDerivs,{% endif %}
 ) -> vec2<f32> {
     var color = vec2<f32>(material.metallic_factor, material.roughness_factor);
-    {% if pbr_features.metallic_roughness_tex %}
-    if material.metallic_roughness_tex_info.exists {
-        let tex = {{ mipmap.sample_fn() }}(material.metallic_roughness_tex_info, attribute_uv{% if mipmap.is_gradient() %}, uv_derivs{% endif %});
-        // glTF uses B channel for metallic, G channel for roughness
-        color *= vec2<f32>(tex.b, tex.g);
-    }
-    {% endif %}
+    // Branchless: unbound slot = the 1x1 NEUTRAL (white), so B/G multiply by
+    // identity — glTF's defined no-texture result.
+    let tex = {{ mipmap.sample_fn() }}(material.metallic_roughness_tex_info, attribute_uv{% if mipmap.is_gradient() %}, uv_derivs{% endif %});
+    // glTF uses B channel for metallic, G channel for roughness
+    color *= vec2<f32>(tex.b, tex.g);
     return color;
 }
 
@@ -437,25 +429,20 @@ fn _pbr_normal_color{{ mipmap.suffix() }}(
     {% if mipmap.is_gradient() %}uv_derivs: UvDerivs,{% endif %}
     geometry_tbn: TBN,
 ) -> vec3<f32> {
-    // Compile-time gate: a feature-set without a normal map emits none of
-    // the sampler load / TBN transform — it just returns the geometry
-    // normal. Equivalent to the absent-texture runtime path.
-    {% if pbr_features.normal_tex %}
-    if material.normal_tex_info.exists {
-        // Sample normal map and unpack from [0,1] to [-1,1] range
-        let tex = {{ mipmap.sample_fn() }}(material.normal_tex_info, attribute_uv{% if mipmap.is_gradient() %}, uv_derivs{% endif %});
-        let tangent_normal = vec3<f32>(
-            (tex.r * 2.0 - 1.0) * material.normal_scale,
-            (tex.g * 2.0 - 1.0) * material.normal_scale,
-            tex.b * 2.0 - 1.0,
-        );
+    // Branchless: unbound slot = the 1x1 NEUTRAL flat normal (0.5, 0.5, 1),
+    // which unpacks to tangent (0,0,1) — and TBN * (0,0,1) is exactly the
+    // geometry normal, glTF's defined no-normal-map result.
+    // Sample normal map and unpack from [0,1] to [-1,1] range
+    let tex = {{ mipmap.sample_fn() }}(material.normal_tex_info, attribute_uv{% if mipmap.is_gradient() %}, uv_derivs{% endif %});
+    let tangent_normal = vec3<f32>(
+        (tex.r * 2.0 - 1.0) * material.normal_scale,
+        (tex.g * 2.0 - 1.0) * material.normal_scale,
+        tex.b * 2.0 - 1.0,
+    );
 
-        // Transform the tangent-space normal to world space using the TBN matrix from geometry pass
-        let tbn_matrix = mat3x3<f32>(geometry_tbn.T, geometry_tbn.B, geometry_tbn.N);
-        return normalize(tbn_matrix * tangent_normal);
-    }
-    {% endif %}
-    return geometry_tbn.N;
+    // Transform the tangent-space normal to world space using the TBN matrix from geometry pass
+    let tbn_matrix = mat3x3<f32>(geometry_tbn.T, geometry_tbn.B, geometry_tbn.N);
+    return normalize(tbn_matrix * tangent_normal);
 }
 
 // Occlusion
@@ -464,13 +451,10 @@ fn _pbr_occlusion_color{{ mipmap.suffix() }}(
     attribute_uv: vec2<f32>,
     {% if mipmap.is_gradient() %}uv_derivs: UvDerivs,{% endif %}
 ) -> f32 {
-    var occlusion = 1.0;
-    {% if pbr_features.occlusion_tex %}
-    if material.occlusion_tex_info.exists {
-        let tex = {{ mipmap.sample_fn() }}(material.occlusion_tex_info, attribute_uv{% if mipmap.is_gradient() %}, uv_derivs{% endif %});
-        occlusion = mix(1.0, tex.r, material.occlusion_strength);
-    }
-    {% endif %}
+    // Branchless: unbound slot = the 1x1 NEUTRAL (white), so
+    // mix(1, 1, strength) == 1 — glTF's defined no-occlusion-map result.
+    let tex = {{ mipmap.sample_fn() }}(material.occlusion_tex_info, attribute_uv{% if mipmap.is_gradient() %}, uv_derivs{% endif %});
+    let occlusion = mix(1.0, tex.r, material.occlusion_strength);
     return occlusion;
 }
 
@@ -482,11 +466,8 @@ fn _pbr_material_emissive_color{{ mipmap.suffix() }}(
     {% if mipmap.is_gradient() %}uv_derivs: UvDerivs,{% endif %}
 ) -> vec3<f32> {
     var color = material.emissive_factor;
-    {% if pbr_features.emissive_tex %}
-    if material.emissive_tex_info.exists {
-        color *= {{ mipmap.sample_fn() }}(material.emissive_tex_info, attribute_uv{% if mipmap.is_gradient() %}, uv_derivs{% endif %}).rgb;
-    }
-    {% endif %}
+    // Branchless: unbound slot = the 1x1 NEUTRAL (white) — identity multiply.
+    color *= {{ mipmap.sample_fn() }}(material.emissive_tex_info, attribute_uv{% if mipmap.is_gradient() %}, uv_derivs{% endif %}).rgb;
     color *= emissive_strength;
     return color;
 }

--- a/packages/crates/renderer/src/render_passes/material_prep/mod.rs
+++ b/packages/crates/renderer/src/render_passes/material_prep/mod.rs
@@ -60,17 +60,25 @@ pub struct PrepPassConfig {
     /// params stay live uniforms in `ShadowsConfig` / `ShadowGlobals`.
     pub sscs_enabled: bool,
     pub sscs_step_count: u32,
+    /// `ShadowsConfig::denoise`, mirrored here (kept in sync by
+    /// `AwsmRenderer::set_shadows_config`) because it gates which prep
+    /// pipelines exist at all: the `cs_blur_h`/`cs_blur_v` pair is only
+    /// compiled while denoise is on. A runtime enable flags the same
+    /// "re-ensure on next commit" path the SSCS fields use; until that runs,
+    /// `render_blur` warn-skips.
+    pub denoise: bool,
 }
 
 impl Default for PrepPassConfig {
     fn default() -> Self {
         Self {
             max_shadow_casters_per_pixel: 4,
-            // Match `ShadowsConfig::default()` (SSCS off; 16-step march) so the
-            // initial pipeline build and the shadow config agree before any
-            // `set_shadows_config` sync runs.
+            // Match `ShadowsConfig::default()` (SSCS off; 16-step march;
+            // denoise on) so the initial pipeline build and the shadow config
+            // agree before any `set_shadows_config` sync runs.
             sscs_enabled: false,
             sscs_step_count: 16,
+            denoise: true,
         }
     }
 }

--- a/packages/crates/renderer/src/render_passes/material_prep/render_pass.rs
+++ b/packages/crates/renderer/src/render_passes/material_prep/render_pass.rs
@@ -4,12 +4,23 @@
 //! A static compute pass (mirrors [`crate::render_passes::light_culling`]): runs
 //! once per pixel over the visibility buffer, after classify and before
 //! per-material shading, materializing the material-INDEPENDENT geometry-pool
-//! attributes (UV0 + vertex color) into the prep output storage textures. There
-//! are exactly two pipeline variants — multisampled-geometry on/off — both built
-//! up-front so an MSAA change needs only a bind-group rebuild, not a recompile.
+//! attributes (UV0 + vertex color) into the prep output storage textures.
 //!
-//! The prep pass is unconditional — always constructed and dispatched. The
-//! opaque deferred path reads its outputs.
+//! **Lazy-pool, active-branch-only.** The prep megashader is the single most
+//! expensive compile in the renderer (~1s per pipeline on a cold cache), so
+//! only the pipelines the LIVE config can dispatch are compiled at boot,
+//! through the cross-renderer pool (`describe → from_resolved`, like the
+//! geometry/classify passes):
+//! - `cs_prep` for the active MSAA-geometry branch only;
+//! - `cs_prep_edge` only under MSAA on a device with edge-resolve support;
+//! - the denoise blur pair only while `ShadowsConfig::denoise` is on.
+//!
+//! The other MSAA branch compiles on the first `set_anti_aliasing` flip (which
+//! is already a modal-covered, material-recompiling operation); a runtime
+//! denoise enable compiles the blur pair through the same config-ensure path.
+//!
+//! The prep pass itself is unconditional — always constructed and dispatched.
+//! The opaque deferred path reads its outputs.
 
 use std::borrow::Cow;
 
@@ -33,85 +44,246 @@ use crate::{
     },
 };
 
-/// Material prep pass bind groups + the two compiled (MSAA on/off) pipelines.
+/// Which prep pipeline a pooled cache-key slot resolves to. Parallel to the
+/// `pipeline_cache_keys` vec in [`MaterialPrepPrewarmDescriptors`] — the same
+/// routing trick the classify/HZB passes use so `merge_resolved` can drop each
+/// compiled key into the right [`MaterialPrepPipelines`] field.
+#[derive(Clone, Copy, Debug)]
+pub enum PrepPipelineSlot {
+    /// `cs_prep` for one MSAA-geometry branch.
+    Main { multisampled: bool },
+    /// `cs_prep_edge` (multisampled main layout + edge group(3)). MSAA-only.
+    Edge,
+    /// `cs_blur_h` for one MSAA-geometry branch.
+    BlurH { multisampled: bool },
+    /// `cs_blur_v` for one MSAA-geometry branch.
+    BlurV { multisampled: bool },
+}
+
+/// Phase-2 output of [`MaterialPrepPipelines::build_descriptors`]: the pooled
+/// compute cache keys + the slot each resolves to.
+pub struct MaterialPrepPrewarmDescriptors {
+    pub pipeline_cache_keys: Vec<ComputePipelineCacheKey>,
+    pub slots: Vec<PrepPipelineSlot>,
+}
+
+/// The prep pass's compiled pipelines, branch-keyed. Every field is an
+/// `Option`: only the live config's branch is compiled at boot (through the
+/// cross-renderer pool); the other MSAA branch fills on the first
+/// `set_anti_aliasing` flip, and the blur pair only exists while denoise is
+/// configured on. `merge_resolved` preserves already-populated fields, so a
+/// flip-back is a cache hit, never a loss.
+#[derive(Default)]
+pub struct MaterialPrepPipelines {
+    multisampled: Option<ComputePipelineKey>,
+    singlesampled: Option<ComputePipelineKey>,
+    edge: Option<ComputePipelineKey>,
+    blur_h_multisampled: Option<ComputePipelineKey>,
+    blur_h_singlesampled: Option<ComputePipelineKey>,
+    blur_v_multisampled: Option<ComputePipelineKey>,
+    blur_v_singlesampled: Option<ComputePipelineKey>,
+}
+
+impl MaterialPrepPipelines {
+    /// The shader cache keys the ACTIVE config's prep pipelines need — pooled
+    /// into the cross-renderer `Shaders::ensure_keys` batch by
+    /// `RenderPasses::describe_shaders`. One prep megashader module covers
+    /// both `cs_prep` and `cs_prep_edge` (same cache key); the blur module is
+    /// separate and only needed while denoise is on.
+    pub fn shader_cache_keys(
+        multisampled_geometry: bool,
+        prep_config: &crate::render_passes::material_prep::PrepPassConfig,
+    ) -> Vec<crate::shaders::ShaderCacheKey> {
+        let msaa_sample_count = if multisampled_geometry { Some(4) } else { None };
+        let mut keys: Vec<crate::shaders::ShaderCacheKey> = vec![ShaderCacheKeyMaterialPrep {
+            msaa_sample_count,
+            max_shadow_casters: prep_config.clamped_k(),
+            sscs_enabled: prep_config.sscs_enabled,
+            sscs_step_count: prep_config.sscs_step_count,
+        }
+        .into()];
+        if prep_config.denoise {
+            keys.push(
+                ShaderCacheKeyShadowBlur {
+                    msaa_sample_count,
+                    max_shadow_casters: prep_config.clamped_k(),
+                }
+                .into(),
+            );
+        }
+        keys
+    }
+
+    /// Build the pooled pipeline cache keys for ONE MSAA-geometry branch of
+    /// the current `ctx.prep_config`. Shared by the boot orchestrator (active
+    /// branch) and `set_anti_aliasing` (incoming branch). Sync apart from
+    /// cache-hit `shaders.get_key` awaits — the shader modules are already
+    /// warm from the pooled shader batch.
+    ///
+    /// `edge_resolve_enabled` gates `cs_prep_edge` (multisampled branch only —
+    /// its layout binds the multisampled main BGL); the blur pair is gated on
+    /// `prep_config.denoise`.
+    pub async fn build_descriptors_for_config(
+        ctx: &mut RenderPassInitContext<'_>,
+        bind_groups: &MaterialPrepBindGroups,
+        multisampled_geometry: bool,
+        edge_resolve_enabled: bool,
+    ) -> Result<MaterialPrepPrewarmDescriptors> {
+        let mut pipeline_cache_keys = Vec::new();
+        let mut slots = Vec::new();
+
+        pipeline_cache_keys.push(main_cache_key(ctx, bind_groups, multisampled_geometry).await?);
+        slots.push(PrepPipelineSlot::Main {
+            multisampled: multisampled_geometry,
+        });
+
+        if multisampled_geometry && edge_resolve_enabled {
+            pipeline_cache_keys.push(edge_cache_key(ctx, bind_groups).await?);
+            slots.push(PrepPipelineSlot::Edge);
+        }
+
+        if ctx.prep_config.denoise {
+            pipeline_cache_keys.push(
+                blur_cache_key(ctx, bind_groups, multisampled_geometry, "cs_blur_h").await?,
+            );
+            slots.push(PrepPipelineSlot::BlurH {
+                multisampled: multisampled_geometry,
+            });
+            pipeline_cache_keys.push(
+                blur_cache_key(ctx, bind_groups, multisampled_geometry, "cs_blur_v").await?,
+            );
+            slots.push(PrepPipelineSlot::BlurV {
+                multisampled: multisampled_geometry,
+            });
+        }
+
+        Ok(MaterialPrepPrewarmDescriptors {
+            pipeline_cache_keys,
+            slots,
+        })
+    }
+
+    /// Route resolved pipeline keys into their branch fields. Preserves
+    /// already-populated fields not mentioned in `slots` (the lazy-branch
+    /// merge contract, mirroring `GeometryPipelines::merge_resolved`).
+    pub fn merge_resolved(&mut self, slots: &[PrepPipelineSlot], keys: Vec<ComputePipelineKey>) {
+        debug_assert_eq!(slots.len(), keys.len());
+        for (slot, key) in slots.iter().zip(keys) {
+            match slot {
+                PrepPipelineSlot::Main { multisampled: true } => self.multisampled = Some(key),
+                PrepPipelineSlot::Main {
+                    multisampled: false,
+                } => self.singlesampled = Some(key),
+                PrepPipelineSlot::Edge => self.edge = Some(key),
+                PrepPipelineSlot::BlurH { multisampled: true } => {
+                    self.blur_h_multisampled = Some(key)
+                }
+                PrepPipelineSlot::BlurH {
+                    multisampled: false,
+                } => self.blur_h_singlesampled = Some(key),
+                PrepPipelineSlot::BlurV { multisampled: true } => {
+                    self.blur_v_multisampled = Some(key)
+                }
+                PrepPipelineSlot::BlurV {
+                    multisampled: false,
+                } => self.blur_v_singlesampled = Some(key),
+            }
+        }
+    }
+
+    /// Whether everything the given config needs is already compiled — the
+    /// `set_anti_aliasing` / config-ensure guard that makes a flip-back a
+    /// no-op (mirrors `GeometryPipelines::has_branch_for`).
+    pub fn has_branch_for(
+        &self,
+        multisampled_geometry: bool,
+        edge_resolve_enabled: bool,
+        denoise: bool,
+    ) -> bool {
+        let main = if multisampled_geometry {
+            self.multisampled.is_some()
+        } else {
+            self.singlesampled.is_some()
+        };
+        let edge = !(multisampled_geometry && edge_resolve_enabled) || self.edge.is_some();
+        let blur = !denoise
+            || if multisampled_geometry {
+                self.blur_h_multisampled.is_some() && self.blur_v_multisampled.is_some()
+            } else {
+                self.blur_h_singlesampled.is_some() && self.blur_v_singlesampled.is_some()
+            };
+        main && edge && blur
+    }
+}
+
+/// Material prep pass bind groups + the branch-keyed compiled pipelines.
 pub struct MaterialPrepRenderPass {
     pub bind_groups: MaterialPrepBindGroups,
-    /// Compiled `cs_prep` pipeline for the multisampled-geometry variant.
-    pub multisampled_pipeline_key: ComputePipelineKey,
-    /// Compiled `cs_prep` pipeline for the single-sample variant.
-    pub singlesampled_pipeline_key: ComputePipelineKey,
-    /// Stage 5b-shadow: `cs_prep_edge` pipeline (MSAA only — `None` otherwise).
-    /// Indirect-dispatched over `edge_count`, filling `edge_shadow` so the MSAA
-    /// `cs_edge` reads per-edge-sample shadow visibility instead of inline
-    /// sampling.
-    pub edge_pipeline_key: Option<ComputePipelineKey>,
+    pub pipelines: MaterialPrepPipelines,
     /// Stage 5b-shadow: the compact per-edge-sample shadow texture cs_prep_edge
-    /// writes + cs_edge reads. `None` when not MSAA.
+    /// writes + cs_edge reads. `Some` only under MSAA on a device with
+    /// edge-resolve support (~8 MB — allocated on the MSAA-on flip, dropped on
+    /// MSAA-off, mirroring `material_edge_buffers`).
     pub edge_shadow: Option<EdgeShadowBuffer>,
-    /// Optional shadow-denoise blur pipelines (`cs_blur_h` / `cs_blur_v`), one
-    /// per MSAA-geometry variant. Built eagerly; dispatched by `render_blur`
-    /// only when the runtime `ShadowsConfig::denoise` toggle is on.
-    blur_h_multisampled_pipeline_key: ComputePipelineKey,
-    blur_h_singlesampled_pipeline_key: ComputePipelineKey,
-    blur_v_multisampled_pipeline_key: ComputePipelineKey,
-    blur_v_singlesampled_pipeline_key: ComputePipelineKey,
+    /// One-shot "blur pipelines not compiled yet" warning latch (mirrors the
+    /// shadow pass's `warn_pipeline_not_compiled` discipline): a runtime
+    /// denoise enable is only picked up by the next config-ensure/commit, so
+    /// the frames in between skip the blur with a single warn instead of
+    /// erroring the whole frame.
+    blur_warned: std::cell::Cell<bool>,
 }
 
 impl MaterialPrepRenderPass {
-    /// Creates the prep render pass resources. Eager compile of both MSAA
-    /// variants — matches the static-compute-pass convention
-    /// ([`crate::render_passes::light_culling`]). Always called (prep is
-    /// unconditional).
-    pub async fn new(ctx: &mut RenderPassInitContext<'_>) -> Result<Self> {
-        let bind_groups = MaterialPrepBindGroups::new(ctx).await?;
-        let multisampled_pipeline_key = build_pipeline(ctx, &bind_groups, true).await?;
-        let singlesampled_pipeline_key = build_pipeline(ctx, &bind_groups, false).await?;
-
-        // Stage 5b-shadow: the cs_prep_edge pipeline + compact edge-shadow
-        // texture. Built eagerly (not gated on build-time MSAA) so an
-        // `set_anti_aliasing(off → on)` flip finds them ready — the cs_prep_edge
-        // pipeline shares the always-built multisampled main layout, and the
-        // texture costs ~8 MB. `render_edge` only dispatches when the edge
-        // buffers exist (MSAA on), so this is inert otherwise. The texture is
-        // sized from the resolved edge budget; layers = ceil(K/4).
-        let edge_pipeline_key = Some(build_edge_pipeline(ctx, &bind_groups).await?);
-        let edge_shadow = Some(EdgeShadowBuffer::new(
-            ctx.gpu,
-            ctx.max_edge_budget,
-            ctx.prep_config.shadow_visibility_layers(),
-        )?);
-
-        let blur_h_multisampled_pipeline_key =
-            build_blur_pipeline(ctx, &bind_groups, true, "cs_blur_h").await?;
-        let blur_h_singlesampled_pipeline_key =
-            build_blur_pipeline(ctx, &bind_groups, false, "cs_blur_h").await?;
-        let blur_v_multisampled_pipeline_key =
-            build_blur_pipeline(ctx, &bind_groups, true, "cs_blur_v").await?;
-        let blur_v_singlesampled_pipeline_key =
-            build_blur_pipeline(ctx, &bind_groups, false, "cs_blur_v").await?;
-
-        Ok(Self {
+    /// Assemble the pass from staged parts (bind groups from
+    /// `describe_shaders`, pipelines merged from the cross-renderer pool,
+    /// edge-shadow texture allocated by `describe_pipelines` when gated in).
+    pub fn from_resolved(
+        bind_groups: MaterialPrepBindGroups,
+        pipelines: MaterialPrepPipelines,
+        edge_shadow: Option<EdgeShadowBuffer>,
+    ) -> Self {
+        Self {
             bind_groups,
-            multisampled_pipeline_key,
-            singlesampled_pipeline_key,
-            edge_pipeline_key,
+            pipelines,
             edge_shadow,
-            blur_h_multisampled_pipeline_key,
-            blur_h_singlesampled_pipeline_key,
-            blur_v_multisampled_pipeline_key,
-            blur_v_singlesampled_pipeline_key,
-        })
+            blur_warned: std::cell::Cell::new(false),
+        }
+    }
+
+    /// Stage 5b-shadow: allocate the compact edge-shadow texture if absent
+    /// (the MSAA-on flip path). No-op when already allocated.
+    pub fn ensure_edge_shadow(
+        &mut self,
+        gpu: &awsm_renderer_core::renderer::AwsmRendererWebGpu,
+        max_edge_budget: u32,
+        layers: u32,
+    ) -> Result<()> {
+        if self.edge_shadow.is_none() {
+            self.edge_shadow = Some(EdgeShadowBuffer::new(gpu, max_edge_budget, layers)?);
+        }
+        Ok(())
+    }
+
+    /// Stage 5b-shadow: drop the compact edge-shadow texture (the MSAA-off
+    /// flip path — mirrors `material_edge_buffers` teardown; the ~8 MB
+    /// texture is pure waste while single-sampled).
+    pub fn drop_edge_shadow(&mut self) {
+        self.edge_shadow = None;
     }
 
     /// Dispatches the prep shader: one workgroup per 8×8 tile of the
     /// visibility buffer. Picks the pipeline variant matching the live MSAA
-    /// state.
+    /// state — which MUST be compiled (boot compiles the active branch;
+    /// `set_anti_aliasing` compiles the incoming one before flipping).
     pub fn render(&self, ctx: &RenderContext) -> Result<()> {
         let pipeline_key = if ctx.anti_aliasing.msaa_sample_count.is_some() {
-            self.multisampled_pipeline_key
+            self.pipelines.multisampled
         } else {
-            self.singlesampled_pipeline_key
+            self.pipelines.singlesampled
         };
+        let pipeline_key = pipeline_key.ok_or(crate::error::AwsmError::PipelineVariantNotCompiled(
+            "material prep pipeline for the live MSAA branch (set_anti_aliasing must compile the incoming branch before flipping)",
+        ))?;
         let pipeline = ctx.pipelines.compute.get(pipeline_key)?;
         let bind_group = self.bind_groups.get_bind_group()?;
         let lights_bind_group = self.bind_groups.get_lights_bind_group()?;
@@ -173,20 +345,31 @@ impl MaterialPrepRenderPass {
         if ctx.anti_aliasing.msaa_sample_count.is_none() {
             return Ok(());
         }
-        let (edge_pipeline_key, edge_shadow) =
-            match (self.edge_pipeline_key, self.edge_shadow.as_ref()) {
-                (Some(k), Some(b)) => (k, b),
-                _ => return Ok(()),
-            };
-        let edge_bgl_key = match self.bind_groups.edge_bind_group_layout_key {
-            Some(k) => k,
-            None => return Ok(()),
-        };
+        // Edge buffers exist ⟺ MSAA-on AND the device supports edge resolve
+        // (see `set_anti_aliasing`) — absent means this frame legitimately has
+        // no edge-resolve path, so skip.
         let (edge_buffers, edge_layout_uniform) =
             match (ctx.material_edge_buffers, ctx.material_edge_layout_uniform) {
                 (Some(b), Some(u)) => (b, u),
                 _ => return Ok(()),
             };
+        // Past this point the edge path IS live — a missing pipeline/texture is
+        // a broken invariant (cs_edge reads the compact texture this dispatch
+        // fills; skipping silently would shade edges with garbage shadows).
+        let edge_pipeline_key = self.pipelines.edge.ok_or(
+            crate::error::AwsmError::PipelineVariantNotCompiled(
+                "cs_prep_edge (edge buffers live but the edge prep pipeline never compiled)",
+            ),
+        )?;
+        let edge_shadow = self.edge_shadow.as_ref().ok_or(
+            crate::error::AwsmError::PipelineVariantNotCompiled(
+                "edge-shadow texture (edge buffers live but the compact texture never allocated)",
+            ),
+        )?;
+        let edge_bgl_key = match self.bind_groups.edge_bind_group_layout_key {
+            Some(k) => k,
+            None => return Ok(()),
+        };
 
         let pipeline = ctx.pipelines.compute.get(edge_pipeline_key)?;
         let bind_group = self.bind_groups.get_bind_group()?;
@@ -254,17 +437,34 @@ impl MaterialPrepRenderPass {
             return Ok(());
         }
         let msaa = ctx.anti_aliasing.msaa_sample_count.is_some();
-        let (h_key, v_key) = if msaa {
+        let keys = if msaa {
             (
-                self.blur_h_multisampled_pipeline_key,
-                self.blur_v_multisampled_pipeline_key,
+                self.pipelines.blur_h_multisampled,
+                self.pipelines.blur_v_multisampled,
             )
         } else {
             (
-                self.blur_h_singlesampled_pipeline_key,
-                self.blur_v_singlesampled_pipeline_key,
+                self.pipelines.blur_h_singlesampled,
+                self.pipelines.blur_v_singlesampled,
             )
         };
+        let (h_key, v_key) = match keys {
+            (Some(h), Some(v)) => (h, v),
+            _ => {
+                // Denoise was enabled at runtime and the config-ensure that
+                // compiles the blur pair hasn't run yet — skip the blur (the
+                // un-denoised visibility is still correct) with a one-shot
+                // warn, mirroring the shadow pass's not-compiled discipline.
+                if !self.blur_warned.replace(true) {
+                    tracing::warn!(
+                        "shadow denoise blur pipelines not compiled for the live MSAA branch — \
+                         skipping the blur until the next commit_load / config ensure"
+                    );
+                }
+                return Ok(());
+            }
+        };
+        self.blur_warned.set(false);
         let h_pipeline = ctx.pipelines.compute.get(h_key)?;
         let v_pipeline = ctx.pipelines.compute.get(v_key)?;
         let h_bind_group = self.bind_groups.get_blur_h_bind_group()?;
@@ -297,12 +497,14 @@ impl MaterialPrepRenderPass {
     }
 }
 
-/// Builds the `cs_prep` pipeline for one MSAA-geometry variant.
-async fn build_pipeline(
+/// Derives the `cs_prep` pipeline CACHE KEY for one MSAA-geometry variant —
+/// no compile; the key joins the cross-renderer pool. The `shaders.get_key`
+/// await is a cache hit (the pooled shader batch ran first).
+async fn main_cache_key(
     ctx: &mut RenderPassInitContext<'_>,
     bind_groups: &MaterialPrepBindGroups,
     multisampled_geometry: bool,
-) -> Result<ComputePipelineKey> {
+) -> Result<ComputePipelineCacheKey> {
     let bgl_key = if multisampled_geometry {
         bind_groups.multisampled_bind_group_layout_key
     } else {
@@ -329,28 +531,18 @@ async fn build_pipeline(
             },
         )
         .await?;
-    let pipeline_key = ctx
-        .pipelines
-        .compute
-        .get_key(
-            ctx.gpu,
-            ctx.shaders,
-            ctx.pipeline_layouts,
-            ComputePipelineCacheKey::new(shader_key, pipeline_layout_key)
-                .with_entry_point("cs_prep"),
-        )
-        .await?;
-    Ok(pipeline_key)
+    Ok(ComputePipelineCacheKey::new(shader_key, pipeline_layout_key).with_entry_point("cs_prep"))
 }
 
-/// Stage 5b-shadow: builds the `cs_prep_edge` pipeline (MSAA only). Shares the
-/// MSAA prep shader module (same cache key as the multisampled `cs_prep`); its
-/// pipeline layout adds group(3) = the edge layout (edge_data + edge_layout +
-/// edge_shadow_out) on top of the multisampled main + lights + shadows groups.
-async fn build_edge_pipeline(
+/// Stage 5b-shadow: derives the `cs_prep_edge` pipeline CACHE KEY (MSAA only).
+/// Shares the MSAA prep shader module (same cache key as the multisampled
+/// `cs_prep`); its pipeline layout adds group(3) = the edge layout (edge_data +
+/// edge_layout + edge_shadow_out) on top of the multisampled main + lights +
+/// shadows groups.
+async fn edge_cache_key(
     ctx: &mut RenderPassInitContext<'_>,
     bind_groups: &MaterialPrepBindGroups,
-) -> Result<ComputePipelineKey> {
+) -> Result<ComputePipelineCacheKey> {
     let edge_bgl_key = bind_groups
         .edge_bind_group_layout_key
         .expect("edge bind group layout must exist under MSAA");
@@ -376,31 +568,23 @@ async fn build_edge_pipeline(
             },
         )
         .await?;
-    let pipeline_key = ctx
-        .pipelines
-        .compute
-        .get_key(
-            ctx.gpu,
-            ctx.shaders,
-            ctx.pipeline_layouts,
-            ComputePipelineCacheKey::new(shader_key, pipeline_layout_key)
-                .with_entry_point("cs_prep_edge"),
-        )
-        .await?;
-    Ok(pipeline_key)
+    Ok(
+        ComputePipelineCacheKey::new(shader_key, pipeline_layout_key)
+            .with_entry_point("cs_prep_edge"),
+    )
 }
 
-/// Builds one shadow-denoise blur pipeline (`entry_point` = `cs_blur_h` or
-/// `cs_blur_v`) for one MSAA-geometry variant. Both entry points share the one
-/// blur shader module (same `ShaderCacheKeyShadowBlur`); only the pipeline's
-/// entry point + the H/V bind group differ. Pipeline layout = the single blur
-/// bind group at group(0).
-async fn build_blur_pipeline(
+/// Derives one shadow-denoise blur pipeline CACHE KEY (`entry_point` =
+/// `cs_blur_h` or `cs_blur_v`) for one MSAA-geometry variant. Both entry
+/// points share the one blur shader module (same `ShaderCacheKeyShadowBlur`);
+/// only the pipeline's entry point + the H/V bind group differ. Pipeline
+/// layout = the single blur bind group at group(0).
+async fn blur_cache_key(
     ctx: &mut RenderPassInitContext<'_>,
     bind_groups: &MaterialPrepBindGroups,
     multisampled_geometry: bool,
     entry_point: &str,
-) -> Result<ComputePipelineKey> {
+) -> Result<ComputePipelineCacheKey> {
     let bgl_key = if multisampled_geometry {
         bind_groups.blur_multisampled_bind_group_layout_key
     } else {
@@ -421,16 +605,5 @@ async fn build_blur_pipeline(
             },
         )
         .await?;
-    let pipeline_key = ctx
-        .pipelines
-        .compute
-        .get_key(
-            ctx.gpu,
-            ctx.shaders,
-            ctx.pipeline_layouts,
-            ComputePipelineCacheKey::new(shader_key, pipeline_layout_key)
-                .with_entry_point(entry_point),
-        )
-        .await?;
-    Ok(pipeline_key)
+    Ok(ComputePipelineCacheKey::new(shader_key, pipeline_layout_key).with_entry_point(entry_point))
 }

--- a/packages/crates/renderer/src/render_passes/material_prep/render_pass.rs
+++ b/packages/crates/renderer/src/render_passes/material_prep/render_pass.rs
@@ -143,15 +143,13 @@ impl MaterialPrepPipelines {
         }
 
         if ctx.prep_config.denoise {
-            pipeline_cache_keys.push(
-                blur_cache_key(ctx, bind_groups, multisampled_geometry, "cs_blur_h").await?,
-            );
+            pipeline_cache_keys
+                .push(blur_cache_key(ctx, bind_groups, multisampled_geometry, "cs_blur_h").await?);
             slots.push(PrepPipelineSlot::BlurH {
                 multisampled: multisampled_geometry,
             });
-            pipeline_cache_keys.push(
-                blur_cache_key(ctx, bind_groups, multisampled_geometry, "cs_blur_v").await?,
-            );
+            pipeline_cache_keys
+                .push(blur_cache_key(ctx, bind_groups, multisampled_geometry, "cs_blur_v").await?);
             slots.push(PrepPipelineSlot::BlurV {
                 multisampled: multisampled_geometry,
             });
@@ -356,16 +354,18 @@ impl MaterialPrepRenderPass {
         // Past this point the edge path IS live — a missing pipeline/texture is
         // a broken invariant (cs_edge reads the compact texture this dispatch
         // fills; skipping silently would shade edges with garbage shadows).
-        let edge_pipeline_key = self.pipelines.edge.ok_or(
-            crate::error::AwsmError::PipelineVariantNotCompiled(
-                "cs_prep_edge (edge buffers live but the edge prep pipeline never compiled)",
-            ),
-        )?;
-        let edge_shadow = self.edge_shadow.as_ref().ok_or(
-            crate::error::AwsmError::PipelineVariantNotCompiled(
+        let edge_pipeline_key =
+            self.pipelines
+                .edge
+                .ok_or(crate::error::AwsmError::PipelineVariantNotCompiled(
+                    "cs_prep_edge (edge buffers live but the edge prep pipeline never compiled)",
+                ))?;
+        let edge_shadow =
+            self.edge_shadow
+                .as_ref()
+                .ok_or(crate::error::AwsmError::PipelineVariantNotCompiled(
                 "edge-shadow texture (edge buffers live but the compact texture never allocated)",
-            ),
-        )?;
+            ))?;
         let edge_bgl_key = match self.bind_groups.edge_bind_group_layout_key {
             Some(k) => k,
             None => return Ok(()),

--- a/packages/crates/renderer/src/render_passes/material_transparent/bind_group.rs
+++ b/packages/crates/renderer/src/render_passes/material_transparent/bind_group.rs
@@ -36,6 +36,7 @@ pub struct MaterialTransparentBindGroups {
     pub texture_pool_textures_bind_group_layout_key: BindGroupLayoutKey,
     pub shadows_bind_group_layout_key: BindGroupLayoutKey,
     pub texture_pool_arrays_len: u32,
+    pub texture_pool_samplers_len: u32,
     pub texture_pool_sampler_keys: IndexSet<SamplerKey>,
 
     _main_bind_group: Option<web_sys::GpuBindGroup>,
@@ -50,6 +51,7 @@ impl MaterialTransparentBindGroups {
         let TexturePoolDeps {
             bind_group_layout_key: texture_pool_textures_bind_group_layout_key,
             arrays_len: texture_pool_arrays_len,
+            samplers_len: texture_pool_samplers_len,
             sampler_keys: texture_pool_sampler_keys,
         } = TexturePoolDeps::new(ctx, TexturePoolVisibility::Render)?;
 
@@ -323,6 +325,7 @@ impl MaterialTransparentBindGroups {
             texture_pool_textures_bind_group_layout_key,
             shadows_bind_group_layout_key,
             texture_pool_arrays_len,
+            texture_pool_samplers_len,
             texture_pool_sampler_keys,
 
             _main_bind_group: None,
@@ -340,6 +343,7 @@ impl MaterialTransparentBindGroups {
         let TexturePoolDeps {
             bind_group_layout_key: texture_pool_textures_bind_group_layout_key,
             arrays_len: texture_pool_arrays_len,
+            samplers_len: texture_pool_samplers_len,
             sampler_keys: texture_pool_sampler_keys,
         } = TexturePoolDeps::new(ctx, TexturePoolVisibility::Render)?;
 
@@ -349,6 +353,7 @@ impl MaterialTransparentBindGroups {
             texture_pool_textures_bind_group_layout_key,
             shadows_bind_group_layout_key: self.shadows_bind_group_layout_key,
             texture_pool_arrays_len,
+            texture_pool_samplers_len,
             texture_pool_sampler_keys,
             _main_bind_group: self._main_bind_group.clone(),
             _mesh_material_bind_group: self._mesh_material_bind_group.clone(),
@@ -621,12 +626,39 @@ impl MaterialTransparentBindGroups {
             ));
         }
 
+        // Pad texture slots up to the layout's tier with the placeholder
+        // view — the layout declares the tier, so every slot must bind.
+        let placeholder_view = ctx
+            .textures
+            .pool_placeholder_view()
+            .ok_or(AwsmBindGroupError::TexturePoolPlaceholderMissing("view"))?;
+        while entries.len() < self.texture_pool_arrays_len as usize {
+            entries.push(BindGroupEntry::new(
+                entries.len() as u32,
+                BindGroupResource::TextureView(Cow::Borrowed(placeholder_view)),
+            ));
+        }
+
         for sampler_key in self.texture_pool_sampler_keys.iter() {
             let sampler = ctx.textures.get_sampler(*sampler_key)?;
 
             entries.push(BindGroupEntry::new(
                 entries.len() as u32,
                 BindGroupResource::Sampler(sampler),
+            ));
+        }
+
+        // Pad sampler slots up to the tier with the placeholder sampler.
+        let placeholder_sampler = ctx
+            .textures
+            .pool_placeholder_sampler()
+            .ok_or(AwsmBindGroupError::TexturePoolPlaceholderMissing("sampler"))?;
+        while entries.len()
+            < (self.texture_pool_arrays_len + self.texture_pool_samplers_len) as usize
+        {
+            entries.push(BindGroupEntry::new(
+                entries.len() as u32,
+                BindGroupResource::Sampler(placeholder_sampler),
             ));
         }
 

--- a/packages/crates/renderer/src/render_passes/material_transparent/pipeline.rs
+++ b/packages/crates/renderer/src/render_passes/material_transparent/pipeline.rs
@@ -177,7 +177,7 @@ impl MaterialTransparentPipelines {
         I: IntoIterator<Item = &'a TransparentMeshPipelineRequest<'a>>,
     {
         let texture_pool_arrays_len = material_bind_groups.texture_pool_arrays_len;
-        let texture_pool_samplers_len = material_bind_groups.texture_pool_sampler_keys.len() as u32;
+        let texture_pool_samplers_len = material_bind_groups.texture_pool_samplers_len;
         let mut out = Vec::new();
         for req in requests {
             let mesh_buffer_info = mesh_buffer_infos.get(req.buffer_info_key)?;
@@ -234,7 +234,7 @@ impl MaterialTransparentPipelines {
         ];
 
         let texture_pool_arrays_len = material_bind_groups.texture_pool_arrays_len;
-        let texture_pool_samplers_len = material_bind_groups.texture_pool_sampler_keys.len() as u32;
+        let texture_pool_samplers_len = material_bind_groups.texture_pool_samplers_len;
 
         let mut out = Vec::new();
         for req in requests {
@@ -323,7 +323,7 @@ impl MaterialTransparentPipelines {
         }
 
         let texture_pool_arrays_len = material_bind_groups.texture_pool_arrays_len;
-        let texture_pool_samplers_len = material_bind_groups.texture_pool_sampler_keys.len() as u32;
+        let texture_pool_samplers_len = material_bind_groups.texture_pool_samplers_len;
 
         // Build all shader cache keys first.
         let mut shader_cache_keys: Vec<ShaderCacheKeyMaterialTransparent> =

--- a/packages/crates/renderer/src/render_passes/material_transparent/shader/material_transparent_wgsl/helpers/material_color_calc.wgsl
+++ b/packages/crates/renderer/src/render_passes/material_transparent/shader/material_transparent_wgsl/helpers/material_color_calc.wgsl
@@ -132,12 +132,10 @@ fn pbr_material_base_color(
     fragment_input: FragmentInput
 ) -> vec4<f32> {
     var color = material.base_color_factor;
-    {% if pbr_features.base_color_tex %}
-    if material.base_color_tex_info.exists {
-        let uv = texture_uv(material.base_color_tex_info, fragment_input);
-        color *= texture_pool_sample(material.base_color_tex_info, uv);
-    }
-    {% endif %}
+    // Branchless: an unbound slot packs the shared 1x1 NEUTRAL (white) —
+    // identity multiply, glTF's defined no-texture result.
+    let uv = texture_uv(material.base_color_tex_info, fragment_input);
+    color *= texture_pool_sample(material.base_color_tex_info, uv);
     return color;
 }
 
@@ -148,13 +146,10 @@ fn pbr_material_metallic_roughness(
     fragment_input: FragmentInput
 ) -> vec2<f32> {
     var color = vec2<f32>(material.metallic_factor, material.roughness_factor);
-    {% if pbr_features.metallic_roughness_tex %}
-    if material.metallic_roughness_tex_info.exists {
-        let uv = texture_uv(material.metallic_roughness_tex_info, fragment_input);
-        let tex = texture_pool_sample(material.metallic_roughness_tex_info, uv);
-        color *= vec2<f32>(tex.b, tex.g);
-    }
-    {% endif %}
+    // Branchless: unbound slot = the 1x1 NEUTRAL (white).
+    let uv = texture_uv(material.metallic_roughness_tex_info, fragment_input);
+    let tex = texture_pool_sample(material.metallic_roughness_tex_info, uv);
+    color *= vec2<f32>(tex.b, tex.g);
     return color;
 }
 
@@ -166,28 +161,25 @@ fn pbr_normal(
     world_tangent: vec4<f32>,  // w = handedness (+1 or -1)
     fragment_input: FragmentInput
 ) -> vec3<f32> {
-    {% if pbr_features.normal_tex %}
-    if material.normal_tex_info.exists {
-        // Sample normal map and unpack from [0,1] to [-1,1] range
-        let uv = texture_uv(material.normal_tex_info, fragment_input);
-        let tex = texture_pool_sample(material.normal_tex_info, uv);
-        let tangent_normal = vec3<f32>(
-            (tex.r * 2.0 - 1.0) * material.normal_scale,
-            (tex.g * 2.0 - 1.0) * material.normal_scale,
-            tex.b * 2.0 - 1.0,
-        );
+    // Branchless: unbound slot = the 1x1 NEUTRAL flat normal (0.5, 0.5, 1)
+    // → tangent (0,0,1) → tbn * (0,0,1) == N exactly.
+    // Sample normal map and unpack from [0,1] to [-1,1] range
+    let uv = texture_uv(material.normal_tex_info, fragment_input);
+    let tex = texture_pool_sample(material.normal_tex_info, uv);
+    let tangent_normal = vec3<f32>(
+        (tex.r * 2.0 - 1.0) * material.normal_scale,
+        (tex.g * 2.0 - 1.0) * material.normal_scale,
+        tex.b * 2.0 - 1.0,
+    );
 
-        // Build TBN matrix from interpolated vertex data
-        let N = normalize(world_normal);
-        let T = orthonormal_tangent_from_vertex(N, world_tangent.xyz);
-        let B = cross(N, T) * world_tangent.w;
-        let tbn = mat3x3<f32>(T, B, N);
+    // Build TBN matrix from interpolated vertex data
+    let N = normalize(world_normal);
+    let T = orthonormal_tangent_from_vertex(N, world_tangent.xyz);
+    let B = cross(N, T) * world_tangent.w;
+    let tbn = mat3x3<f32>(T, B, N);
 
-        // Transform tangent-space normal to world space
-        return normalize(tbn * tangent_normal);
-    }
-    {% endif %}
-    return normalize(world_normal);
+    // Transform tangent-space normal to world space
+    return normalize(tbn * tangent_normal);
 }
 
 // Sample occlusion texture and apply strength factor
@@ -195,14 +187,10 @@ fn pbr_occlusion(
     material: PbrMaterial,
     fragment_input: FragmentInput
 ) -> f32 {
-    var occlusion = 1.0;
-    {% if pbr_features.occlusion_tex %}
-    if material.occlusion_tex_info.exists {
-        let uv = texture_uv(material.occlusion_tex_info, fragment_input);
-        let tex = texture_pool_sample(material.occlusion_tex_info, uv);
-        occlusion = mix(1.0, tex.r, material.occlusion_strength);
-    }
-    {% endif %}
+    // Branchless: unbound slot = the 1x1 NEUTRAL (white) → mix(1,1,s) == 1.
+    let uv = texture_uv(material.occlusion_tex_info, fragment_input);
+    let tex = texture_pool_sample(material.occlusion_tex_info, uv);
+    let occlusion = mix(1.0, tex.r, material.occlusion_strength);
     return occlusion;
 }
 
@@ -213,12 +201,9 @@ fn pbr_emissive(
     fragment_input: FragmentInput
 ) -> vec3<f32> {
     var color = material.emissive_factor;
-    {% if pbr_features.emissive_tex %}
-    if material.emissive_tex_info.exists {
-        let uv = texture_uv(material.emissive_tex_info, fragment_input);
-        color *= texture_pool_sample(material.emissive_tex_info, uv).rgb;
-    }
-    {% endif %}
+    // Branchless: unbound slot = the 1x1 NEUTRAL (white) — identity multiply.
+    let uv = texture_uv(material.emissive_tex_info, fragment_input);
+    color *= texture_pool_sample(material.emissive_tex_info, uv).rgb;
     color *= emissive_strength;
     return color;
 }

--- a/packages/crates/renderer/src/render_passes/shadow_custom_vertex/pipeline.rs
+++ b/packages/crates/renderer/src/render_passes/shadow_custom_vertex/pipeline.rs
@@ -119,7 +119,7 @@ impl ShadowCustomVertexPipelines {
             shader_id: variant.shader_id,
             dynamic_vertex: variant.dynamic_vertex.clone(),
             texture_pool_arrays_len: masked_bind_group.texture_pool_arrays_len,
-            texture_pool_samplers_len: masked_bind_group.texture_pool_sampler_keys.len() as u32,
+            texture_pool_samplers_len: masked_bind_group.texture_pool_samplers_len,
             instancing_transforms: false,
         };
         ctx.shaders

--- a/packages/crates/renderer/src/render_passes/shadow_masked/bind_group.rs
+++ b/packages/crates/renderer/src/render_passes/shadow_masked/bind_group.rs
@@ -43,6 +43,7 @@ const MASKED_SHADOW_GROUP0_BUFFER_BINDINGS: u32 = 6;
 pub struct ShadowMaskedBindGroup {
     pub bind_group_layout_key: BindGroupLayoutKey,
     pub texture_pool_arrays_len: u32,
+    pub texture_pool_samplers_len: u32,
     pub texture_pool_sampler_keys: IndexSet<SamplerKey>,
     _bind_group: Option<web_sys::GpuBindGroup>,
 }
@@ -55,6 +56,7 @@ impl ShadowMaskedBindGroup {
         Ok(Self {
             bind_group_layout_key,
             texture_pool_arrays_len: pool.arrays_len,
+            texture_pool_samplers_len: pool.samplers_len,
             texture_pool_sampler_keys: pool.sampler_keys,
             _bind_group: None,
         })
@@ -71,6 +73,7 @@ impl ShadowMaskedBindGroup {
         Ok(Self {
             bind_group_layout_key,
             texture_pool_arrays_len: pool.arrays_len,
+            texture_pool_samplers_len: pool.samplers_len,
             texture_pool_sampler_keys: pool.sampler_keys,
             _bind_group: None,
         })
@@ -128,11 +131,40 @@ impl ShadowMaskedBindGroup {
                 BindGroupResource::TextureView(Cow::Borrowed(view)),
             ));
         }
+        // Pad texture slots up to the layout's tier with the placeholder
+        // view — the layout declares the tier, so every slot must bind.
+        let placeholder_view = ctx
+            .textures
+            .pool_placeholder_view()
+            .ok_or(AwsmBindGroupError::TexturePoolPlaceholderMissing("view"))?;
+        while entries.len()
+            < (MASKED_SHADOW_GROUP0_BUFFER_BINDINGS + self.texture_pool_arrays_len) as usize
+        {
+            entries.push(BindGroupEntry::new(
+                entries.len() as u32,
+                BindGroupResource::TextureView(Cow::Borrowed(placeholder_view)),
+            ));
+        }
         for sampler_key in self.texture_pool_sampler_keys.iter() {
             let sampler = ctx.textures.get_sampler(*sampler_key)?;
             entries.push(BindGroupEntry::new(
                 entries.len() as u32,
                 BindGroupResource::Sampler(sampler),
+            ));
+        }
+        // Pad sampler slots up to the tier with the placeholder sampler.
+        let placeholder_sampler = ctx
+            .textures
+            .pool_placeholder_sampler()
+            .ok_or(AwsmBindGroupError::TexturePoolPlaceholderMissing("sampler"))?;
+        while entries.len()
+            < (MASKED_SHADOW_GROUP0_BUFFER_BINDINGS
+                + self.texture_pool_arrays_len
+                + self.texture_pool_samplers_len) as usize
+        {
+            entries.push(BindGroupEntry::new(
+                entries.len() as u32,
+                BindGroupResource::Sampler(placeholder_sampler),
             ));
         }
 
@@ -162,9 +194,10 @@ fn build_layout_key(
     ctx: &mut RenderPassInitContext<'_>,
     arrays_len: u32,
 ) -> Result<BindGroupLayoutKey> {
-    // Re-read the sampler set so the layout matches what `recreate` will bind.
+    // Re-read the pool deps so the layout matches what `recreate` will bind
+    // (tier-padded sampler count).
     let pool = TexturePoolDeps::new(ctx, TexturePoolVisibility::Render)?;
-    let samplers_len = pool.sampler_keys.len() as u32;
+    let samplers_len = pool.samplers_len;
 
     let shadow_view_v = BindGroupLayoutCacheKeyEntry {
         resource: BindGroupLayoutResource::Buffer(

--- a/packages/crates/renderer/src/render_passes/shadow_masked/pipeline.rs
+++ b/packages/crates/renderer/src/render_passes/shadow_masked/pipeline.rs
@@ -103,7 +103,7 @@ impl ShadowMaskedPipelines {
         for instancing in [false, true] {
             let shader_cache = ShaderCacheKeyShadowMasked {
                 texture_pool_arrays_len: masked_bind_group.texture_pool_arrays_len,
-                texture_pool_samplers_len: masked_bind_group.texture_pool_sampler_keys.len() as u32,
+                texture_pool_samplers_len: masked_bind_group.texture_pool_samplers_len,
                 shader_id: variant.shader_id,
                 base: variant.base,
                 dynamic_alpha: variant.dynamic_alpha.clone(),

--- a/packages/crates/renderer/src/render_passes/shadow_masked_custom_vertex/pipeline.rs
+++ b/packages/crates/renderer/src/render_passes/shadow_masked_custom_vertex/pipeline.rs
@@ -127,7 +127,7 @@ impl ShadowMaskedCustomVertexPipelines {
             dynamic_vertex: variant.dynamic_vertex.clone(),
             dynamic_alpha: variant.dynamic_alpha.clone(),
             texture_pool_arrays_len: masked_bind_group.texture_pool_arrays_len,
-            texture_pool_samplers_len: masked_bind_group.texture_pool_sampler_keys.len() as u32,
+            texture_pool_samplers_len: masked_bind_group.texture_pool_samplers_len,
         };
         ctx.shaders
             .ensure_keys(ctx.gpu, vec![shader_cache.clone().into()])

--- a/packages/crates/renderer/src/render_passes/shared/material/bind_group.rs
+++ b/packages/crates/renderer/src/render_passes/shared/material/bind_group.rs
@@ -19,10 +19,27 @@ use crate::{
 };
 
 /// Bind group layout data for the texture pool.
+///
+/// `arrays_len` / `samplers_len` are the PADDED TIER counts (see
+/// [`pool_binding_tier`]) — they size the layout, the generated WGSL
+/// bindings, and the shader cache keys. The real pool contents fill the
+/// leading slots; the rest bind the shared neutral/default placeholders.
+/// Pool growth therefore only re-keys shaders when it crosses a tier
+/// boundary, instead of on every new (size, format) group.
 pub struct TexturePoolDeps {
     pub bind_group_layout_key: BindGroupLayoutKey,
     pub arrays_len: u32,
+    /// Padded sampler-slot count (tier over `sampler_keys.len()`).
+    pub samplers_len: u32,
     pub sampler_keys: IndexSet<SamplerKey>,
+}
+
+/// The padded binding-slot count for a real count `n`: a floor of 4, then
+/// powers of two. Small enough to stay far from device binding limits,
+/// coarse enough that a growing pool re-keys shaders only at 4 → 8 → 16 …
+/// crossings.
+pub fn pool_binding_tier(n: usize) -> usize {
+    n.next_power_of_two().max(4)
 }
 
 /// Shader stage visibility for texture pool bindings.
@@ -54,9 +71,11 @@ impl TexturePoolDeps {
         ctx: &mut RenderPassInitContext<'_>,
         visibility: TexturePoolVisibility,
     ) -> Result<Self> {
-        // textures
+        // textures — the layout declares the padded TIER; real arrays fill
+        // the leading slots and the rest bind the neutral placeholder view.
         let device_limits = ctx.gpu.device.limits();
-        let texture_arrays_len = ctx.textures.pool.arrays_len();
+        let real_arrays_len = ctx.textures.pool.arrays_len();
+        let texture_arrays_len = pool_binding_tier(real_arrays_len);
 
         let mut entries = Vec::new();
 
@@ -80,6 +99,7 @@ impl TexturePoolDeps {
                 visibility_compute: visibility.compute(),
             });
 
+            // Padded slots (i >= real_arrays_len) have no array → 0 layers.
             let layer_count = ctx
                 .textures
                 .pool
@@ -97,18 +117,20 @@ impl TexturePoolDeps {
             }
         }
 
-        // samplers
+        // samplers — same tiering; real samplers first (the default sampler
+        // is index 0 from boot), padded slots bind it again.
         let sampler_keys = ctx.textures.pool_sampler_set.clone();
+        let samplers_len = pool_binding_tier(sampler_keys.len());
 
-        if sampler_keys.len() > device_limits.max_samplers_per_shader_stage() as usize {
+        if samplers_len > device_limits.max_samplers_per_shader_stage() as usize {
             return Err(AwsmCoreError::TexturePoolTooManySamplers {
-                total_samplers: sampler_keys.len() as u32,
+                total_samplers: samplers_len as u32,
                 max_samplers: device_limits.max_samplers_per_shader_stage(),
             }
             .into());
         }
 
-        for _ in 0..sampler_keys.len() {
+        for _ in 0..samplers_len {
             entries.push(BindGroupLayoutCacheKeyEntry {
                 resource: BindGroupLayoutResource::Sampler(
                     SamplerBindingLayout::new().with_binding_type(SamplerBindingType::Filtering),
@@ -125,6 +147,7 @@ impl TexturePoolDeps {
 
         Ok(Self {
             arrays_len: texture_arrays_len as u32,
+            samplers_len: samplers_len as u32,
             bind_group_layout_key,
             sampler_keys,
         })

--- a/packages/crates/renderer/src/render_passes/shared/shared_wgsl/masked_alpha.wgsl
+++ b/packages/crates/renderer/src/render_passes/shared/shared_wgsl/masked_alpha.wgsl
@@ -164,10 +164,11 @@ fn mask_alpha_at(
     let base_index = (material_offset / 4u) + 1u;
     let base_color_tex = material_load_texture_info(base_index + 2u);
     var alpha = material_load_f32(base_index + 10u);
-    if base_color_tex.exists {
-        let uv = mask_texture_uv(attribute_data_offset, triangle_indices, bary, base_color_tex, vertex_attribute_stride, uv_sets_index);
-        alpha = alpha * texture_pool_sample(base_color_tex, uv).a;
-    }
+    // Branchless: an unbound base-color slot packs the shared 1×1 NEUTRAL
+    // (white, alpha 1) — identity multiply, so the cutout alpha is exactly
+    // the factor alpha, glTF's defined no-texture result.
+    let uv = mask_texture_uv(attribute_data_offset, triangle_indices, bary, base_color_tex, vertex_attribute_stride, uv_sets_index);
+    alpha = alpha * texture_pool_sample(base_color_tex, uv).a;
     return alpha;
 }
 {% endif %}

--- a/packages/crates/renderer/src/renderer.rs
+++ b/packages/crates/renderer/src/renderer.rs
@@ -354,6 +354,9 @@ pub struct AwsmRenderer {
     /// futures are currently stubs — Stage 1 follow-up wires each
     /// `PipelineGroupDef` variant to the real compile path.
     pub pipeline_scheduler: crate::pipeline_scheduler::PipelineScheduler,
+    /// The eager pass groups registered at build (Pending). Marked Ready by
+    /// [`Self::ensure_config_pipelines`] once the deferred boot pool drains.
+    eager_pass_ids: Vec<crate::pipeline_scheduler::PipelineGroupId>,
     /// Bucket-layout fingerprint of the last `ensure_scene_pipelines`
     /// run. The render-driven compile path
     /// ([`crate::AwsmRenderer::ensure_scene_pipelines`]) compares the
@@ -516,11 +519,196 @@ impl AwsmRenderer {
     ///
     /// Cheap no-op when nothing changed since the last commit (the content-keyed
     /// caches make finalize + every compile a hit).
+    /// Compile everything the CURRENT config needs that isn't compiled yet —
+    /// the deferred boot pool (reserved at `build()`) plus any config-keyed
+    /// piece that re-keyed since (material-prep SSCS/denoise drift, the
+    /// MSAA edge-resolve set). Idempotent and cheap when warm: every ensure
+    /// is cache-keyed, so a second call is a no-op.
+    ///
+    /// `build()` compiles NOTHING — an empty project never pays for pipelines
+    /// it doesn't draw. This is the single warm-up point:
+    /// - [`Self::commit_load`] calls it first, so content loads Just Work and
+    ///   report the compile through their existing progress callback;
+    /// - an app that knows its config up front can call it right after
+    ///   `build()` to overlap the warm-up with its own asset fetching;
+    /// - config setters (`set_anti_aliasing`) drain the pool before their
+    ///   branch bookkeeping so `has_branch_for`-style guards see reality.
+    ///
+    /// Returns the number of pipelines compiled (0 when already warm).
+    pub async fn ensure_config_pipelines(&mut self) -> crate::error::Result<usize> {
+        // 1. Drain the reserved boot pool (concurrent; both classes overlap
+        //    inside Dawn's worker pool).
+        let compiled = self.compile_pending_pipelines().await?;
+
+        // 2. Material prep: re-derive the ACTIVE branch's cache keys from the
+        //    live config and ensure them. Catches SSCS / denoise re-keys that
+        //    happened after boot (`set_shadows_config` mirrors them into
+        //    `prep_config` but compiles nothing) — unchanged configs resolve
+        //    as cache hits.
+        self.ensure_material_prep_pipelines().await?;
+
+        // 3. The layout-level MSAA edge-resolve set (moved out of build()).
+        //    Cache-keyed like everything else; the commit path's
+        //    `launch_edge_resolve_compile` covers later bucket changes.
+        if self.material_edge_buffers.is_some() {
+            let color_wgsl = awsm_renderer_core::texture::texture_format_to_wgsl_storage(
+                self.render_textures.formats.color,
+            )?;
+            let bucket_entries = crate::dynamic_materials::first_party_bucket_entries();
+            let pipelines::Pipelines {
+                render: _render_pipelines,
+                compute: compute_pipelines,
+            } = &mut self.pipelines;
+            self.render_passes
+                .material_opaque
+                .edge_pipelines
+                .ensure_compiled(
+                    &self.gpu,
+                    &mut self.shaders,
+                    compute_pipelines,
+                    &mut self.pipeline_layouts,
+                    &mut self.bind_group_layouts,
+                    &self.render_passes.material_opaque.bind_groups,
+                    &self.render_passes.material_opaque.edge_bind_group_layouts,
+                    &bucket_entries,
+                    &self.anti_aliasing,
+                    color_wgsl,
+                    None,
+                    self.prep_config.clamped_k(),
+                    self.prep_config.sscs_enabled,
+                    self.prep_config.sscs_step_count,
+                )
+                .await?;
+        }
+
+        // 4. The eager pass groups registered Pending at build are real now.
+        let eager_ids = std::mem::take(&mut self.eager_pass_ids);
+        for id in &eager_ids {
+            self.pipeline_scheduler.mark_ready(*id);
+        }
+        if !eager_ids.is_empty() {
+            tracing::info!(
+                target: "awsm_renderer::pipeline_readiness",
+                "ensure_config_pipelines: boot pool drained ({compiled} compiled), {} eager groups marked Ready",
+                eager_ids.len()
+            );
+        }
+        Ok(compiled)
+    }
+
+    /// Drain every reserved (uncompiled) slot in the compute + render
+    /// pipeline caches in one concurrent batch. Idempotent.
+    pub(crate) async fn compile_pending_pipelines(&mut self) -> crate::error::Result<usize> {
+        if self.pipelines.compute.pending_count() == 0
+            && self.pipelines.render.pending_count() == 0
+        {
+            return Ok(0);
+        }
+        let pipelines::Pipelines {
+            render: render_pipelines,
+            compute: compute_pipelines,
+        } = &mut self.pipelines;
+        let compute_fut = async {
+            compute_pipelines
+                .compile_pending(&self.gpu, &self.shaders, &self.pipeline_layouts)
+                .await
+                .map_err(crate::error::AwsmError::from)
+        };
+        let render_fut = async {
+            render_pipelines
+                .compile_pending(&self.gpu, &self.shaders, &self.pipeline_layouts)
+                .await
+                .map_err(crate::error::AwsmError::from)
+        };
+        let (c, r) = futures::future::try_join(compute_fut, render_fut).await?;
+        Ok(c + r)
+    }
+
+    /// Ensure the material-prep pipelines for the LIVE config (active MSAA
+    /// branch, edge under MSAA + device support, blur pair while denoise is
+    /// on). Re-derives cache keys from `prep_config`, so SSCS / denoise
+    /// changes re-key + recompile here; unchanged configs are cache hits.
+    pub(crate) async fn ensure_material_prep_pipelines(&mut self) -> crate::error::Result<()> {
+        use crate::render_passes::material_prep::render_pass::MaterialPrepPipelines;
+        if self.render_passes.material_prep.is_none() {
+            return Ok(());
+        }
+        let multisampled = self.anti_aliasing.has_msaa_checked()?;
+        let edge_resolve = multisampled && crate::edge_resolve_supported(&self.gpu);
+        self.shaders
+            .ensure_keys(
+                &self.gpu,
+                MaterialPrepPipelines::shader_cache_keys(multisampled, &self.prep_config),
+            )
+            .await?;
+        let mut ctx = crate::render_passes::RenderPassInitContext {
+            gpu: &self.gpu,
+            bind_group_layouts: &mut self.bind_group_layouts,
+            pipeline_layouts: &mut self.pipeline_layouts,
+            pipelines: &mut self.pipelines,
+            shaders: &mut self.shaders,
+            render_texture_formats: &mut self.render_textures.formats,
+            textures: &mut self.textures,
+            features: &self.features,
+            anti_aliasing: &self.anti_aliasing,
+            post_processing: &self.post_processing,
+            prep_config: &self.prep_config,
+            max_edge_budget: self
+                .material_edge_buffers
+                .as_ref()
+                .map(|b| b.max_edge_budget)
+                .unwrap_or(
+                    crate::render_passes::material_opaque::edge_buffers::DEFAULT_MAX_EDGE_BUDGET_DESKTOP,
+                ),
+        };
+        let prep = self
+            .render_passes
+            .material_prep
+            .as_ref()
+            .expect("checked is_none above");
+        let descs = MaterialPrepPipelines::build_descriptors_for_config(
+            &mut ctx,
+            &prep.bind_groups,
+            multisampled,
+            edge_resolve,
+        )
+        .await?;
+        let keys = self
+            .pipelines
+            .compute
+            .ensure_keys(
+                &self.gpu,
+                &self.shaders,
+                &self.pipeline_layouts,
+                descs.pipeline_cache_keys.clone(),
+            )
+            .await?;
+        if let Some(prep) = self.render_passes.material_prep.as_mut() {
+            prep.pipelines.merge_resolved(&descs.slots, keys);
+        }
+        Ok(())
+    }
+
     pub async fn commit_load(
         &mut self,
         mut on_progress: impl FnMut(crate::loading::LoadingStats),
     ) -> crate::error::Result<crate::loading::LoadingStats> {
         use crate::loading::{LoadPhase, LoadingStats};
+
+        // ── Phase -1: the deferred boot pool — compile everything the current
+        //    config needs that build() only reserved (plus any config re-keys
+        //    since). Cheap no-op when already warm. Reported under `Compiling`
+        //    so loading UIs label the (first-visit-expensive) wait honestly.
+        {
+            let pending = self.pipelines.compute.pending_count() + self.pipelines.render.pending_count();
+            if pending > 0 {
+                self.load_phase = LoadPhase::Compiling;
+                let mut stats = self.loading_stats();
+                stats.pipelines_pending = pending;
+                on_progress(stats);
+            }
+            self.ensure_config_pipelines().await?;
+        }
 
         // ── Phase 0: resolve geometry — derive + upload each registered geometry's
         //    needed pass representations (visibility/transparency) from the union of
@@ -1872,11 +2060,16 @@ impl AwsmRendererBuilder {
                 &post_processing,
             ),
         );
-        // Phase transition: the actual WGSL → MSL compile happens
-        // inside the next await. Emit `CompilingShaders` here so the
-        // frontend's "Browser is compiling shaders…" label is correct.
+        // Deferred-boot: create every module SYNCHRONOUSLY without awaiting
+        // validation — `compile_shader` returns immediately and the browser
+        // compiles in the background; nothing blocks here. Validation errors
+        // surface through the (deferred) pipeline creations, which carry the
+        // shader diagnostics. This is what makes `build()` compile-free: the
+        // pipelines that consume these modules are RESERVED below and only
+        // compiled by `ensure_config_pipelines` (first `commit_load`, or the
+        // app's explicit call).
         emit_phase(RendererLoadingPhase::CompilingShaders);
-        shaders.ensure_keys(&gpu, all_shader_keys).await?;
+        shaders.ensure_keys_sync_skip_validate(&gpu, all_shader_keys)?;
 
         // ── 2. Tail descriptors (cache-hit shader resolutions for
         //       Shadows caster; Shadows internally issues 3 EVSM
@@ -2007,35 +2200,17 @@ impl AwsmRendererBuilder {
             s..render_pool.len()
         };
 
-        // ── 6. ONE try_join'd compute + render ensure_keys covering
-        //       every compute + render pipeline across the entire
-        //       renderer (~36 compute + ~27 render on a fully-
-        //       featured build). Split-borrow Pipelines.compute /
-        //       Pipelines.render so Dawn overlaps both classes inside
-        //       its worker pool.
-        let pipelines::Pipelines {
-            render: render_pipelines,
-            compute: compute_pipelines,
-        } = &mut pipelines;
-        let compute_fut = async {
-            compute_pipelines
-                .ensure_keys(&gpu, &shaders, &pipeline_layouts, compute_pool)
-                .await
-                .map_err(crate::error::AwsmError::from)
-        };
-        let render_fut = async {
-            render_pipelines
-                .ensure_keys(&gpu, &shaders, &pipeline_layouts, render_pool)
-                .await
-                .map_err(crate::error::AwsmError::from)
-        };
-        // Phase transition: every shader is now warm; the pipeline
-        // assembly happens inside the next await. Emit
-        // `BuildingPipelines` so the frontend's "Building render
-        // pipelines…" label is correct.
+        // ── 6. RESERVE every compute + render pipeline key across the
+        //       entire renderer (~36 compute + ~27 render on a fully-
+        //       featured build) WITHOUT compiling — the deferred boot
+        //       pool. `AwsmRenderer::ensure_config_pipelines` (called by
+        //       the first `commit_load`, or explicitly by an app that
+        //       wants to overlap the warmup with its asset fetches)
+        //       drains the reserved slots in one batched, concurrent
+        //       compile. An empty project therefore compiles NOTHING.
         emit_phase(RendererLoadingPhase::BuildingPipelines);
-        let (compute_keys, render_keys) =
-            futures::future::try_join(compute_fut, render_fut).await?;
+        let compute_keys = pipelines.compute.reserve_keys(compute_pool);
+        let render_keys = pipelines.render.reserve_keys(render_pool);
 
         // ── 7. Sync fold-up — slice resolved keys back to each
         //       subsystem.
@@ -2087,42 +2262,12 @@ impl AwsmRendererBuilder {
             crate::dynamic_materials::extras_pool::DEFAULT_CAPACITY_WORDS,
         )?;
 
-        // Edge-resolve pipeline compile (Priority 3 dispatch wiring). Only
-        // when MSAA is on AND device supports the required limits. We
-        // pass first_party-only bucket entries — the edge pipelines
-        // recompile through the same path when dynamic materials
-        // register (Stage 1.14 follow-up will route through the
-        // scheduler).
-        if edge_resolve_enabled {
-            let color_wgsl = awsm_renderer_core::texture::texture_format_to_wgsl_storage(
-                render_textures.formats.color,
-            )?;
-            let bucket_entries = crate::dynamic_materials::first_party_bucket_entries();
-            let pipelines::Pipelines {
-                render: _render_pipelines,
-                compute: compute_pipelines,
-            } = &mut pipelines;
-            render_passes
-                .material_opaque
-                .edge_pipelines
-                .ensure_compiled(
-                    &gpu,
-                    &mut shaders,
-                    compute_pipelines,
-                    &mut pipeline_layouts,
-                    &mut bind_group_layouts,
-                    &render_passes.material_opaque.bind_groups,
-                    &render_passes.material_opaque.edge_bind_group_layouts,
-                    &bucket_entries,
-                    &anti_aliasing,
-                    color_wgsl,
-                    None,
-                    prep_config.clamped_k(),
-                    prep_config.sscs_enabled,
-                    prep_config.sscs_step_count,
-                )
-                .await?;
-        }
+        // NOTE: the layout-level edge-resolve pipeline set (Priority 3
+        // dispatch wiring) is no longer compiled here — it moved into
+        // `ensure_config_pipelines` (the deferred boot pool's drain), keyed
+        // off the same MSAA + device gate. The commit path also rebuilds it
+        // for config changes via `ensure_scene_pipelines` →
+        // `launch_edge_resolve_compile` (cache-keyed, so overlaps are hits).
 
         let mut _self = AwsmRenderer {
             gpu,
@@ -2207,6 +2352,7 @@ impl AwsmRendererBuilder {
             renderable_pool: crate::renderable::RenderablePool::default(),
             hud_resolve: crate::render::HudResolveState::default(),
             pipeline_scheduler: crate::pipeline_scheduler::PipelineScheduler::new(),
+            eager_pass_ids: Vec::new(),
             last_ensured_bucket_layout: None,
             // Flipped to true at end of build(). Used by config-change
             // APIs to enforce the race policy from the architecture doc.
@@ -2317,14 +2463,17 @@ impl AwsmRendererBuilder {
             let pass_ids = _self
                 .pipeline_scheduler
                 .submit_pipeline_group_batch(eager_passes);
-            for id in &pass_ids {
-                if matches!(id, PipelineGroupId::Pass(_)) {
-                    _self.pipeline_scheduler.mark_ready(*id);
-                }
-            }
+            // Deferred-boot: the pass pipelines are RESERVED, not compiled, so
+            // the groups stay Pending here. `ensure_config_pipelines` marks
+            // them Ready once the reserved pool actually drains.
+            _self.eager_pass_ids = pass_ids
+                .iter()
+                .copied()
+                .filter(|id| matches!(id, PipelineGroupId::Pass(_)))
+                .collect();
             tracing::info!(
                 target: "awsm_renderer::pipeline_readiness",
-                "eager-set registered with scheduler: {} groups marked Ready",
+                "eager-set registered with scheduler: {} groups Pending until ensure_config_pipelines",
                 pass_ids.len()
             );
         }

--- a/packages/crates/renderer/src/renderer.rs
+++ b/packages/crates/renderer/src/renderer.rs
@@ -305,7 +305,17 @@ pub struct AwsmRenderer {
     pub(crate) hud_resolve: crate::render::HudResolveState,
     /// Per-frame mipmap generator for the opaque RT — only dispatched
     /// when the visible material set contains a transmissive material.
-    pub opaque_mipgen: opaque_mipgen::OpaqueMipgen,
+    /// Transmission-only mipgen pipeline. `None` until the first commit whose
+    /// content has a transmissive material (`ensure_config_pipelines`) —
+    /// non-transmission scenes never compile it.
+    pub opaque_mipgen: Option<opaque_mipgen::OpaqueMipgen>,
+    /// Deferred-boot placeholder tracking: true while the corresponding
+    /// lighting resource is still the 1×1 build-time placeholder. Cleared by
+    /// the real `set_*` (app/scene-loader content) or by
+    /// `ensure_config_pipelines` generating the authored defaults.
+    skybox_is_placeholder: bool,
+    ibl_is_placeholder: bool,
+    brdf_lut_is_placeholder: bool,
     /// Shadow mapping subsystem. Owns the depth atlas, EVSM atlas,
     /// cube-array pool, descriptors, and the comparison / filterable
     /// samplers used by the shadow-aware shading passes.
@@ -581,7 +591,21 @@ impl AwsmRenderer {
                 .await?;
         }
 
-        // 4. The eager pass groups registered Pending at build are real now.
+        // 4. Real lighting defaults: build() installs 1×1 placeholders for
+        //    the skybox / IBL cubemaps and the BRDF LUT. If content hasn't
+        //    replaced them by now (the scene loader's environment apply
+        //    happens BEFORE its commit, so a real scene skips all of this),
+        //    generate the authored defaults from the config snapshot through
+        //    the same setter paths. One-shot per slot.
+        self.ensure_lighting_defaults().await?;
+
+        // 5. Content-gated pipelines that used to compile at build:
+        //    the transmission mipgen (only if a transmissive material is
+        //    actually attached) and the decal composite (feature-gated).
+        self.ensure_opaque_mipgen_compiled().await?;
+        self.ensure_decal_composite_compiled().await?;
+
+        // 6. The eager pass groups registered Pending at build are real now.
         let eager_ids = std::mem::take(&mut self.eager_pass_ids);
         for id in &eager_ids {
             self.pipeline_scheduler.mark_ready(*id);
@@ -594,6 +618,112 @@ impl AwsmRenderer {
             );
         }
         Ok(compiled)
+    }
+
+    /// Deferred-boot flag clears — called by the real `set_skybox` /
+    /// `set_ibl` / `set_brdf_lut` so `ensure_lighting_defaults` knows the
+    /// placeholder was replaced by content.
+    pub(crate) fn mark_skybox_real(&mut self) {
+        self.skybox_is_placeholder = false;
+    }
+    pub(crate) fn mark_ibl_real(&mut self) {
+        self.ibl_is_placeholder = false;
+    }
+    pub(crate) fn mark_brdf_lut_real(&mut self) {
+        self.brdf_lut_is_placeholder = false;
+    }
+
+    /// Swap any still-placeholder lighting resource for the authored default
+    /// (from the build-time config snapshot), through the same setter paths a
+    /// scene load uses. One-shot per slot; no-op once real content or a prior
+    /// call replaced it.
+    async fn ensure_lighting_defaults(&mut self) -> crate::error::Result<()> {
+        if self.skybox_is_placeholder {
+            let resources =
+                Skybox::prepare_resources(&self.gpu, self.config_spec.skybox_colors.clone())
+                    .await?;
+            let skybox = Skybox::register(&self.gpu, &mut self.textures, resources)?;
+            self.set_skybox(skybox);
+        }
+        if self.ibl_is_placeholder {
+            let (filtered, irradiance) = futures::try_join!(
+                IblTexture::prepare_resources(
+                    &self.gpu,
+                    self.config_spec.ibl_filtered_env_colors.clone()
+                ),
+                IblTexture::prepare_resources(
+                    &self.gpu,
+                    self.config_spec.ibl_irradiance_colors.clone()
+                ),
+            )?;
+            let ibl = Ibl::new(
+                IblTexture::register(&self.gpu, &mut self.textures, filtered)?,
+                IblTexture::register(&self.gpu, &mut self.textures, irradiance)?,
+            );
+            self.set_ibl(ibl);
+        }
+        if self.brdf_lut_is_placeholder {
+            let lut = BrdfLut::new(&self.gpu, self.config_spec.brdf_lut_options.clone()).await?;
+            self.set_brdf_lut(lut);
+        }
+        Ok(())
+    }
+
+    /// Compile the transmission mipgen pipeline iff any attached mesh's
+    /// material is transmissive and it isn't compiled yet. Content-gated —
+    /// non-transmission scenes never pay for it.
+    async fn ensure_opaque_mipgen_compiled(&mut self) -> crate::error::Result<()> {
+        if self.opaque_mipgen.is_some() {
+            return Ok(());
+        }
+        let any_transmission = self
+            .meshes
+            .iter()
+            .any(|(_, mesh)| self.materials.has_transmission(mesh.material_key));
+        if any_transmission {
+            self.opaque_mipgen = Some(opaque_mipgen::OpaqueMipgen::new(&self.gpu).await?);
+        }
+        Ok(())
+    }
+
+    /// Compile the decal composite's two inline-WGSL pipelines iff the decals
+    /// feature is on and they aren't compiled yet (moved out of build()).
+    async fn ensure_decal_composite_compiled(&mut self) -> crate::error::Result<()> {
+        let needs = self
+            .render_passes
+            .material_decal
+            .as_ref()
+            .is_some_and(|d| d.composite.is_none());
+        if !needs {
+            return Ok(());
+        }
+        let mut ctx = crate::render_passes::RenderPassInitContext {
+            gpu: &self.gpu,
+            bind_group_layouts: &mut self.bind_group_layouts,
+            pipeline_layouts: &mut self.pipeline_layouts,
+            pipelines: &mut self.pipelines,
+            shaders: &mut self.shaders,
+            render_texture_formats: &mut self.render_textures.formats,
+            textures: &mut self.textures,
+            features: &self.features,
+            anti_aliasing: &self.anti_aliasing,
+            post_processing: &self.post_processing,
+            prep_config: &self.prep_config,
+            max_edge_budget: self
+                .material_edge_buffers
+                .as_ref()
+                .map(|b| b.max_edge_budget)
+                .unwrap_or(
+                    crate::render_passes::material_opaque::edge_buffers::DEFAULT_MAX_EDGE_BUDGET_DESKTOP,
+                ),
+        };
+        let composite =
+            crate::render_passes::material_decal::composite::MaterialDecalComposite::new(&mut ctx)
+                .await?;
+        if let Some(decal) = self.render_passes.material_decal.as_mut() {
+            decal.composite = Some(composite);
+        }
+        Ok(())
     }
 
     /// Drain every reserved (uncompiled) slot in the compute + render
@@ -1703,10 +1833,26 @@ impl AwsmRendererBuilder {
         };
         emit_phase(RendererLoadingPhase::Init);
 
+        // Init sub-phase wall-clock marks (same `boot_timing` target as the
+        // phase log) — Init used to lump device acquisition, resource
+        // generation, and descriptor staging into one number; these say
+        // where a slow Init actually goes.
+        let mut sub_t = web_sys::js_sys::Date::now();
+        let mut submark = move |label: &str| {
+            let now = web_sys::js_sys::Date::now();
+            tracing::info!(
+                target: "awsm_renderer::boot_timing",
+                "init sub-phase: {label} (+{:.0}ms)",
+                now - sub_t,
+            );
+            sub_t = now;
+        };
+
         let gpu = match gpu {
             AwsmRendererGpuBuilderKind::WebGpuBuilder(builder) => builder.build().await?,
             AwsmRendererGpuBuilderKind::WebGpuBuilt(gpu) => gpu,
         };
+        submark("WebGPU device acquired");
 
         // Resolve `indirect_first_instance` against device capability.
         // After this point any `Auto` in the toggle is replaced by
@@ -1840,25 +1986,34 @@ impl AwsmRendererBuilder {
         // transition fires further down, right before the
         // cross-renderer `Shaders::ensure_keys` call where actual
         // WGSL → MSL compilation begins.
+        // Deferred-boot: the IBL / skybox slots get 1×1 PLACEHOLDER cubemaps
+        // and the BRDF LUT a 1×1 zero texture — structurally valid (every
+        // lighting bind-group layout binds *something*) but generated for
+        // free. `ensure_config_pipelines` swaps in the real defaults (via
+        // the same `set_skybox`/`set_ibl`/`set_brdf_lut` paths a scene load
+        // uses) unless the app already replaced them — so an empty project
+        // never generates 256² cubemaps or bakes a 1024² LUT it won't show.
+        // The opaque-mipgen pipeline (transmission-only) is likewise
+        // deferred: compiled by `ensure_config_pipelines` on the first
+        // commit whose content actually has a transmissive material.
+        // The builder's authored colors + LUT options ride `config_spec`
+        // (snapshotted above) for the deferred real-default generation;
+        // the placeholders reuse the same colors so even a stray sample
+        // reads the authored tint.
+        let _ = brdf_lut_options;
         let (
             ibl_filtered_resources,
             ibl_irradiance_resources,
             skybox_resources,
             brdf_lut,
-            opaque_mipgen,
             mut render_passes_plan,
             render_textures,
         ) = futures::try_join!(
-            IblTexture::prepare_resources(&gpu, ibl_filtered_env_colors),
-            IblTexture::prepare_resources(&gpu, ibl_irradiance_colors),
-            Skybox::prepare_resources(&gpu, skybox_colors),
+            IblTexture::prepare_resources_sized(&gpu, ibl_filtered_env_colors, 1),
+            IblTexture::prepare_resources_sized(&gpu, ibl_irradiance_colors, 1),
+            Skybox::prepare_resources_sized(&gpu, skybox_colors, 1),
             async {
-                BrdfLut::new(&gpu, brdf_lut_options)
-                    .await
-                    .map_err(crate::error::AwsmError::from)
-            },
-            async {
-                opaque_mipgen::OpaqueMipgen::new(&gpu)
+                BrdfLut::placeholder(&gpu)
                     .await
                     .map_err(crate::error::AwsmError::from)
             },
@@ -1874,6 +2029,8 @@ impl AwsmRendererBuilder {
                 .map_err(crate::error::AwsmError::from)
             },
         )?;
+        let opaque_mipgen: Option<opaque_mipgen::OpaqueMipgen> = None;
+        submark("render textures + placeholder lighting resources + shader plan");
         // Move `render_pass_init` into a discard binding so its
         // `&mut`-borrows of bind_group_layouts / pipeline_layouts /
         // pipelines / shaders / render_texture_formats / textures /
@@ -2109,13 +2266,12 @@ impl AwsmRendererBuilder {
         )
         .await?;
 
-        // ── 3. EVSM validate join. Single await covering all 3
-        //       inline-shader validations in parallel.
-        let evsm_results =
-            futures::future::join_all(shadows_descs.evsm.validate_shader_futures()).await;
-        for result in evsm_results {
-            result.map_err(crate::shadows::AwsmShadowError::Core)?;
-        }
+        // ── 3. EVSM validation is NOT awaited (deferred-boot): the modules
+        //       were created synchronously inside `build_descriptors` and the
+        //       browser validates in the background. Any error surfaces at
+        //       the (already-deferred, Block B.1) EVSM pipeline creation with
+        //       the shader diagnostic attached — the same trade-off the
+        //       pooled `ensure_keys_sync_skip_validate` path accepts.
 
         // Register the 3 EVSM modules into the shader cache via
         // `insert_uncached`; the resulting `ShaderKey`s let us build
@@ -2127,6 +2283,7 @@ impl AwsmRendererBuilder {
             shaders.insert_uncached(shadows_descs.evsm.modules[2].clone()),
         ];
         let evsm_pipeline_cache_keys = shadows_descs.evsm.pipeline_cache_keys(evsm_shader_keys);
+        submark("shadow descriptors (EVSM modules created, validation deferred)");
 
         // ── 4. Now that all shaders are warm, drive RenderPasses
         //       phase 2 (build pipeline cache keys per pass) and the
@@ -2208,6 +2365,7 @@ impl AwsmRendererBuilder {
         //       wants to overlap the warmup with its asset fetches)
         //       drains the reserved slots in one batched, concurrent
         //       compile. An empty project therefore compiles NOTHING.
+        submark("pipeline descriptors staged");
         emit_phase(RendererLoadingPhase::BuildingPipelines);
         let compute_keys = pipelines.compute.reserve_keys(compute_pool);
         let render_keys = pipelines.render.reserve_keys(render_pool);
@@ -2353,6 +2511,9 @@ impl AwsmRendererBuilder {
             hud_resolve: crate::render::HudResolveState::default(),
             pipeline_scheduler: crate::pipeline_scheduler::PipelineScheduler::new(),
             eager_pass_ids: Vec::new(),
+            skybox_is_placeholder: true,
+            ibl_is_placeholder: true,
+            brdf_lut_is_placeholder: true,
             last_ensured_bucket_layout: None,
             // Flipped to true at end of build(). Used by config-change
             // APIs to enforce the race policy from the architecture doc.

--- a/packages/crates/renderer/src/renderer.rs
+++ b/packages/crates/renderer/src/renderer.rs
@@ -274,6 +274,12 @@ pub struct AwsmRenderer {
     /// (alpha-tested) pipelines for MASK customs even if no texture changed
     /// (a procedural cutout needs no texture). Cleared by `finalize_gpu_textures`.
     pub masked_dynamic_dirty: bool,
+    /// The PADDED texture-pool tier `(arrays, samplers)` (see
+    /// [`crate::render_passes::shared::material::bind_group::pool_binding_tier`])
+    /// as of the last `finalize_gpu_textures`. The pool-grow recompile reset
+    /// in that fn only fires when this tier changes — within-tier growth is
+    /// absorbed by the placeholder-padded bind groups.
+    pub(crate) last_pool_tier: Option<(usize, usize)>,
     /// Renderer-wide variable-length per-material data pool. Backs
     /// `BufferSlot` declarations on registered dynamic materials.
     pub extras_pool: crate::dynamic_materials::extras_pool::ExtrasPool,
@@ -1915,6 +1921,12 @@ impl AwsmRendererBuilder {
         let mut shaders = Shaders::new();
 
         let mut textures = Textures::new(&gpu)?;
+        // The shared 1×1 NEUTRALS (white + flat normal) + default sampler:
+        // every unbound built-in texture slot packs one of these, so the five
+        // core slots sample unconditionally (branchless) with identity
+        // results. Registered before ANY material can pack. Also guarantees
+        // the pool is never empty, which the tiered pool layout leans on.
+        textures.ensure_neutrals(&gpu)?;
         let camera = camera::CameraBuffer::new(&gpu)?;
         let frame_globals = crate::frame_globals::FrameGlobals::new(&gpu)?;
 
@@ -2472,6 +2484,7 @@ impl AwsmRendererBuilder {
             materials,
             dynamic_materials: crate::dynamic_materials::DynamicMaterials::new(),
             masked_dynamic_dirty: false,
+            last_pool_tier: None,
             extras_pool: extras_pool_built,
             pipeline_layouts,
             pipelines,

--- a/packages/crates/renderer/src/renderer.rs
+++ b/packages/crates/renderer/src/renderer.rs
@@ -729,8 +729,7 @@ impl AwsmRenderer {
     /// Drain every reserved (uncompiled) slot in the compute + render
     /// pipeline caches in one concurrent batch. Idempotent.
     pub(crate) async fn compile_pending_pipelines(&mut self) -> crate::error::Result<usize> {
-        if self.pipelines.compute.pending_count() == 0
-            && self.pipelines.render.pending_count() == 0
+        if self.pipelines.compute.pending_count() == 0 && self.pipelines.render.pending_count() == 0
         {
             return Ok(0);
         }
@@ -830,7 +829,8 @@ impl AwsmRenderer {
         //    since). Cheap no-op when already warm. Reported under `Compiling`
         //    so loading UIs label the (first-visit-expensive) wait honestly.
         {
-            let pending = self.pipelines.compute.pending_count() + self.pipelines.render.pending_count();
+            let pending =
+                self.pipelines.compute.pending_count() + self.pipelines.render.pending_count();
             if pending > 0 {
                 self.load_phase = LoadPhase::Compiling;
                 let mut stats = self.loading_stats();

--- a/packages/crates/renderer/src/shadows/api.rs
+++ b/packages/crates/renderer/src/shadows/api.rs
@@ -78,6 +78,11 @@ impl AwsmRenderer {
             || self.prep_config.sscs_step_count != config.sscs_step_count;
         self.prep_config.sscs_enabled = config.sscs_enabled;
         self.prep_config.sscs_step_count = config.sscs_step_count;
+        // `denoise` gates whether the prep blur pipelines exist at all (they
+        // are only compiled while it's on). Mirror it so the next
+        // commit_load's config-ensure compiles the pair on an off→on flip;
+        // until then `render_blur` warn-skips (never a frame error).
+        self.prep_config.denoise = config.denoise;
         if recompile {
             self.last_ensured_bucket_layout = None;
             self.materials.mark_variants_dirty();

--- a/packages/crates/renderer/src/textures.rs
+++ b/packages/crates/renderer/src/textures.rs
@@ -163,10 +163,11 @@ impl AwsmRenderer {
         let masked_builtin_missing = self.meshes.iter().any(|(_, mesh)| {
             !mesh.instanced
                 && self.materials.alpha_cutoff(mesh.material_key).is_some()
-                && !self.render_passes.geometry.masked_pipelines.has_variant(
-                    msaa,
-                    self.materials.canonical_shader_id(mesh.material_key),
-                )
+                && !self
+                    .render_passes
+                    .geometry
+                    .masked_pipelines
+                    .has_variant(msaa, self.materials.canonical_shader_id(mesh.material_key))
         });
         let was_dirty = pool_dirty || sampler_pool_dirty;
 

--- a/packages/crates/renderer/src/textures.rs
+++ b/packages/crates/renderer/src/textures.rs
@@ -150,9 +150,27 @@ impl AwsmRenderer {
         // the rebuild below runs; with an unchanged pool the opaque/transparent
         // descriptors below are cache hits and only the new masked variant compiles.
         let force_masked = std::mem::take(&mut self.masked_dynamic_dirty);
+        // A BUILTIN material can also start routing masked with no texture
+        // change — the editor flipping a node's alpha mode to Mask. Nothing
+        // sets a dirty flag on that path, so probe directly: any non-instanced
+        // mesh whose material carries a cutoff but whose masked variant isn't
+        // compiled at the live MSAA needs this rebuild (else it silently
+        // renders solid via the plain-geometry fallback forever).
+        let msaa = match self.anti_aliasing.msaa_sample_count {
+            Some(4) => Some(4u32),
+            _ => None,
+        };
+        let masked_builtin_missing = self.meshes.iter().any(|(_, mesh)| {
+            !mesh.instanced
+                && self.materials.alpha_cutoff(mesh.material_key).is_some()
+                && !self.render_passes.geometry.masked_pipelines.has_variant(
+                    msaa,
+                    self.materials.canonical_shader_id(mesh.material_key),
+                )
+        });
         let was_dirty = pool_dirty || sampler_pool_dirty;
 
-        if !was_dirty && !force_masked {
+        if !was_dirty && !force_masked && !masked_builtin_missing {
             return Ok(());
         }
 

--- a/packages/crates/renderer/src/textures.rs
+++ b/packages/crates/renderer/src/textures.rs
@@ -914,8 +914,25 @@ impl AwsmRenderer {
         // recompiles every bucket against the new pool. `finalize_gpu_textures`
         // runs at the START of `commit_load`, so `mark_variants_dirty` here is
         // consumed by the commit's own `reconcile_material_variants`.
-        self.last_ensured_bucket_layout = None;
-        self.materials.mark_variants_dirty();
+        //
+        // Tier gate: the cache keys embed the PADDED TIER counts (see
+        // `pool_binding_tier`), not the raw pool counts — so this reset is
+        // only needed when the tier of (arrays, samplers) actually crosses a
+        // boundary since the last finalize. Within a tier, growth is absorbed
+        // by the placeholder-padded bind groups rebuilt above.
+        let tier_now = (
+            crate::render_passes::shared::material::bind_group::pool_binding_tier(
+                self.textures.pool.arrays_len(),
+            ),
+            crate::render_passes::shared::material::bind_group::pool_binding_tier(
+                self.textures.pool_sampler_set.len(),
+            ),
+        );
+        if self.last_pool_tier != Some(tier_now) {
+            self.last_ensured_bucket_layout = None;
+            self.materials.mark_variants_dirty();
+            self.last_pool_tier = Some(tier_now);
+        }
 
         // (Removed: the eager `edge_pipelines.ensure_compiled(...)` block that
         // used to recompile the full edge-resolve set HERE, against the new
@@ -994,6 +1011,15 @@ pub struct Textures {
     pub pool: TexturePool<TextureKey>,
     pub pool_sampler_set: IndexSet<SamplerKey>,
     pub texture_transform_identity_offset: usize,
+    /// The shared 1×1 NEUTRAL pool entries (white + flat normal) + the default
+    /// filtering sampler, registered by [`Self::ensure_neutrals`] at build.
+    /// Every unbound built-in texture slot packs one of these, so slot
+    /// sampling is unconditional (branchless) and always an identity
+    /// operation. The default sampler is inserted FIRST so it takes pool
+    /// sampler index 0 (the decal shader hard-codes `pool_sampler_0`).
+    neutral_white: Option<TextureKey>,
+    neutral_flat_normal: Option<TextureKey>,
+    neutral_sampler: Option<SamplerKey>,
     pool_textures: SlotMap<TextureKey, TexturePoolEntryInfo<TextureKey>>,
     cubemaps: SlotMap<CubemapTextureKey, web_sys::GpuTexture>,
     samplers: SlotMap<SamplerKey, web_sys::GpuSampler>,
@@ -1198,6 +1224,9 @@ impl Textures {
         Ok(Self {
             pool: TexturePool::new(),
             pool_sampler_set: IndexSet::new(),
+            neutral_white: None,
+            neutral_flat_normal: None,
+            neutral_sampler: None,
             pool_textures: SlotMap::with_key(),
             cubemaps: SlotMap::with_key(),
             texture_transforms,
@@ -1222,6 +1251,66 @@ impl Textures {
         &self,
     ) -> crate::buffer::mapped_staging_ring::UploadStats {
         self.texture_transforms_uploader.stats()
+    }
+
+    /// Registers the shared NEUTRAL pool entries + default sampler (idempotent;
+    /// called once from `build()`). One 1×1 rgba8 array holds both layers:
+    /// white (identity multiply for base-color / MR / occlusion / emissive)
+    /// and the flat normal (128,128,255 — the same u8 quantization every
+    /// authored normal map's flat regions carry; ~0.2° from exact, invisible).
+    /// The default sampler is inserted before any content sampler so it lands
+    /// at pool index 0.
+    pub(crate) fn ensure_neutrals(&mut self, gpu: &AwsmRendererWebGpu) -> Result<()> {
+        if self.neutral_white.is_some() {
+            return Ok(());
+        }
+        let sampler_key = self.get_sampler_key(gpu, SamplerCacheKey::default())?;
+        if self.pool_sampler_set.insert(sampler_key) {
+            self.sampler_pool_dirty = true;
+        }
+        self.neutral_sampler = Some(sampler_key);
+        let white = self.add_image_rgba_raw(
+            &[255, 255, 255, 255],
+            1,
+            1,
+            sampler_key,
+            TextureColorInfo {
+                mipmap_kind: awsm_renderer_core::texture::mipmap::MipmapTextureKind::Albedo,
+                srgb_to_linear: false,
+                premultiplied_alpha: Some(false),
+            },
+        )?;
+        let flat_normal = self.add_image_rgba_raw(
+            &[128, 128, 255, 255],
+            1,
+            1,
+            sampler_key,
+            TextureColorInfo {
+                mipmap_kind: awsm_renderer_core::texture::mipmap::MipmapTextureKind::Normal,
+                srgb_to_linear: false,
+                premultiplied_alpha: Some(false),
+            },
+        )?;
+        self.neutral_white = Some(white);
+        self.neutral_flat_normal = Some(flat_normal);
+        Ok(())
+    }
+
+    /// The neutral-white pool array's GPU view — the placeholder bound into
+    /// PADDED texture-pool slots (tier > real array count). `None` only
+    /// before the first `finalize_gpu_textures` upload, which precedes any
+    /// bind-group recreate.
+    pub fn pool_placeholder_view(&self) -> Option<&web_sys::GpuTextureView> {
+        let entry = self.pool_textures.get(self.neutral_white?)?;
+        self.pool
+            .array_by_index(entry.array_index)
+            .and_then(|a| a.gpu_texture_view.as_ref())
+    }
+
+    /// The default filtering sampler — the placeholder bound into PADDED
+    /// sampler slots (and pool sampler index 0 from boot).
+    pub fn pool_placeholder_sampler(&self) -> Option<&web_sys::GpuSampler> {
+        self.samplers.get(self.neutral_sampler?)
     }
 
     /// Adds an image to the texture pool and returns its key.
@@ -1686,6 +1775,24 @@ fn create_sampler_key(
 pub use awsm_renderer_core::keys::{SamplerKey, TextureKey, TextureTransformKey};
 
 impl awsm_renderer_materials::TextureContext for Textures {
+    fn neutral_texture(
+        &self,
+        kind: awsm_renderer_materials::NeutralTexture,
+    ) -> Option<(
+        &awsm_renderer_core::texture::texture_pool::TexturePoolArray<TextureKey>,
+        &TexturePoolEntryInfo<TextureKey>,
+        u32,
+    )> {
+        let key = match kind {
+            awsm_renderer_materials::NeutralTexture::White => self.neutral_white?,
+            awsm_renderer_materials::NeutralTexture::FlatNormal => self.neutral_flat_normal?,
+        };
+        let entry = self.pool_textures.get(key)?;
+        let array = self.pool.array_by_index(entry.array_index)?;
+        let sampler_index = self.pool_sampler_set.get_index_of(&self.neutral_sampler?)? as u32;
+        Some((array, entry, sampler_index))
+    }
+
     fn pool_array_by_index(
         &self,
         index: usize,

--- a/packages/crates/scene-loader/src/material.rs
+++ b/packages/crates/scene-loader/src/material.rs
@@ -90,6 +90,17 @@ pub fn material_to_pbr(
     vertex_color_set: Option<u32>,
 ) -> PbrMaterial {
     let mut pbr = PbrMaterial::new(alpha_mode, def.double_sided);
+    // Slot capabilities (declared ∪ bound-on-the-asset) key the bucket, so
+    // every instance of this material shares one pipeline whether or not it
+    // binds an image into a capable slot.
+    let caps = def.slot_capabilities();
+    pbr.texture_capabilities = awsm_renderer::materials::pbr::PbrTextureCapabilities {
+        base_color: caps.base_color,
+        metallic_roughness: caps.metallic_roughness,
+        normal: caps.normal,
+        occlusion: caps.occlusion,
+        emissive: caps.emissive,
+    };
     pbr.base_color_factor = def.base_color;
     pbr.metallic_factor = def.metallic;
     pbr.roughness_factor = def.roughness;
@@ -105,18 +116,15 @@ pub fn material_to_pbr(
     pbr
 }
 
-/// Resolve the authored alpha mode to the renderer's, applying the legacy
-/// "`Opaque` but `base_color.a < 1` ⇒ blend" heuristic the editor has always
-/// used for inline procedural materials.
+/// Resolve the authored alpha mode to the renderer's. A straight type
+/// conversion — per glTF, `Opaque` IGNORES the base-color alpha factor.
+/// (The legacy "`Opaque` but `base_color.a < 1` ⇒ blend" promotion was
+/// removed: it silently rerouted meshes to the transparent pass on a mere
+/// factor tweak — a footgun. Transparency now requires the material to be
+/// explicitly authored `Blend`.)
 pub fn alpha_mode_of(def: &MaterialDef) -> MaterialAlphaMode {
     match def.alpha_mode {
-        awsm_renderer_scene::MaterialAlphaMode::Opaque => {
-            if def.base_color[3] < 0.999 {
-                MaterialAlphaMode::Blend
-            } else {
-                MaterialAlphaMode::Opaque
-            }
-        }
+        awsm_renderer_scene::MaterialAlphaMode::Opaque => MaterialAlphaMode::Opaque,
         awsm_renderer_scene::MaterialAlphaMode::Mask { cutoff } => {
             MaterialAlphaMode::Mask { cutoff }
         }
@@ -241,14 +249,16 @@ mod tests {
         MaterialDef::default()
     }
 
-    // ── alpha_mode_of: the legacy opaque-but-translucent heuristic ───────────
+    // ── alpha_mode_of: a straight type conversion (per glTF, opaque ignores
+    //    the base-color alpha factor — the legacy translucent-base→blend
+    //    promotion is gone; transparency must be authored `Blend`) ──────────
 
     #[test]
-    fn alpha_opaque_with_translucent_base_becomes_blend() {
+    fn alpha_opaque_ignores_translucent_base() {
         let mut d = def();
         d.alpha_mode = awsm_renderer_scene::MaterialAlphaMode::Opaque;
         d.base_color = [1.0, 1.0, 1.0, 0.5];
-        assert_eq!(alpha_mode_of(&d), MaterialAlphaMode::Blend);
+        assert_eq!(alpha_mode_of(&d), MaterialAlphaMode::Opaque);
     }
 
     #[test]
@@ -259,15 +269,28 @@ mod tests {
         assert_eq!(alpha_mode_of(&d), MaterialAlphaMode::Opaque);
     }
 
+    // Capability plumbing: a declared-but-unbound slot must reach the
+    // renderer material's capability mask, so the bucket compiles the
+    // (runtime-guarded) sampling path and instances can bind images later
+    // with no recompile.
     #[test]
-    fn alpha_opaque_heuristic_threshold_is_0_999() {
+    fn declared_capability_reaches_pbr_material() {
+        use awsm_renderer_scene::material::TextureCapabilities;
         let mut d = def();
-        d.alpha_mode = awsm_renderer_scene::MaterialAlphaMode::Opaque;
-        // 0.999 is NOT < 0.999 → opaque; just under it → blend.
-        d.base_color[3] = 0.999;
-        assert_eq!(alpha_mode_of(&d), MaterialAlphaMode::Opaque);
-        d.base_color[3] = 0.998;
-        assert_eq!(alpha_mode_of(&d), MaterialAlphaMode::Blend);
+        d.texture_capabilities = Some(TextureCapabilities {
+            normal: true,
+            ..Default::default()
+        });
+        let pbr = material_to_pbr(&d, alpha_mode_of(&d), None);
+        assert!(pbr.texture_capabilities.normal);
+        assert!(!pbr.texture_capabilities.emissive);
+        use awsm_renderer::materials::pbr::PbrFeatures;
+        let features = PbrFeatures::from_material(&pbr);
+        assert!(
+            features.normal_tex,
+            "capable-but-unbound slot must set the feature bit"
+        );
+        assert!(!features.emissive_tex);
     }
 
     #[test]

--- a/packages/crates/scene-loader/src/material.rs
+++ b/packages/crates/scene-loader/src/material.rs
@@ -90,17 +90,6 @@ pub fn material_to_pbr(
     vertex_color_set: Option<u32>,
 ) -> PbrMaterial {
     let mut pbr = PbrMaterial::new(alpha_mode, def.double_sided);
-    // Slot capabilities (declared ∪ bound-on-the-asset) key the bucket, so
-    // every instance of this material shares one pipeline whether or not it
-    // binds an image into a capable slot.
-    let caps = def.slot_capabilities();
-    pbr.texture_capabilities = awsm_renderer::materials::pbr::PbrTextureCapabilities {
-        base_color: caps.base_color,
-        metallic_roughness: caps.metallic_roughness,
-        normal: caps.normal,
-        occlusion: caps.occlusion,
-        emissive: caps.emissive,
-    };
     pbr.base_color_factor = def.base_color;
     pbr.metallic_factor = def.metallic;
     pbr.roughness_factor = def.roughness;
@@ -269,28 +258,22 @@ mod tests {
         assert_eq!(alpha_mode_of(&d), MaterialAlphaMode::Opaque);
     }
 
-    // Capability plumbing: a declared-but-unbound slot must reach the
-    // renderer material's capability mask, so the bucket compiles the
-    // (runtime-guarded) sampling path and instances can bind images later
-    // with no recompile.
+    // The five texture-slot feature bits are RETIRED: texture presence must
+    // NOT split buckets (an unbound slot samples the shared 1x1 neutral).
     #[test]
-    fn declared_capability_reaches_pbr_material() {
-        use awsm_renderer_scene::material::TextureCapabilities;
-        let mut d = def();
-        d.texture_capabilities = Some(TextureCapabilities {
-            normal: true,
-            ..Default::default()
-        });
-        let pbr = material_to_pbr(&d, alpha_mode_of(&d), None);
-        assert!(pbr.texture_capabilities.normal);
-        assert!(!pbr.texture_capabilities.emissive);
+    fn texture_presence_does_not_split_buckets() {
         use awsm_renderer::materials::pbr::PbrFeatures;
-        let features = PbrFeatures::from_material(&pbr);
-        assert!(
-            features.normal_tex,
-            "capable-but-unbound slot must set the feature bit"
+        let plain = material_to_pbr(&def(), MaterialAlphaMode::Opaque, None);
+        let mut with_tex = def();
+        with_tex.normal_texture = Some(awsm_renderer_scene::TextureRef::new(
+            awsm_renderer_scene::AssetId::new(),
+        ));
+        let textured = material_to_pbr(&with_tex, MaterialAlphaMode::Opaque, None);
+        assert_eq!(
+            PbrFeatures::from_material(&plain).bits(),
+            PbrFeatures::from_material(&textured).bits(),
+            "texture binds are data-only and must never re-key the bucket"
         );
-        assert!(!features.emissive_tex);
     }
 
     #[test]

--- a/packages/crates/scene/src/material.rs
+++ b/packages/crates/scene/src/material.rs
@@ -51,11 +51,11 @@ pub struct MaterialDef {
     pub occlusion_strength: f32,
     pub double_sided: bool,
     pub vertex_colors_enabled: bool,
-    /// glTF-style alpha rendering mode. Defaults to `Opaque` so
-    /// pre-extension project.json round-trips identically (the
-    /// material_to_pbr translation then falls back to the
-    /// "base_color.a < 1 → blend" heuristic the editor has always used
-    /// for inline procedural materials).
+    /// glTF-style alpha rendering mode. Defaults to `Opaque`, which — per
+    /// glTF — IGNORES the base-color alpha factor. Transparency requires
+    /// explicitly authoring `Blend`; cutouts require `Mask`. The alpha mode
+    /// is pipeline ROUTING and therefore owned by the material asset alone
+    /// (never a per-node override).
     #[serde(default)]
     pub alpha_mode: MaterialAlphaMode,
     /// Shading model selector. `Pbr` is the default; `Unlit` is the existing
@@ -65,8 +65,47 @@ pub struct MaterialDef {
     /// Optional KHR PBR extensions (only meaningful when `shading == Pbr`). Each
     /// enabled extension is a variant bit; its factors are per-mesh uniforms.
     /// `#[serde(default)]` so pre-extension projects round-trip cleanly.
+    ///
+    /// Extensions are STRICT capabilities: enabling one on the material means
+    /// every mesh using this material runs its code unconditionally (nodes
+    /// override only the parameter uniforms). A mesh that shouldn't have the
+    /// extension uses a different material.
     #[serde(default)]
     pub extensions: PbrExtensions,
+    /// Texture-slot CAPABILITIES — which of the five standard PBR slots this
+    /// material's compiled shader is ABLE to sample. Declaring a capability
+    /// compiles the slot's sampling path in (guarded by a cheap per-material
+    /// runtime "bound?" check), so meshes sharing this material can each bind
+    /// or omit an image without minting a new pipeline. A slot that is neither
+    /// declared here nor bound on the material itself compiles NO code and
+    /// per-node binds to it are rejected.
+    ///
+    /// `None` (the default, and every pre-capability project) derives the
+    /// capabilities from texture presence — byte-identical pipelines to the
+    /// old behavior. Binding a texture on the material always implies the
+    /// capability; this field can only WIDEN, never narrow. See
+    /// [`MaterialDef::slot_capabilities`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub texture_capabilities: Option<TextureCapabilities>,
+}
+
+/// Which of the five standard PBR texture slots a material's shader can
+/// sample — the compile-time half of the capability/usage split (usage is the
+/// per-mesh binding). See [`MaterialDef::texture_capabilities`].
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct TextureCapabilities {
+    #[serde(default)]
+    pub base_color: bool,
+    #[serde(default)]
+    pub metallic_roughness: bool,
+    #[serde(default)]
+    pub normal: bool,
+    #[serde(default)]
+    pub occlusion: bool,
+    #[serde(default)]
+    pub emissive: bool,
 }
 
 fn default_one() -> f32 {
@@ -93,6 +132,23 @@ impl MaterialDef {
         }
         self.extensions.texture_refs(&mut out);
         out
+    }
+
+    /// EFFECTIVE slot capabilities: the declared [`Self::texture_capabilities`]
+    /// widened by the material's own bound textures (a bound default image
+    /// always implies the capability). This — not raw texture presence — is
+    /// what keys the compiled shader's feature set, so meshes sharing this
+    /// material share one pipeline regardless of which of them bind images.
+    pub fn slot_capabilities(&self) -> TextureCapabilities {
+        let declared = self.texture_capabilities.unwrap_or_default();
+        TextureCapabilities {
+            base_color: declared.base_color || self.base_color_texture.is_some(),
+            metallic_roughness: declared.metallic_roughness
+                || self.metallic_roughness_texture.is_some(),
+            normal: declared.normal || self.normal_texture.is_some(),
+            occlusion: declared.occlusion || self.occlusion_texture.is_some(),
+            emissive: declared.emissive || self.emissive_texture.is_some(),
+        }
     }
 }
 
@@ -132,6 +188,7 @@ impl Default for MaterialDef {
             alpha_mode: MaterialAlphaMode::Opaque,
             shading: MaterialShading::Pbr,
             extensions: PbrExtensions::default(),
+            texture_capabilities: None,
         }
     }
 }
@@ -286,25 +343,33 @@ impl PbrExtensions {
 
     /// The per-mesh MERGED view of a node's `inline` extension layer over the
     /// shared library `variant`: per extension, the inline value wins when
-    /// present, otherwise the variant's authored values carry through —
-    /// presence in EITHER layer enables the extension (an inline-only
-    /// extension re-specializes that mesh's pipeline, mirroring texture-slot
-    /// presence). THE single definition of this rule: the editor's mesh
-    /// materialization and the inspector's extension controls both call this,
-    /// so what the UI shows is what actually renders.
+    /// present, otherwise the variant's authored values carry through.
+    /// Extensions are STRICT capabilities: the ENABLE set comes from the
+    /// shared `variant` alone (an extension is pipeline-shaped — enabling one
+    /// is a material edit, never a per-node override), while an enabled
+    /// extension's per-mesh PARAMETERS come from `inline` when seeded there.
+    /// An inline-only extension (variant disabled) is dropped — it can't
+    /// render without the variant's compiled code. THE single definition of
+    /// this rule: the editor's mesh materialization and the inspector's
+    /// extension controls both call this, so what the UI shows is what
+    /// actually renders.
     pub fn merged_over(inline: &Self, variant: &Self) -> Self {
         Self {
-            emissive_strength: inline.emissive_strength.or(variant.emissive_strength),
-            ior: inline.ior.or(variant.ior),
-            specular: inline.specular.or(variant.specular),
-            transmission: inline.transmission.or(variant.transmission),
-            diffuse_transmission: inline.diffuse_transmission.or(variant.diffuse_transmission),
-            volume: inline.volume.or(variant.volume),
-            clearcoat: inline.clearcoat.or(variant.clearcoat),
-            sheen: inline.sheen.or(variant.sheen),
-            dispersion: inline.dispersion.or(variant.dispersion),
-            anisotropy: inline.anisotropy.or(variant.anisotropy),
-            iridescence: inline.iridescence.or(variant.iridescence),
+            emissive_strength: variant
+                .emissive_strength
+                .map(|v| inline.emissive_strength.unwrap_or(v)),
+            ior: variant.ior.map(|v| inline.ior.unwrap_or(v)),
+            specular: variant.specular.map(|v| inline.specular.unwrap_or(v)),
+            transmission: variant.transmission.map(|v| inline.transmission.unwrap_or(v)),
+            diffuse_transmission: variant
+                .diffuse_transmission
+                .map(|v| inline.diffuse_transmission.unwrap_or(v)),
+            volume: variant.volume.map(|v| inline.volume.unwrap_or(v)),
+            clearcoat: variant.clearcoat.map(|v| inline.clearcoat.unwrap_or(v)),
+            sheen: variant.sheen.map(|v| inline.sheen.unwrap_or(v)),
+            dispersion: variant.dispersion.map(|v| inline.dispersion.unwrap_or(v)),
+            anisotropy: variant.anisotropy.map(|v| inline.anisotropy.unwrap_or(v)),
+            iridescence: variant.iridescence.map(|v| inline.iridescence.unwrap_or(v)),
         }
     }
 }

--- a/packages/crates/scene/src/material.rs
+++ b/packages/crates/scene/src/material.rs
@@ -72,40 +72,6 @@ pub struct MaterialDef {
     /// extension uses a different material.
     #[serde(default)]
     pub extensions: PbrExtensions,
-    /// Texture-slot CAPABILITIES — which of the five standard PBR slots this
-    /// material's compiled shader is ABLE to sample. Declaring a capability
-    /// compiles the slot's sampling path in (guarded by a cheap per-material
-    /// runtime "bound?" check), so meshes sharing this material can each bind
-    /// or omit an image without minting a new pipeline. A slot that is neither
-    /// declared here nor bound on the material itself compiles NO code and
-    /// per-node binds to it are rejected.
-    ///
-    /// `None` (the default, and every pre-capability project) derives the
-    /// capabilities from texture presence — byte-identical pipelines to the
-    /// old behavior. Binding a texture on the material always implies the
-    /// capability; this field can only WIDEN, never narrow. See
-    /// [`MaterialDef::slot_capabilities`].
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub texture_capabilities: Option<TextureCapabilities>,
-}
-
-/// Which of the five standard PBR texture slots a material's shader can
-/// sample — the compile-time half of the capability/usage split (usage is the
-/// per-mesh binding). See [`MaterialDef::texture_capabilities`].
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-pub struct TextureCapabilities {
-    #[serde(default)]
-    pub base_color: bool,
-    #[serde(default)]
-    pub metallic_roughness: bool,
-    #[serde(default)]
-    pub normal: bool,
-    #[serde(default)]
-    pub occlusion: bool,
-    #[serde(default)]
-    pub emissive: bool,
 }
 
 fn default_one() -> f32 {
@@ -132,23 +98,6 @@ impl MaterialDef {
         }
         self.extensions.texture_refs(&mut out);
         out
-    }
-
-    /// EFFECTIVE slot capabilities: the declared [`Self::texture_capabilities`]
-    /// widened by the material's own bound textures (a bound default image
-    /// always implies the capability). This — not raw texture presence — is
-    /// what keys the compiled shader's feature set, so meshes sharing this
-    /// material share one pipeline regardless of which of them bind images.
-    pub fn slot_capabilities(&self) -> TextureCapabilities {
-        let declared = self.texture_capabilities.unwrap_or_default();
-        TextureCapabilities {
-            base_color: declared.base_color || self.base_color_texture.is_some(),
-            metallic_roughness: declared.metallic_roughness
-                || self.metallic_roughness_texture.is_some(),
-            normal: declared.normal || self.normal_texture.is_some(),
-            occlusion: declared.occlusion || self.occlusion_texture.is_some(),
-            emissive: declared.emissive || self.emissive_texture.is_some(),
-        }
     }
 }
 
@@ -188,7 +137,6 @@ impl Default for MaterialDef {
             alpha_mode: MaterialAlphaMode::Opaque,
             shading: MaterialShading::Pbr,
             extensions: PbrExtensions::default(),
-            texture_capabilities: None,
         }
     }
 }
@@ -360,7 +308,9 @@ impl PbrExtensions {
                 .map(|v| inline.emissive_strength.unwrap_or(v)),
             ior: variant.ior.map(|v| inline.ior.unwrap_or(v)),
             specular: variant.specular.map(|v| inline.specular.unwrap_or(v)),
-            transmission: variant.transmission.map(|v| inline.transmission.unwrap_or(v)),
+            transmission: variant
+                .transmission
+                .map(|v| inline.transmission.unwrap_or(v)),
             diffuse_transmission: variant
                 .diffuse_transmission
                 .map(|v| inline.diffuse_transmission.unwrap_or(v)),

--- a/packages/frontend/editor/Cargo.toml
+++ b/packages/frontend/editor/Cargo.toml
@@ -27,6 +27,9 @@ awsm-renderer = { workspace = true, features = ["ktx", "serde", "texture-export"
 awsm-renderer-core = { workspace = true }
 awsm-renderer-gltf = { workspace = true }
 awsm-renderer-scene-loader = { workspace = true }
+# Direct dep for the RUNTIME asset-table types (editor-protocol's glob
+# re-export shadows AssetSource/AssetEntry with its authoring variants).
+awsm-renderer-scene = { workspace = true }
 awsm-renderer-editor-protocol = { workspace = true }
 awsm-renderer-web-shared = { workspace = true }
 

--- a/packages/frontend/editor/src/controller/export.rs
+++ b/packages/frontend/editor/src/controller/export.rs
@@ -258,7 +258,7 @@ pub async fn bake_player_bundle(
     for n in &roots {
         collect_skinned(n, &mut skinned_sources, &mut lod_skinned);
     }
-    for src in skinned_sources {
+    for &src in &skinned_sources {
         if let Some(glb) = crate::engine::bridge::skinned_bake_cache::get_rig_glb(src) {
             // Bake LOD levels (from the rig glb bytes) before `glb` is moved.
             let lod_files = if lod_skinned.contains(&src) {
@@ -282,7 +282,64 @@ pub async fn bake_player_bundle(
         files.push(BundleFile::new(path, bytes));
     }
 
-    // 6. Environment skybox / IBL KTX2 cubemaps → the shared `env_ktx_path`
+    // 6. Baked-asset-table hygiene. The editor keeps `AssetSource::Filename`
+    //    as import-provenance (a UI label; the editor's on-disk path derives
+    //    from `content_hash`), but in a BAKED bundle that filename is the only
+    //    path downstream tooling (CAS publishers re-hashing file-backed
+    //    entries) can resolve the shipped bytes by. Two fixes:
+    //    * a shipped skinned rig's entry is rewritten to name the file that
+    //      ACTUALLY ships (`assets/<uuid>.glb`, step 4) instead of the
+    //      original import filename (which is not in the bundle), and
+    //    * Filename entries nothing references at runtime (e.g. the original
+    //      combined glb of a fully static import — its geometry ships as
+    //      per-mesh baked glbs) are dropped from the baked table entirely.
+    //    Cluster sources keep their entries (their side files ship keyed by
+    //    the asset id, `assets/<source>.clusters.bin`).
+    {
+        fn collect_cluster_sources(node: &Node, out: &mut HashSet<AssetId>) {
+            if let NodeKind::ClusterMesh { cluster, .. } = &node.kind.get_cloned() {
+                out.insert(cluster.source);
+            }
+            for c in node.children.lock_ref().iter() {
+                collect_cluster_sources(c, out);
+            }
+        }
+        let mut cluster_sources: HashSet<AssetId> = HashSet::new();
+        for n in &roots {
+            collect_cluster_sources(n, &mut cluster_sources);
+        }
+        let mut dropped = 0usize;
+        scene.assets.entries.retain(|id, entry| {
+            if !matches!(entry.source, awsm_renderer_scene::AssetSource::Filename(_)) {
+                return true;
+            }
+            if skinned_sources.contains(id) {
+                return true;
+            }
+            if cluster_sources.contains(id) {
+                return true;
+            }
+            dropped += 1;
+            false
+        });
+        for src in &skinned_sources {
+            if let Some(entry) = scene.assets.entries.get_mut(src) {
+                if matches!(entry.source, awsm_renderer_scene::AssetSource::Filename(_)) {
+                    entry.source = awsm_renderer_scene::AssetSource::Filename(
+                        awsm_renderer_editor_protocol::mesh_glb_filename(*src),
+                    );
+                }
+            }
+        }
+        if dropped > 0 {
+            tracing::info!(
+                "bundle bake: dropped {dropped} import-provenance asset entr{}                  (no runtime reference)",
+                if dropped == 1 { "y" } else { "ies" }
+            );
+        }
+    }
+
+    // 7. Environment skybox / IBL KTX2 cubemaps → the shared `env_ktx_path`
     //    convention (`assets/<id>.ktx2`) the player's `scene_loader::environment`
     //    fetches. STRICT (unlike Save's `ktx_files`): a KTX env id whose bytes
     //    can't be resolved FAILS the export instead of silently baking a bundle

--- a/packages/frontend/editor/src/controller/state.rs
+++ b/packages/frontend/editor/src/controller/state.rs
@@ -2711,36 +2711,6 @@ impl EditorController {
                 Some(n) => {
                     let prev = n.kind.get_cloned();
                     let mut next = prev.clone();
-                    // BINDING (not clearing) requires the slot to be CAPABLE on
-                    // the assigned library material — capability is pipeline
-                    // identity and lives on the material asset; a per-node bind
-                    // can only fill a slot the material's shader can sample.
-                    if texture.is_some() {
-                        if let Some(asset) = node_material_mut(&mut next).map(|inst| inst.asset) {
-                            let capable = find_material(&self.custom_materials, asset)
-                                .and_then(|m| m.builtin.get_cloned())
-                                .is_some_and(|def| {
-                                    let caps = def.slot_capabilities();
-                                    use awsm_renderer_editor_protocol::BuiltinTextureSlot as S;
-                                    match slot {
-                                        S::BaseColor => caps.base_color,
-                                        S::MetallicRoughness => caps.metallic_roughness,
-                                        S::Normal => caps.normal,
-                                        S::Occlusion => caps.occlusion,
-                                        S::Emissive => caps.emissive,
-                                    }
-                                });
-                            if !capable {
-                                return Err(crate::error::EditorError::msg(format!(
-                                    "slot {slot:?} is not a capability of this node's material — \
-                                     texture-slot capabilities are pipeline identity and live on \
-                                     the material asset. Enable the slot on the material first \
-                                     (update_builtin_material with texture_capabilities, or bind \
-                                     a default image there), then bind per-node images freely."
-                                )));
-                            }
-                        }
-                    }
                     if !patch_builtin_texture(&mut next, slot, texture) {
                         return Ok(None);
                     }

--- a/packages/frontend/editor/src/controller/state.rs
+++ b/packages/frontend/editor/src/controller/state.rs
@@ -2680,25 +2680,28 @@ impl EditorController {
                 )),
                 }
             }
-            EditorCommand::SetBuiltinAlphaMode { node, mode } => {
-                match mutate::find_by_id(&self.scene, node) {
-                    Some(n) => {
-                        let prev = n.kind.get_cloned();
-                        let mut next = prev.clone();
-                        if !patch_builtin_alpha_mode(&mut next, mode) {
-                            return Ok(None);
-                        }
-                        n.kind.set(next);
-                        self.scene.bump_revision();
-                        Ok(Some(EditorCommand::SetKind {
-                            id: node,
-                            kind: Box::new(prev),
-                        }))
-                    }
-                    None => Err(crate::error::EditorError::msg(
-                    "target id not found — command not applied (check ids against get_snapshot)",
-                )),
-                }
+            EditorCommand::SetBuiltinAlphaMode { material, mode } => {
+                // Alpha mode is pipeline routing → a MATERIAL edit. Delegate to
+                // the full def-update path (thumbnail refresh, per-mesh inline
+                // reseed, inspector rebuild, inverse = prior def) so the typed
+                // command and `update_builtin_material` behave identically.
+                let Some(mat) = find_material(&self.custom_materials, material) else {
+                    return Err(crate::error::EditorError::msg(format!(
+                        "no material {material}"
+                    )));
+                };
+                let Some(mut def) = mat.builtin.get_cloned() else {
+                    return Err(crate::error::EditorError::msg(format!(
+                        "material {material} is not a built-in (custom WGSL materials \
+                         author their alpha via set_material_alpha_wgsl)"
+                    )));
+                };
+                def.alpha_mode = mode;
+                Box::pin(self.apply_inner(EditorCommand::UpdateBuiltinMaterial {
+                    id: material,
+                    def: Box::new(def),
+                }))
+                .await
             }
             EditorCommand::SetBuiltinTexture {
                 node,
@@ -2708,6 +2711,36 @@ impl EditorController {
                 Some(n) => {
                     let prev = n.kind.get_cloned();
                     let mut next = prev.clone();
+                    // BINDING (not clearing) requires the slot to be CAPABLE on
+                    // the assigned library material — capability is pipeline
+                    // identity and lives on the material asset; a per-node bind
+                    // can only fill a slot the material's shader can sample.
+                    if texture.is_some() {
+                        if let Some(asset) = node_material_mut(&mut next).map(|inst| inst.asset) {
+                            let capable = find_material(&self.custom_materials, asset)
+                                .and_then(|m| m.builtin.get_cloned())
+                                .is_some_and(|def| {
+                                    let caps = def.slot_capabilities();
+                                    use awsm_renderer_editor_protocol::BuiltinTextureSlot as S;
+                                    match slot {
+                                        S::BaseColor => caps.base_color,
+                                        S::MetallicRoughness => caps.metallic_roughness,
+                                        S::Normal => caps.normal,
+                                        S::Occlusion => caps.occlusion,
+                                        S::Emissive => caps.emissive,
+                                    }
+                                });
+                            if !capable {
+                                return Err(crate::error::EditorError::msg(format!(
+                                    "slot {slot:?} is not a capability of this node's material — \
+                                     texture-slot capabilities are pipeline identity and live on \
+                                     the material asset. Enable the slot on the material first \
+                                     (update_builtin_material with texture_capabilities, or bind \
+                                     a default image there), then bind per-node images freely."
+                                )));
+                            }
+                        }
+                    }
                     if !patch_builtin_texture(&mut next, slot, texture) {
                         return Ok(None);
                     }
@@ -7614,21 +7647,6 @@ fn patch_builtin_param(
             }
         }
     }
-    true
-}
-
-/// Set the alpha mode (Opaque | Mask { cutoff } | Blend) of a node's
-/// **built-in/inline** `MaterialDef` (§13). Changing the mode is a pipeline
-/// feature flip, so the node re-materializes (the kind observer). Returns false
-/// if the node has no inline material (unassigned / non-geometry).
-fn patch_builtin_alpha_mode(
-    kind: &mut NodeKind,
-    mode: awsm_renderer_editor_protocol::MaterialAlphaMode,
-) -> bool {
-    let Some(inst) = node_material_mut(kind) else {
-        return false;
-    };
-    inst.inline.alpha_mode = mode;
     true
 }
 

--- a/packages/frontend/editor/src/engine/bridge/node_sync.rs
+++ b/packages/frontend/editor/src/engine/bridge/node_sync.rs
@@ -775,20 +775,14 @@ pub(crate) fn merged_builtin_def(
     // binding/unbinding an image is a data write — never a recompile, and
     // never a per-mesh pipeline.
 
-    // Texture binding: only CAPABLE slots accept a binding — per-mesh `inline`
-    // image wins, then a custom `texture_overrides` swap, then the variant's
-    // default image. Non-capable slots merge to `None` unconditionally
-    // (`set_node_texture` rejects them at command time; this drop is the
-    // belt-and-braces for stale stored bindings).
-    let caps = variant.slot_capabilities();
-    let tex = |capable: bool,
-               slot: &str,
+    // Texture binding is pure DATA — every slot's sampling code is always
+    // compiled (unbound slots pack the shared 1×1 neutral), so a per-mesh
+    // `inline` image wins, then a custom `texture_overrides` swap, then the
+    // variant's default image. Binds never re-key the pipeline.
+    let tex = |slot: &str,
                inline_tex: Option<TextureRef>,
                default: Option<TextureRef>|
      -> Option<TextureRef> {
-        if !capable {
-            return None;
-        }
         merge_slot_texture(
             inline_tex,
             inst.texture_overrides.get(slot).cloned(),
@@ -829,31 +823,26 @@ pub(crate) fn merged_builtin_def(
         normal_scale: inline.normal_scale,
         occlusion_strength: inline.occlusion_strength,
         base_color_texture: tex(
-            caps.base_color,
             "base_color_texture",
             inline.base_color_texture,
             variant.base_color_texture,
         ),
         metallic_roughness_texture: tex(
-            caps.metallic_roughness,
             "metallic_roughness_texture",
             inline.metallic_roughness_texture,
             variant.metallic_roughness_texture,
         ),
         normal_texture: tex(
-            caps.normal,
             "normal_texture",
             inline.normal_texture,
             variant.normal_texture,
         ),
         occlusion_texture: tex(
-            caps.occlusion,
             "occlusion_texture",
             inline.occlusion_texture,
             variant.occlusion_texture,
         ),
         emissive_texture: tex(
-            caps.emissive,
             "emissive_texture",
             inline.emissive_texture,
             variant.emissive_texture,
@@ -861,11 +850,6 @@ pub(crate) fn merged_builtin_def(
         alpha_mode,
         shading,
         extensions,
-        // Carry the EFFECTIVE capabilities (declared ∪ variant-bound) so the
-        // flattened export def keys the same bucket in the player as the
-        // shared variant does in the editor — even for capable slots nobody
-        // bound an image into.
-        texture_capabilities: Some(caps),
         // variant-only: double_sided, vertex_colors_enabled, label.
         ..variant.clone()
     }
@@ -2066,48 +2050,37 @@ mod builtin_merge_tests {
     fn alpha_mode_is_variant_only() {
         use awsm_renderer_editor_protocol::material::MaterialAlphaMode;
         let variant = MaterialDef::default(); // Opaque
-        let mut inline = MaterialDef::default();
-        inline.alpha_mode = MaterialAlphaMode::Mask { cutoff: 0.5 };
+        let inline = MaterialDef {
+            alpha_mode: MaterialAlphaMode::Mask { cutoff: 0.5 },
+            ..Default::default()
+        };
         let merged = merged_builtin_def(&inst(inline), &variant);
         assert_eq!(merged.alpha_mode, MaterialAlphaMode::Opaque);
 
-        let mut mask_variant = MaterialDef::default();
-        mask_variant.alpha_mode = MaterialAlphaMode::Mask { cutoff: 0.5 };
-        let mut inline = MaterialDef::default();
-        inline.alpha_mode = MaterialAlphaMode::Mask { cutoff: 0.25 };
+        let mask_variant = MaterialDef {
+            alpha_mode: MaterialAlphaMode::Mask { cutoff: 0.5 },
+            ..Default::default()
+        };
+        let inline = MaterialDef {
+            alpha_mode: MaterialAlphaMode::Mask { cutoff: 0.25 },
+            ..Default::default()
+        };
         let merged = merged_builtin_def(&inst(inline), &mask_variant);
         assert_eq!(merged.alpha_mode, MaterialAlphaMode::Mask { cutoff: 0.25 });
     }
 
-    // Texture-slot capability: an inline image binds only into a CAPABLE slot
-    // (declared on the variant, or implied by the variant's own binding). A
-    // non-capable inline binding is dropped; a declared-but-unbound capability
-    // accepts it and the merged def carries the effective capabilities so the
-    // player keys the same bucket.
+    // Texture binds are pure data: an inline image binds into ANY slot (the
+    // slot code is always compiled; unbound slots sample the 1×1 neutral).
     #[test]
-    fn inline_textures_bind_only_capable_slots() {
-        use awsm_renderer_editor_protocol::material::TextureCapabilities;
-        // Variant declares the normal slot capable but binds no image.
-        let mut variant = MaterialDef::default();
-        variant.texture_capabilities = Some(TextureCapabilities {
-            normal: true,
+    fn inline_textures_bind_any_slot() {
+        let variant = MaterialDef::default();
+        let inline = MaterialDef {
+            normal_texture: Some(TextureRef::new(AssetId::new())),
+            emissive_texture: Some(TextureRef::new(AssetId::new())),
             ..Default::default()
-        });
-        let mut inline = MaterialDef::default();
-        inline.normal_texture = Some(TextureRef::new(AssetId::new()));
-        inline.emissive_texture = Some(TextureRef::new(AssetId::new()));
+        };
         let merged = merged_builtin_def(&inst(inline), &variant);
-        assert!(
-            merged.normal_texture.is_some(),
-            "capable slot accepts the per-node image"
-        );
-        assert!(
-            merged.emissive_texture.is_none(),
-            "non-capable slot drops the per-node image"
-        );
-        let caps = merged
-            .texture_capabilities
-            .expect("merged def carries effective capabilities");
-        assert!(caps.normal && !caps.emissive);
+        assert!(merged.normal_texture.is_some());
+        assert!(merged.emissive_texture.is_some());
     }
 }

--- a/packages/frontend/editor/src/engine/bridge/node_sync.rs
+++ b/packages/frontend/editor/src/engine/bridge/node_sync.rs
@@ -803,12 +803,24 @@ pub(crate) fn merged_builtin_def(
     // the UI shows exactly what renders.
     let extensions = PbrExtensions::merged_over(&inline.extensions, &variant.extensions);
 
-    // Alpha MODE (Opaque/Mask/Blend) is variant routing; the Mask *cutoff* value
-    // is a per-mesh uniform compare, so carry it from inline when both are Mask.
+    // Alpha MODE (Opaque/Mask/Blend): a NON-DEFAULT per-node `inline` mode wins
+    // (what `set_builtin_alpha_mode` / the inspector dropdown write) — like
+    // texture-slot presence (§11 above), it re-specializes THIS mesh's routing
+    // instead of being silently dropped. `inline` Opaque is the unset default,
+    // so it falls through to the shared variant's authored mode (assigning a
+    // Blend/Mask library material keeps working). The Mask *cutoff* is a
+    // per-mesh uniform compare, so inline's value also wins when both layers
+    // are Mask.
+    //
+    // (Regression this fixes: per-node `mask` was ignored → mode stayed the
+    // variant's Opaque → the lowering's `alpha_mode_of` convenience heuristic
+    // saw base_color.a < 1 and routed the mesh to the BLEND/transparent pass —
+    // ghost render, no cutout, no shadow.)
     let alpha_mode = match (&variant.alpha_mode, &inline.alpha_mode) {
         (MaterialAlphaMode::Mask { .. }, MaterialAlphaMode::Mask { cutoff }) => {
             MaterialAlphaMode::Mask { cutoff: *cutoff }
         }
+        (_, inline_mode) if *inline_mode != MaterialAlphaMode::Opaque => inline_mode.clone(),
         _ => variant.alpha_mode.clone(),
     };
 

--- a/packages/frontend/editor/src/engine/bridge/node_sync.rs
+++ b/packages/frontend/editor/src/engine/bridge/node_sync.rs
@@ -764,27 +764,31 @@ pub(crate) fn merged_builtin_def(
     use awsm_renderer_editor_protocol::TextureRef;
     let inline = &inst.inline;
 
-    // ── The override rule ────────────────────────────────────────────────────
-    // Most VARIANT fields (shading model, alpha *mode*, double-sided cull,
-    // vertex-colors, KHR extension *enables*) come ONLY from the shared `variant`,
-    // so meshes sharing those features share one pipeline. The uniform-buffer
-    // surface — factors + extension *parameters* + Toon knobs + mask cutoff — is
-    // per-mesh from `inline`.
-    //
-    // Texture-slot *presence* (§11) is ALSO per-mesh: a per-node `inline` texture
-    // (what `set_node_texture` / `set_node_texture_transform` write) ENABLES the
-    // slot even when the shared variant lacks it, re-specializing THIS mesh's
-    // pipeline to sample it — instead of storing the binding and silently
-    // rendering flat. Variants key on texture *presence* (not the image), so this
-    // adds at most one extra bucket per distinct slot-presence combination, not
-    // one per mesh; the bound *image* is still a per-mesh binding (no recompile).
+    // ── The override rule: the MATERIAL owns the pipeline, the NODE owns data ─
+    // Everything pipeline-shaped comes ONLY from the shared `variant`: shading
+    // model, alpha MODE, double-sided cull, vertex-colors, extension ENABLES,
+    // and texture-slot CAPABILITIES. The per-mesh `inline` surface is pure
+    // data: factors, extension PARAMETERS (where the variant enables the
+    // extension), Toon/FlipBook knobs, the Mask cutoff value, and texture
+    // IMAGES bound into CAPABLE slots. A capable slot's sampling code is
+    // compiled into the shared bucket behind a runtime `exists` flag, so
+    // binding/unbinding an image is a data write — never a recompile, and
+    // never a per-mesh pipeline.
 
-    // Texture binding: per-mesh `inline` texture wins (+ enables the slot), then a
-    // custom `texture_overrides` swap, then the shared variant's default image.
-    let tex = |slot: &str,
+    // Texture binding: only CAPABLE slots accept a binding — per-mesh `inline`
+    // image wins, then a custom `texture_overrides` swap, then the variant's
+    // default image. Non-capable slots merge to `None` unconditionally
+    // (`set_node_texture` rejects them at command time; this drop is the
+    // belt-and-braces for stale stored bindings).
+    let caps = variant.slot_capabilities();
+    let tex = |capable: bool,
+               slot: &str,
                inline_tex: Option<TextureRef>,
                default: Option<TextureRef>|
      -> Option<TextureRef> {
+        if !capable {
+            return None;
+        }
         merge_slot_texture(
             inline_tex,
             inst.texture_overrides.get(slot).cloned(),
@@ -792,35 +796,19 @@ pub(crate) fn merged_builtin_def(
         )
     };
 
-    // Extension merge, mirroring texture-slot presence (§11): enabled when
-    // EITHER layer carries the extension — a per-node `inline` extension
-    // re-specializes THIS mesh's pipeline (one extra bucket per distinct
-    // feature combination, not one per mesh) instead of being silently
-    // dropped. Params: inline wins, else the variant's AUTHORED values
-    // (previously an enabled-but-inline-unseeded extension fell back to
-    // struct DEFAULTS, discarding the library material's factors). The rule
-    // lives on `PbrExtensions::merged_over` — shared with the inspector so
-    // the UI shows exactly what renders.
+    // Extension ENABLES are variant-only (strict capabilities); an enabled
+    // extension's parameters come from `inline` when seeded. The rule lives
+    // on `PbrExtensions::merged_over` — shared with the inspector so the UI
+    // shows exactly what renders.
     let extensions = PbrExtensions::merged_over(&inline.extensions, &variant.extensions);
 
-    // Alpha MODE (Opaque/Mask/Blend): a NON-DEFAULT per-node `inline` mode wins
-    // (what `set_builtin_alpha_mode` / the inspector dropdown write) — like
-    // texture-slot presence (§11 above), it re-specializes THIS mesh's routing
-    // instead of being silently dropped. `inline` Opaque is the unset default,
-    // so it falls through to the shared variant's authored mode (assigning a
-    // Blend/Mask library material keeps working). The Mask *cutoff* is a
-    // per-mesh uniform compare, so inline's value also wins when both layers
-    // are Mask.
-    //
-    // (Regression this fixes: per-node `mask` was ignored → mode stayed the
-    // variant's Opaque → the lowering's `alpha_mode_of` convenience heuristic
-    // saw base_color.a < 1 and routed the mesh to the BLEND/transparent pass —
-    // ghost render, no cutout, no shadow.)
+    // Alpha MODE is variant-only (pipeline routing). The Mask *cutoff* is a
+    // per-mesh uniform compare, so inline's value wins when both layers are
+    // Mask.
     let alpha_mode = match (&variant.alpha_mode, &inline.alpha_mode) {
         (MaterialAlphaMode::Mask { .. }, MaterialAlphaMode::Mask { cutoff }) => {
             MaterialAlphaMode::Mask { cutoff: *cutoff }
         }
-        (_, inline_mode) if *inline_mode != MaterialAlphaMode::Opaque => inline_mode.clone(),
         _ => variant.alpha_mode.clone(),
     };
 
@@ -841,26 +829,31 @@ pub(crate) fn merged_builtin_def(
         normal_scale: inline.normal_scale,
         occlusion_strength: inline.occlusion_strength,
         base_color_texture: tex(
+            caps.base_color,
             "base_color_texture",
             inline.base_color_texture,
             variant.base_color_texture,
         ),
         metallic_roughness_texture: tex(
+            caps.metallic_roughness,
             "metallic_roughness_texture",
             inline.metallic_roughness_texture,
             variant.metallic_roughness_texture,
         ),
         normal_texture: tex(
+            caps.normal,
             "normal_texture",
             inline.normal_texture,
             variant.normal_texture,
         ),
         occlusion_texture: tex(
+            caps.occlusion,
             "occlusion_texture",
             inline.occlusion_texture,
             variant.occlusion_texture,
         ),
         emissive_texture: tex(
+            caps.emissive,
             "emissive_texture",
             inline.emissive_texture,
             variant.emissive_texture,
@@ -868,6 +861,11 @@ pub(crate) fn merged_builtin_def(
         alpha_mode,
         shading,
         extensions,
+        // Carry the EFFECTIVE capabilities (declared ∪ variant-bound) so the
+        // flattened export def keys the same bucket in the player as the
+        // shared variant does in the editor — even for capable slots nobody
+        // bound an image into.
+        texture_capabilities: Some(caps),
         // variant-only: double_sided, vertex_colors_enabled, label.
         ..variant.clone()
     }
@@ -2004,19 +2002,18 @@ mod builtin_merge_tests {
         }
     }
 
-    // Regression guard for "inline extensions stored but never rendered":
-    // library None + inline Some(clearcoat) must ENABLE the extension for
-    // this mesh (the variant bit comes from presence in EITHER layer).
+    // Extensions are STRICT capabilities: the ENABLE set is variant-only.
+    // Library None + inline Some(clearcoat) must NOT enable the extension —
+    // an inline-only extension has no compiled code to render through, so
+    // the merge drops it (enabling clearcoat is a material edit).
     #[test]
-    fn inline_extension_enables_what_the_library_lacks() {
+    fn inline_extension_cannot_enable_what_the_library_lacks() {
         let variant = MaterialDef::default();
         let merged = merged_builtin_def(&inst(with_clearcoat(1.0, 0.0)), &variant);
-        let cc = merged
-            .extensions
-            .clearcoat
-            .expect("inline-only clearcoat must survive");
-        assert_eq!(cc.factor, 1.0);
-        assert_eq!(cc.roughness_factor, 0.0);
+        assert!(
+            merged.extensions.clearcoat.is_none(),
+            "extension enables are variant-only; inline-only clearcoat must be dropped"
+        );
     }
 
     // Library Some(factor 0) + inline Some(factor 1): the inline factors must
@@ -2060,5 +2057,57 @@ mod builtin_merge_tests {
         // per-instance override maps empty (they don't ship in the bundle).
         let reflattened = merged_builtin_def(&inst(merged.clone()), &variant);
         assert_eq!(reflattened, merged);
+    }
+
+    // Alpha MODE is variant-only routing: a per-node inline mode must never
+    // reroute the mesh. Only the Mask cutoff VALUE (a uniform) carries from
+    // inline, and only when the variant is Mask.
+    #[test]
+    fn alpha_mode_is_variant_only() {
+        use awsm_renderer_editor_protocol::material::MaterialAlphaMode;
+        let variant = MaterialDef::default(); // Opaque
+        let mut inline = MaterialDef::default();
+        inline.alpha_mode = MaterialAlphaMode::Mask { cutoff: 0.5 };
+        let merged = merged_builtin_def(&inst(inline), &variant);
+        assert_eq!(merged.alpha_mode, MaterialAlphaMode::Opaque);
+
+        let mut mask_variant = MaterialDef::default();
+        mask_variant.alpha_mode = MaterialAlphaMode::Mask { cutoff: 0.5 };
+        let mut inline = MaterialDef::default();
+        inline.alpha_mode = MaterialAlphaMode::Mask { cutoff: 0.25 };
+        let merged = merged_builtin_def(&inst(inline), &mask_variant);
+        assert_eq!(merged.alpha_mode, MaterialAlphaMode::Mask { cutoff: 0.25 });
+    }
+
+    // Texture-slot capability: an inline image binds only into a CAPABLE slot
+    // (declared on the variant, or implied by the variant's own binding). A
+    // non-capable inline binding is dropped; a declared-but-unbound capability
+    // accepts it and the merged def carries the effective capabilities so the
+    // player keys the same bucket.
+    #[test]
+    fn inline_textures_bind_only_capable_slots() {
+        use awsm_renderer_editor_protocol::material::TextureCapabilities;
+        // Variant declares the normal slot capable but binds no image.
+        let mut variant = MaterialDef::default();
+        variant.texture_capabilities = Some(TextureCapabilities {
+            normal: true,
+            ..Default::default()
+        });
+        let mut inline = MaterialDef::default();
+        inline.normal_texture = Some(TextureRef::new(AssetId::new()));
+        inline.emissive_texture = Some(TextureRef::new(AssetId::new()));
+        let merged = merged_builtin_def(&inst(inline), &variant);
+        assert!(
+            merged.normal_texture.is_some(),
+            "capable slot accepts the per-node image"
+        );
+        assert!(
+            merged.emissive_texture.is_none(),
+            "non-capable slot drops the per-node image"
+        );
+        let caps = merged
+            .texture_capabilities
+            .expect("merged def carries effective capabilities");
+        assert!(caps.normal && !caps.emissive);
     }
 }

--- a/packages/frontend/editor/src/engine/settings_sync.rs
+++ b/packages/frontend/editor/src/engine/settings_sync.rs
@@ -45,8 +45,11 @@ pub fn start() {
             .await;
     });
 
-    // Shadow denoise blur (cheap, synchronous — no pipeline recompile, just a
-    // per-frame dispatch gate in ShadowsConfig).
+    // Shadow denoise blur. `denoise` gates whether the prep blur pipelines are
+    // COMPILED (not just dispatched), so an off→on flip must drain the config
+    // pipelines to build the pair — otherwise render_blur warn-skips until an
+    // unrelated commit_load. Async + guarded against redundant re-applies,
+    // mirroring the MSAA observer below.
     spawn_local(async {
         let mut first = true;
         controller()
@@ -57,15 +60,20 @@ pub fn start() {
                 let skip = first;
                 first = false;
                 async move {
-                    if !skip {
-                        with_renderer_mut(move |r| {
-                            let mut cfg = r.shadows_config().clone();
-                            if cfg.denoise != on {
-                                cfg.denoise = on;
-                                r.set_shadows_config(cfg);
-                            }
-                        })
-                        .await;
+                    if skip {
+                        return;
+                    }
+                    let handle = renderer_handle();
+                    let mut r = handle.lock().await;
+                    let mut cfg = r.shadows_config().clone();
+                    if cfg.denoise != on {
+                        cfg.denoise = on;
+                        r.set_shadows_config(cfg);
+                        // Compile the blur pair for the new config (no-op on
+                        // off, a cache hit on a later on→off→on).
+                        if let Err(e) = r.ensure_config_pipelines().await {
+                            tracing::warn!("ensure_config_pipelines after denoise flip: {e}");
+                        }
                     }
                 }
             })

--- a/packages/frontend/editor/src/material_mode/studio.rs
+++ b/packages/frontend/editor/src/material_mode/studio.rs
@@ -386,41 +386,6 @@ fn textures_section(
             },
         ));
     }
-    // Slot CAPABILITIES (PBR): a checked slot compiles its sampling path into
-    // the material's shared pipeline (runtime-guarded), so meshes can each
-    // bind or omit a per-node image with no recompile and no per-mesh
-    // pipeline. A slot with a default image above is implicitly capable
-    // (shown checked + disabled would be nicer; keep it simple: the OR rule
-    // lives in `MaterialDef::slot_capabilities`). Unchecked + no default
-    // image = the slot's code doesn't exist and per-node binds are rejected.
-    if matches!(def.shading, MaterialShading::Pbr) {
-        let caps = def.texture_capabilities.unwrap_or_default();
-        let mut cap_sec = Section::new("Per-node texture slots (capabilities)");
-        macro_rules! cap_toggle {
-            ($label:expr, $field:ident, $bound:expr) => {
-                cap_sec = cap_sec.child(builtin_toggle_row(
-                    mat,
-                    $label,
-                    caps.$field || $bound,
-                    |d, on| {
-                        let mut c = d.texture_capabilities.unwrap_or_default();
-                        c.$field = on;
-                        d.texture_capabilities = Some(c);
-                    },
-                ));
-            };
-        }
-        cap_toggle!("Base color", base_color, def.base_color_texture.is_some());
-        cap_toggle!(
-            "Metal/rough",
-            metallic_roughness,
-            def.metallic_roughness_texture.is_some()
-        );
-        cap_toggle!("Normal", normal, def.normal_texture.is_some());
-        cap_toggle!("Occlusion", occlusion, def.occlusion_texture.is_some());
-        cap_toggle!("Emissive", emissive, def.emissive_texture.is_some());
-        sec = sec.child(cap_sec.render());
-    }
     sec.render()
 }
 

--- a/packages/frontend/editor/src/material_mode/studio.rs
+++ b/packages/frontend/editor/src/material_mode/studio.rs
@@ -386,6 +386,41 @@ fn textures_section(
             },
         ));
     }
+    // Slot CAPABILITIES (PBR): a checked slot compiles its sampling path into
+    // the material's shared pipeline (runtime-guarded), so meshes can each
+    // bind or omit a per-node image with no recompile and no per-mesh
+    // pipeline. A slot with a default image above is implicitly capable
+    // (shown checked + disabled would be nicer; keep it simple: the OR rule
+    // lives in `MaterialDef::slot_capabilities`). Unchecked + no default
+    // image = the slot's code doesn't exist and per-node binds are rejected.
+    if matches!(def.shading, MaterialShading::Pbr) {
+        let caps = def.texture_capabilities.unwrap_or_default();
+        let mut cap_sec = Section::new("Per-node texture slots (capabilities)");
+        macro_rules! cap_toggle {
+            ($label:expr, $field:ident, $bound:expr) => {
+                cap_sec = cap_sec.child(builtin_toggle_row(
+                    mat,
+                    $label,
+                    caps.$field || $bound,
+                    |d, on| {
+                        let mut c = d.texture_capabilities.unwrap_or_default();
+                        c.$field = on;
+                        d.texture_capabilities = Some(c);
+                    },
+                ));
+            };
+        }
+        cap_toggle!("Base color", base_color, def.base_color_texture.is_some());
+        cap_toggle!(
+            "Metal/rough",
+            metallic_roughness,
+            def.metallic_roughness_texture.is_some()
+        );
+        cap_toggle!("Normal", normal, def.normal_texture.is_some());
+        cap_toggle!("Occlusion", occlusion, def.occlusion_texture.is_some());
+        cap_toggle!("Emissive", emissive, def.emissive_texture.is_some());
+        sec = sec.child(cap_sec.render());
+    }
     sec.render()
 }
 

--- a/packages/frontend/editor/src/scene_mode/inspector.rs
+++ b/packages/frontend/editor/src/scene_mode/inspector.rs
@@ -1924,9 +1924,11 @@ fn material_editor(node: &Arc<Node>, mat: &MaterialDef, _has_custom: bool) -> Do
                 if let Some(cur) = current_primitive_material(&n) {
                     let mut base_color = cur.base_color;
                     base_color[3] = v as f32;
-                    // alpha_MODE (opaque/mask/blend) is a variant setting on the
-                    // material; opacity is just the per-mesh alpha factor. The
-                    // bridge's alpha_mode_of heuristic still blends when a < 1.
+                    // Opacity is the per-mesh base-color ALPHA factor. It only
+                    // renders when the material's alpha MODE (a material-asset
+                    // setting) is Blend (translucency) or Mask (vs the cutoff).
+                    // Per glTF, an Opaque material ignores it — the old
+                    // "alpha < 1 silently becomes blend" promotion is gone.
                     set_inline_material(&n, MaterialDef { base_color, ..cur });
                 }
             })

--- a/packages/mcp/editor-protocol/src/command.rs
+++ b/packages/mcp/editor-protocol/src/command.rs
@@ -983,13 +983,16 @@ pub enum EditorCommand {
         param: BuiltinParamKind,
         value: Vec<f32>,
     },
-    /// Set the alpha mode of a mesh node's **built-in/inline** material (§13) —
-    /// `Opaque | Mask { cutoff } | Blend`. A pipeline-feature flip (e.g. glass =
-    /// `Blend` + a sub-1 base-color alpha), so the node re-materializes. The typed
-    /// alternative to resending the whole `NodeKind` via `set_kind`. Inverse:
-    /// restore the node's prior kind.
+    /// Set the alpha mode of a built-in **library material** —
+    /// `Opaque | Mask { cutoff } | Blend`. Alpha mode is pipeline ROUTING and
+    /// therefore owned by the material asset: the change applies to every
+    /// node using the material (their variants re-materialize). Per-node
+    /// state stays data-only — the Mask *cutoff* value can still be tuned
+    /// per node via the inline def. The typed alternative to resending the
+    /// whole def via `update_builtin_material`. Inverse: restore the
+    /// material's prior def.
     SetBuiltinAlphaMode {
-        node: NodeId,
+        material: AssetId,
         mode: crate::MaterialAlphaMode,
     },
     /// Set a light parameter on a light node (writable counterpart of

--- a/packages/mcp/editor-protocol/src/transport.rs
+++ b/packages/mcp/editor-protocol/src/transport.rs
@@ -298,7 +298,7 @@ mod wire_roundtrip_tests {
             (
                 "set_builtin_alpha_mode",
                 EditorCommand::SetBuiltinAlphaMode {
-                    node: NodeId::new(),
+                    material: AssetId::new(),
                     mode: crate::MaterialAlphaMode::Mask { cutoff: 0.4 },
                 },
             ),

--- a/packages/mcp/src/mcp.rs
+++ b/packages/mcp/src/mcp.rs
@@ -97,6 +97,17 @@ pub struct Vec3Params {
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct LookAtParams {
+    /// Target node UUID (typically a light or camera).
+    pub node: String,
+    /// World-space point to aim at, `[x, y, z]`.
+    pub target: [f32; 3],
+    /// Optional up-hint for the roll-free frame (default `[0,1,0]`;
+    /// auto-falls back when the aim direction is parallel to it).
+    pub up: Option<[f32; 3]>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct EulerParams {
     /// Target node UUID.
     pub node: String,
@@ -670,10 +681,12 @@ pub struct MaterialBoolParams {
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct BuiltinAlphaModeParams {
-    /// Mesh node UUID (its built-in/inline material).
-    pub node: String,
+    /// Built-in library material UUID (see get_snapshot's materials list).
+    pub material: String,
     pub mode: AlphaModeArg,
-    /// Alpha cutoff for `mask` mode (default 0.5; ignored otherwise).
+    /// Alpha cutoff for `mask` mode (default 0.5; ignored otherwise). The
+    /// cutoff VALUE is a per-mesh uniform — tune it per node afterwards via
+    /// set_builtin_param alpha_cutoff.
     #[serde(default)]
     pub cutoff: Option<f64>,
 }
@@ -2090,6 +2103,63 @@ impl EditorMcp {
     }
 
     #[tool(
+        description = "Aim a node at a world-space target: computes the roll-free rotation that points the node's local -Z (the forward axis of lights and cameras) at `target`, converts it into the node's parent space, and applies it — translation and scale are untouched. Params: { node, target: [x,y,z], up?: [x,y,z] }. Replaces hand-computing quaternions for spot/camera aiming."
+    )]
+    async fn node_look_at(
+        &self,
+        Parameters(p): Parameters<LookAtParams>,
+    ) -> Result<CallToolResult, McpError> {
+        use glam::{Mat3, Mat4, Quat, Vec3};
+        let node = parse_node(&p.node)?;
+        let (trs, world) = self.current_trs_and_world(node).await?;
+
+        let world_mat = Mat4::from_cols_array(&world);
+        let world_pos = world_mat.w_axis.truncate();
+        let target = Vec3::from_array(p.target);
+        let dir = target - world_pos;
+        if dir.length_squared() < 1e-12 {
+            return Err(McpError::invalid_params(
+                "look_at target coincides with the node's position",
+                None,
+            ));
+        }
+        let dir = dir.normalize();
+
+        // Roll-free frame: -Z = dir; X ⊥ up-hint; fall back when the aim
+        // direction is (anti)parallel to the hint.
+        let mut up = Vec3::from_array(p.up.unwrap_or([0.0, 1.0, 0.0]));
+        if up.cross(dir).length_squared() < 1e-8 {
+            up = if dir.y.abs() > 0.99 { Vec3::Z } else { Vec3::Y };
+        }
+        let z = -dir;
+        let x = up.cross(z).normalize();
+        let y = z.cross(x);
+        let world_rot = Quat::from_mat3(&Mat3::from_cols(x, y, z));
+
+        // Local = parent⁻¹ * world. Parent rotation from the node's world
+        // basis with scale stripped, divided by its current local rotation.
+        let local_rot_cur = Quat::from_array(trs.rotation);
+        let basis = Mat3::from_cols(
+            world_mat.x_axis.truncate().normalize(),
+            world_mat.y_axis.truncate().normalize(),
+            world_mat.z_axis.truncate().normalize(),
+        );
+        let world_rot_cur = Quat::from_mat3(&basis).normalize();
+        let parent_rot = (world_rot_cur * local_rot_cur.inverse()).normalize();
+        let local_rot = (parent_rot.inverse() * world_rot).normalize();
+
+        self.dispatch(EditorCommand::SetTransform {
+            id: node,
+            transform: Trs {
+                translation: trs.translation,
+                rotation: local_rot.to_array(),
+                scale: trs.scale,
+            },
+        })
+        .await
+    }
+
+    #[tool(
         description = "Set a node's local translation [x,y,z], keeping its current rotation + scale."
     )]
     async fn set_translation(
@@ -3198,7 +3268,7 @@ impl EditorMcp {
     }
 
     #[tool(
-        description = "Set a built-in material factor on a mesh node's inline material. param: base_color (value = 3 floats RGB, OR 4 floats RGBA where the 4th is the base-color ALPHA — pair with set_builtin_alpha_mode blend for glass) | emissive (3 floats) | metallic | roughness | normal_scale | occlusion_strength (1 float). For KHR extension params (clearcoat, sheen, transmission, ior, ...) use patch_kind on mesh.material.inline.extensions — e.g. {\"mesh\":{\"material\":{\"inline\":{\"extensions\":{\"clearcoat\":{\"factor\":1.0,\"roughness_factor\":0.0}}}}}} — an inline extension ENABLES it for that mesh (recompiles its variant) and null disables."
+        description = "Set a built-in material factor on a mesh node's inline material. param: base_color (value = 3 floats RGB, OR 4 floats RGBA where the 4th is the base-color ALPHA — pair with set_builtin_alpha_mode blend for glass) | emissive (3 floats) | metallic | roughness | normal_scale | occlusion_strength (1 float). For KHR extension PARAMS (clearcoat, sheen, transmission, ior, ...) use patch_kind on mesh.material.inline.extensions — e.g. {\"mesh\":{\"material\":{\"inline\":{\"extensions\":{\"clearcoat\":{\"factor\":1.0,\"roughness_factor\":0.0}}}}}}. Extension ENABLES are owned by the library material (update_builtin_material) — inline params only take effect when the material enables the extension; an inline-only extension is dropped."
     )]
     async fn set_builtin_param(
         &self,
@@ -3230,7 +3300,7 @@ impl EditorMcp {
     }
 
     #[tool(
-        description = "Set a mesh node's BUILT-IN/inline material alpha mode: opaque | mask (with `cutoff`) | blend. The typed alternative to resending the whole NodeKind via set_kind. For glass: `blend` + set_builtin_param base_color with a 4th alpha float < 1. Re-materializes the node (pipeline-feature flip)."
+        description = "Set a BUILT-IN library MATERIAL's alpha mode: opaque | mask (with `cutoff`) | blend. Alpha mode is pipeline routing owned by the material asset — it applies to every node using the material (their variants re-materialize). Per glTF, opaque IGNORES base-color alpha; for glass set the material to `blend`, then set_builtin_param base_color with a 4th alpha float < 1 per node. Mask cutoff VALUE stays per-node tunable (set_builtin_param alpha_cutoff)."
     )]
     async fn set_builtin_alpha_mode(
         &self,
@@ -3244,14 +3314,14 @@ impl EditorMcp {
             AlphaModeArg::Blend => awsm_renderer_editor_protocol::MaterialAlphaMode::Blend,
         };
         self.dispatch(EditorCommand::SetBuiltinAlphaMode {
-            node: parse_node(&p.node)?,
+            material: parse_asset(&p.material)?,
             mode,
         })
         .await
     }
 
     #[tool(
-        description = "Bind a texture asset onto a mesh node's BUILT-IN (inline PBR) material slot: base_color | metallic_roughness | normal | occlusion | emissive. Omit `texture` to clear. Create textures with import_texture_from_url (raster) or add_texture_asset (procedural). (set_material_texture is the custom-WGSL-material counterpart.)"
+        description = "Bind a texture asset onto a mesh node's BUILT-IN (inline PBR) material slot: base_color | metallic_roughness | normal | occlusion | emissive. The slot must be a CAPABILITY of the node's library material (declared via update_builtin_material texture_capabilities, or implied by a default image bound on the material) — capabilities are pipeline identity and live on the material; per-node binds are pure data and never recompile. Omit `texture` to clear (always allowed). Create textures with import_texture_from_url (raster) or add_texture_asset (procedural). (set_material_texture is the custom-WGSL-material counterpart.)"
     )]
     async fn set_node_texture(
         &self,
@@ -4377,6 +4447,43 @@ impl EditorMcp {
         serde_json::from_value(v.clone()).map_err(|e| {
             McpError::internal_error(format!("node {node} kind did not parse: {e}"), None)
         })
+    }
+
+    /// Read a node's current local TRS + world matrix (column-major 16)
+    /// via the `NodeTransforms` query — for tools that need world-space
+    /// context (`node_look_at`).
+    async fn current_trs_and_world(&self, node: NodeId) -> Result<(Trs, [f32; 16]), McpError> {
+        let trs = self.current_trs(node).await?;
+        let resp = self
+            .req(Request::Query(EditorQuery::NodeTransforms {
+                nodes: vec![node],
+            }))
+            .await?;
+        let Response::Query(qr) = resp else {
+            return Err(unexpected(resp));
+        };
+        let QueryResult::Map(m) = *qr else {
+            return Err(McpError::internal_error(
+                "unexpected transforms result",
+                None,
+            ));
+        };
+        let mut world = [0.0f32; 16];
+        world[0] = 1.0;
+        world[5] = 1.0;
+        world[10] = 1.0;
+        world[15] = 1.0;
+        if let Some(a) = m
+            .entries
+            .get(&node.to_string())
+            .and_then(|v| v.get("world"))
+            .and_then(|a| a.as_array())
+        {
+            for (i, x) in a.iter().take(16).enumerate() {
+                world[i] = x.as_f64().unwrap_or(world[i] as f64) as f32;
+            }
+        }
+        Ok((trs, world))
     }
 
     /// Read a node's current local TRS (for the partial-transform convenience

--- a/packages/mcp/src/mcp.rs
+++ b/packages/mcp/src/mcp.rs
@@ -3321,7 +3321,7 @@ impl EditorMcp {
     }
 
     #[tool(
-        description = "Bind a texture asset onto a mesh node's BUILT-IN (inline PBR) material slot: base_color | metallic_roughness | normal | occlusion | emissive. The slot must be a CAPABILITY of the node's library material (declared via update_builtin_material texture_capabilities, or implied by a default image bound on the material) — capabilities are pipeline identity and live on the material; per-node binds are pure data and never recompile. Omit `texture` to clear (always allowed). Create textures with import_texture_from_url (raster) or add_texture_asset (procedural). (set_material_texture is the custom-WGSL-material counterpart.)"
+        description = "Bind a texture asset onto a mesh node's BUILT-IN (inline PBR) material slot: base_color | metallic_roughness | normal | occlusion | emissive. Binds are pure data — every core slot's sampling code is always compiled (unbound slots sample a shared 1x1 neutral), so binding any slot on any node never recompiles anything. Omit `texture` to clear. Create textures with import_texture_from_url (raster) or add_texture_asset (procedural). (set_material_texture is the custom-WGSL-material counterpart.)"
     )]
     async fn set_node_texture(
         &self,


### PR DESCRIPTION
## Summary

Two related reworks of how the renderer compiles pipelines and binds material textures. Net effect: **cold load no longer stalls on shader compiles**, and **binding a texture is pure data** — it never recompiles a pipeline or splits a render bucket.

### 1. Lazy `build()`-time pipeline compilation

`build()` used to compile the material-prep megashader **3× sequentially (~1s each on a cold cache)** during its Init phase, plus BRDF LUT bake, decal-composite, blur variants, light-culling entry points, and EVSM validations — the dominant cold-load stall.

Now `build()` compiles **nothing**: shader modules are created without awaiting validation (the browser validates in the background), and every pass pipeline key is *reserved* (slot allocated, compile deferred). A new public `ensure_config_pipelines()` drains the reserved pool in **one concurrent batch**:

- `commit_load` calls it first (reported as a "Compiling" phase), so content loads Just Work with progress.
- Apps can call it right after `build()` to overlap warm-up with asset fetches.
- **An empty project compiles zero pipelines.** IBL/skybox get 1×1 placeholder cubemaps and the BRDF LUT a 1×1 zero texture at boot; the authored 256² defaults / 1024² LUT bake only happen if content never sets its own environment (every exported scene does).
- Only the **active** MSAA branch's `cs_prep` compiles at boot; the other branch fills on the first `set_anti_aliasing` flip. The ~8 MB edge-shadow texture now follows the MSAA on→off lifecycle instead of living forever.

### 2. Material capability/usage split + branchless texture slots

**The material asset owns everything pipeline-shaped; per-node overrides are pure data.**

- **Routing (asset-only):** alpha mode, shading model, double-sided, transmission. `set_builtin_alpha_mode` now takes `{material, mode}` (was per-node). The legacy *"opaque + base_color.a < 1 → blend"* auto-promotion is **deleted** everywhere (editor + loader/player) — per glTF, opaque ignores factor alpha.
- **Texture slots — branchless.** The five core PBR slots' sampling code is **always compiled**; the `{% if pbr_features.X_tex %}` gates and inner `exists` checks are gone from both `material_color_calc.wgsl` templates and `masked_alpha.wgsl`. An unbound slot packs a shared **1×1 neutral** pool entry (white for base/MR/occlusion/emissive; flat-normal `128,128,255` for normal — `TBN·(0,0,1)` is exactly the geometry normal). Sampling a neutral **is** glTF's defined no-texture result, branch-free. The five `PbrFeatures` texture bits are retired (always false).
- **Pool-tier padding.** Texture-pool bind layouts, generated WGSL, and shader cache keys use `pool_binding_tier(n) = max(4, next_power_of_two(n))`; the neutral view / default sampler fill empty slots. The recompile-on-pool-change gate now fires **only on a tier crossing** (4 → 8 → 16 …). Pool growth — including the first texture of a session — no longer recompiles the pool-dependent shader set.
- **Extensions (11 KHR): strict capabilities.** The enable set comes from the shared variant alone; an inline-only extension is dropped. Enabled-extension parameters stay per-node uniforms.

Custom/dynamic WGSL materials, extension texture slots, and the flipbook atlas keep the **zero-sentinel** unbound semantics (their dynamic layouts detect unbound declared slots off the zero word) — only the four built-in packers' five core slots pack neutrals.

## Migration note

Content that previously relied on the *opaque + translucent base-color factor → auto-blend* behavior will now render **opaque**. Transparency must be explicitly authored as `Blend` (and cutouts as `Mask`). This is the intended, glTF-correct behavior.

## Self-review

A high-effort PR-style review (multi-agent, adversarially verified) ran against `main`. Disposition of the surviving findings:

| Finding | Disposition |
|---|---|
| **Shadow-denoise runtime toggle didn't compile the blur pair** — on this branch blur is compile-gated on `denoise`, but the editor observer called the sync `set_shadows_config` and stopped, so an off→on flip left shadows grainy until a reload. | **Fixed** — observer now drains config pipelines via `ensure_config_pipelines().await` on a flip (mirrors the MSAA observer). Verified live. |
| **Flat-normal neutral doc** claimed a float format with exact 0.5, but the impl packs rgba8 `[128,128,255]` (≈0.502). | **Fixed** — doc corrected to the real encoding + the `normal_scale` caveat. |
| **`normal_scale` applied to the neutral's ≈0.502 residual** tilts the normal slightly when a material has `normal_scale` but no normal map. | Kept — the u8 neutral is a deliberate decision (it matches authored normal maps' flat-region quantization); magnitude is ~0.2° at default scale. Documented in the neutral's doc. |
| **Deleted "opaque + a<1 → blend" promotion** drops transparency on content that relied on it. | Working as intended (see Migration note); glTF-correct. |
| **Tier-gated `mark_variants_dirty` could leave built-in meshes unshaded** after a within-tier pool grow. | Investigated — **did not reproduce** at runtime across two scenarios (unbound import + second textured mesh); built-in meshes stay shaded because the reconcile rebuilds the first-party buckets. No change. |
| **Device-limit check compares the padded tier count**, so a non-power-of-two device limit between the real and padded count could reject a scene that would otherwise fit. | Noted — edge case on non-power-of-two hardware limits (WebGPU baseline is 16, a power of two). Not changed. |
| **Padding block duplicated across 5 bind-group files.** | Acknowledged tech debt — behavior-neutral; left for a focused follow-up. |

## Verification

- `cargo check --workspace --all-targets`, `cargo test --workspace`, and `task lint` (rustfmt + clippy `-D warnings`, all features + tests) all clean, including the review fixes.
- Runtime (live editor via MCP): untextured render parity; **first texture bind causes no relayout** (`render_pipelines` held at 68); flat-normal neutral no-wobble on a sphere and a real glTF tangent mesh; masked cutout correct with the neutral base-color; within-tier pool growth keeps built-in meshes shaded; denoise toggle fires the config-ensure with no error/warn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
